### PR TITLE
VPS-022/Timer

### DIFF
--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -30,7 +30,7 @@ const retrieveSceneList = async (scenarioId) => {
   const dbScenario = await Scenario.findById(scenarioId);
   const dbScenes = await Scene.find(
     { _id: { $in: dbScenario.scenes } },
-    "name",
+    "name"
   );
 
   return dbScenes;
@@ -119,7 +119,7 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const newScene = {
     name: `${sceneToCopy.name} Copy`,
     components: sceneToCopy.components,
-    time: `${sceneToCopy.time} Copy`
+    time: `${sceneToCopy.time} Copy`,
   };
   const dbScene = new Scene(newScene);
   await dbScene.save();

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -119,6 +119,7 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const newScene = {
     name: `${sceneToCopy.name} Copy`,
     components: sceneToCopy.components,
+    time: sceneToCopy.time,
   };
   const dbScene = new Scene(newScene);
   await dbScene.save();

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -31,7 +31,6 @@ const retrieveSceneList = async (scenarioId) => {
   const dbScenes = await Scene.find(
     { _id: { $in: dbScenario.scenes } },
     "name",
-    "time"
   );
 
   return dbScenes;

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -119,7 +119,6 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const newScene = {
     name: `${sceneToCopy.name} Copy`,
     components: sceneToCopy.components,
-
   };
   const dbScene = new Scene(newScene);
   await dbScene.save();

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -6,7 +6,7 @@ import { tryDeleteFile, updateFileMetadata } from "../../firebase/storage";
 /**
  * Creates a scene in the database, and updates its parent scenario to contain the scene
  * @param {String} scenarioId MongoDB ID of parent scenario
- * @param {{name: String, components: Object[]}} scene scene object
+ * @param {{name: String, components: Object[]}, time: Number} scene scene object
  * @returns the created database scene object
  */
 const createScene = async (scenarioId, scene) => {
@@ -30,7 +30,8 @@ const retrieveSceneList = async (scenarioId) => {
   const dbScenario = await Scenario.findById(scenarioId);
   const dbScenes = await Scene.find(
     { _id: { $in: dbScenario.scenes } },
-    "name"
+    "name",
+    "time"
   );
 
   return dbScenes;
@@ -50,7 +51,7 @@ const retrieveScene = async (sceneId) => {
 /**
  * Updates a scene in the database
  * @param {String} sceneId MongoDB ID of scene
- * @param {{name: String, components: Object[]}} updatedScene updated scene object
+ * @param {{name: String, components: Object[]}, time: Number} updatedScene updated scene object
  * @returns updated database scene object
  */
 const updateScene = async (sceneId, updatedScene) => {
@@ -79,6 +80,7 @@ const updateScene = async (sceneId, updatedScene) => {
   // if we are updating name only, components will be null
   const dbScene = await Scene.findById(sceneId);
   dbScene.name = updatedScene.name;
+  dbScene.time = updatedScene.time;
   await dbScene.save();
   return dbScene;
 };
@@ -118,6 +120,7 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const newScene = {
     name: `${sceneToCopy.name} Copy`,
     components: sceneToCopy.components,
+    time: `${sceneToCopy.time} Copy`
   };
   const dbScene = new Scene(newScene);
   await dbScene.save();

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -119,7 +119,7 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const newScene = {
     name: `${sceneToCopy.name} Copy`,
     components: sceneToCopy.components,
-    time: `${sceneToCopy.time} Copy`,
+
   };
   const dbScene = new Scene(newScene);
   await dbScene.save();

--- a/backend/src/db/models/scene.js
+++ b/backend/src/db/models/scene.js
@@ -14,6 +14,9 @@ const sceneSchema = new Schema({
       type: Object,
     },
   ],
+  time: {
+    type: Number,
+  }
 });
 
 // before removal of scene from the database, first attempt to delete all user-uploaded images from firebase

--- a/backend/src/db/models/scene.js
+++ b/backend/src/db/models/scene.js
@@ -16,7 +16,7 @@ const sceneSchema = new Schema({
   ],
   time: {
     type: Number,
-  }
+  },
 });
 
 // before removal of scene from the database, first attempt to delete all user-uploaded images from firebase

--- a/backend/src/routes/api/scene.js
+++ b/backend/src/routes/api/scene.js
@@ -40,7 +40,11 @@ router.use(scenarioAuth);
 router.post("/", async (req, res) => {
   const { name, components, time } = req.body;
 
-  const scene = await createScene(req.params.scenarioId, { name, components, time });
+  const scene = await createScene(req.params.scenarioId, {
+    name,
+    components,
+    time,
+  });
 
   res.status(HTTP_OK).json(scene);
 });
@@ -49,7 +53,11 @@ router.post("/", async (req, res) => {
 router.put("/:sceneId", async (req, res) => {
   const { name, components, time } = req.body;
 
-  const scene = await updateScene(req.params.sceneId, { name, components, time });
+  const scene = await updateScene(req.params.sceneId, {
+    name,
+    components,
+    time,
+  });
 
   res.status(HTTP_OK).json(scene);
 });

--- a/backend/src/routes/api/scene.js
+++ b/backend/src/routes/api/scene.js
@@ -38,18 +38,18 @@ router.use(scenarioAuth);
 
 // Create a scene for a scenario
 router.post("/", async (req, res) => {
-  const { name, components } = req.body;
+  const { name, components, time } = req.body;
 
-  const scene = await createScene(req.params.scenarioId, { name, components });
+  const scene = await createScene(req.params.scenarioId, { name, components, time });
 
   res.status(HTTP_OK).json(scene);
 });
 
 // Update a scene
 router.put("/:sceneId", async (req, res) => {
-  const { name, components } = req.body;
+  const { name, components, time } = req.body;
 
-  const scene = await updateScene(req.params.sceneId, { name, components });
+  const scene = await updateScene(req.params.sceneId, { name, components, time });
 
   res.status(HTTP_OK).json(scene);
 });

--- a/frontend/src/components/TimerComponent/Notification.js
+++ b/frontend/src/components/TimerComponent/Notification.js
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+const Notifcation = () => {
+  return (
+    <div className="expired-notice">
+      <span>Expired!!!</span>
+      <p>Please select a future date and time.</p>
+    </div>
+  );
+};
+
+export default Notifcation;

--- a/frontend/src/components/TimerComponent/Notification.js
+++ b/frontend/src/components/TimerComponent/Notification.js
@@ -1,11 +1,55 @@
 import * as React from "react";
+import Modal from "@material-ui/core/Modal";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "20%",
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
 
 const Notifcation = () => {
+  const [open, setOpen] = React.useState(true);
+  const handleClose = () => setOpen(false);
+  const closeTab = () => window.close();
+
   return (
-    <div className="expired-notice">
-      <span>Expired!!!</span>
-      <p>Please select a future date and time.</p>
-    </div>
+    <Modal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box sx={style}>
+        <Typography id="modal-modal-title" variant="h6" component="h2">
+          Out of Time!
+        </Typography>
+        <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+          Exit the scenario or continue:
+        </Typography>
+        <div style={{ "margin-top": "5%" }}>
+          <Button variant="contained" color="black" onClick={closeTab}>
+            Exit
+          </Button>
+          <Button
+            variant="contained"
+            color="black"
+            onClick={handleClose}
+            style={{ "margin-left": "10%" }}
+          >
+            Continue
+          </Button>
+        </div>
+      </Box>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/TimerComponent/ShowCounter.js
+++ b/frontend/src/components/TimerComponent/ShowCounter.js
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+const DateTimeDisplay = ({ value, type, isDanger }) => {
+  return (
+    <div className={isDanger ? "countdown danger" : "countdown"}>
+      <p>{value}</p>
+      <span>{type}</span>
+    </div>
+  );
+};
+
+const ShowCounter = ({ minutes, seconds }) => {
+  return (
+    <div className="show-counter ">
+      <DateTimeDisplay value={minutes} type="Mins" isDanger={false} />
+      <p>:</p>
+      <DateTimeDisplay value={seconds} type="Seconds" isDanger={false} />
+    </div>
+  );
+};
+
+export default ShowCounter;

--- a/frontend/src/components/TimerComponent/index.js
+++ b/frontend/src/components/TimerComponent/index.js
@@ -1,0 +1,17 @@
+import React from "react";
+import useCountdown from "./useCountdown";
+import Notifcation from "./Notification";
+import ShowCounter from "./ShowCounter";
+import "./styles.css";
+
+const CountdownTimer = ({ targetDate }) => {
+  const [days, hours, minutes, seconds] = useCountdown(targetDate);
+
+  if (days + hours + minutes + seconds <= 0) {
+    return <Notifcation />;
+  }
+
+  return <ShowCounter minutes={minutes} seconds={seconds} />;
+};
+
+export default CountdownTimer;

--- a/frontend/src/components/TimerComponent/styles.css
+++ b/frontend/src/components/TimerComponent/styles.css
@@ -1,62 +1,62 @@
 .expired-notice {
-    text-align: center;
-    padding: 2rem;
-    border: 1px solid #ebebeb;
-    border-radius: 0.25rem;
-    margin: 0.5rem;
+  text-align: center;
+  padding: 2rem;
+  border: 1px solid #ebebeb;
+  border-radius: 0.25rem;
+  margin: 0.5rem;
 }
 
-.expired-notice>span {
-    font-size: 2.5rem;
-    font-weight: bold;
-    color: red;
+.expired-notice > span {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: red;
 }
 
-.expired-notice>p {
-    font-size: 1.5rem;
+.expired-notice > p {
+  font-size: 1.5rem;
 }
 
 .show-counter {
-    padding: 0.5rem;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .show-counter .countdown-link {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    font-weight: 700;
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-    padding: 0.5rem;
-    border: 1px solid #ebebeb;
-    border-radius: 0.25rem;
-    text-decoration: none;
-    color: #000;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  padding: 0.5rem;
+  border: 1px solid #ebebeb;
+  border-radius: 0.25rem;
+  text-decoration: none;
+  color: #000;
 }
 
 .show-counter .countdown {
-    line-height: 1.25rem;
-    padding: 0 0.75rem 0 0.75rem;
-    align-items: center;
-    display: flex;
-    flex-direction: column;
+  line-height: 1.25rem;
+  padding: 0 0.75rem 0 0.75rem;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
 }
 
 .show-counter .countdown.danger {
-    color: #ff0000;
+  color: #ff0000;
 }
 
-.show-counter .countdown>p {
-    margin: 0;
+.show-counter .countdown > p {
+  margin: 0;
 }
 
-.show-counter .countdown>span {
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    line-height: 1rem;
+.show-counter .countdown > span {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1rem;
 }

--- a/frontend/src/components/TimerComponent/styles.css
+++ b/frontend/src/components/TimerComponent/styles.css
@@ -1,0 +1,62 @@
+.expired-notice {
+    text-align: center;
+    padding: 2rem;
+    border: 1px solid #ebebeb;
+    border-radius: 0.25rem;
+    margin: 0.5rem;
+}
+
+.expired-notice>span {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: red;
+}
+
+.expired-notice>p {
+    font-size: 1.5rem;
+}
+
+.show-counter {
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+.show-counter .countdown-link {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    padding: 0.5rem;
+    border: 1px solid #ebebeb;
+    border-radius: 0.25rem;
+    text-decoration: none;
+    color: #000;
+}
+
+.show-counter .countdown {
+    line-height: 1.25rem;
+    padding: 0 0.75rem 0 0.75rem;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+}
+
+.show-counter .countdown.danger {
+    color: #ff0000;
+}
+
+.show-counter .countdown>p {
+    margin: 0;
+}
+
+.show-counter .countdown>span {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    line-height: 1rem;
+}

--- a/frontend/src/components/TimerComponent/useCountdown.js
+++ b/frontend/src/components/TimerComponent/useCountdown.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const getReturnValues = (countDown) => {
+  // calculate time left
+  const days = Math.floor(countDown / (1000 * 60 * 60 * 24));
+  const hours = Math.floor(
+    (countDown % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+  );
+  const minutes = Math.floor((countDown % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((countDown % (1000 * 60)) / 1000);
+
+  return [days, hours, minutes, seconds];
+};
+
+const useCountdown = (targetDate) => {
+  const countDownDate = new Date(targetDate).getTime();
+
+  const [countDown, setCountDown] = useState(
+    countDownDate - new Date().getTime()
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountDown(countDownDate - new Date().getTime());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [countDownDate]);
+
+  return getReturnValues(countDown);
+};
+
+export default useCountdown;

--- a/frontend/src/components/__tests__/__snapshots__/SideBar.test.js.snap
+++ b/frontend/src/components/__tests__/__snapshots__/SideBar.test.js.snap
@@ -143,6 +143,46 @@ exports[`Side Bar component snapshot test 1`] = `
         </span>
       </button>
     </li>
+    <li>
+      <button
+        className="MuiButtonBase-root MuiButton-root MuiButton-outlined btn outlined white side"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiButton-label"
+        >
+          <span
+            className="MuiButton-startIcon MuiButton-iconSizeMedium"
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+              />
+            </svg>
+          </span>
+          Help
+        </span>
+      </button>
+    </li>
   </ul>
 </div>
 `;

--- a/frontend/src/containers/pages/AuthoringTool/AuthoringToolPage.js
+++ b/frontend/src/containers/pages/AuthoringTool/AuthoringToolPage.js
@@ -64,6 +64,7 @@ export default function AuthoringToolPage() {
       `/api/scenario/${scenarioId}/scene/${sceneId}`,
       {
         name: currentScene.name,
+        time: currentScene.time,
         components: currentScene?.components,
       },
       getUserIdToken

--- a/frontend/src/containers/pages/AuthoringTool/AuthoringToolPage.js
+++ b/frontend/src/containers/pages/AuthoringTool/AuthoringToolPage.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Button } from "@material-ui/core";
 import TopBar from "../../../components/TopBar";
 import ToolBar from "./ToolBar/ToolBar";
@@ -13,7 +13,6 @@ import AuthoringToolContext from "../../../context/AuthoringToolContext";
 import ToolbarContextProvider from "../../../context/ToolbarContextProvider";
 import AuthenticationContext from "../../../context/AuthenticationContext";
 import { uploadFiles } from "../../../firebase/storage";
-import HelpButton from "../../../components/HelpButton";
 
 /**
  * This page allows the user to edit a scene.
@@ -32,7 +31,7 @@ export default function AuthoringToolPage() {
   const { setSelect } = useContext(AuthoringToolContext);
   const { getUserIdToken } = useContext(AuthenticationContext);
   const [firstTimeRender, setFirstTimeRender] = useState(true);
-  const history = useHistory();
+  // const history = useHistory();
 
   useGet(
     `/api/scenario/${currentScenario?._id}/scene/full/${currentScene?._id}`,

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
@@ -48,7 +48,14 @@ export default function SceneSettings() {
           <CustomTextField
             label="Scene Timer Duration"
             type="number"
+            value={currentScene?.time}
             fullWidth
+            onChange={(event) => {
+              setCurrentScene({
+                ...currentScene,
+                time: event.target.value,
+              });
+            }}
             InputProps={{
               endAdornment: (
                 <InputAdornment position="end">seconds</InputAdornment>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
@@ -51,9 +51,12 @@ export default function SceneSettings() {
             value={currentScene?.time}
             fullWidth
             onChange={(event) => {
+              // limiting scene timer duration
+              const timeInput = event.target.value < 0 ? 0 : event.target.value;
+
               setCurrentScene({
                 ...currentScene,
-                time: event.target.value,
+                time: timeInput,
               });
             }}
             InputProps={{

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
@@ -61,6 +61,10 @@ export default function SceneSettings() {
                 <InputAdornment position="end">seconds</InputAdornment>
               ),
             }}
+            InputLabelProps={{
+              // label moves up whenever there is input
+              shrink: currentScene?.time || currentScene?.time === 0,
+            }}
           />
         </div>
       </div>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.js
@@ -1,12 +1,16 @@
 import React, { useContext } from "react";
 import TextField from "@material-ui/core/TextField";
 import { withStyles } from "@material-ui/core/styles";
+import { InputAdornment } from "@material-ui/core";
 import SceneContext from "../../../../context/SceneContext";
 
 import styles from "../../../../styling/CanvasSideBar.module.scss";
 
 const CustomTextField = withStyles({
   root: {
+    marginTop: "0.5em",
+    marginBottom: "1.5em",
+
     "& label.Mui-focused": {
       color: "#008a7b",
     },
@@ -28,6 +32,7 @@ export default function SceneSettings() {
       <div className={styles.sceneSettingsContainer}>
         <h1 className={styles.sideBarHeader}>Scene Settings</h1>
         <div className={styles.sideBarBody}>
+          {/* input for scene name */}
           <CustomTextField
             label="Scene Name"
             value={currentScene?.name}
@@ -37,6 +42,17 @@ export default function SceneSettings() {
                 ...currentScene,
                 name: event.target.value,
               });
+            }}
+          />
+          {/* input for scene timer duration */}
+          <CustomTextField
+            label="Scene Timer Duration"
+            type="number"
+            fullWidth
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">seconds</InputAdornment>
+              ),
             }}
           />
         </div>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
@@ -42,6 +42,42 @@ exports[`Scenario Selection page snapshot test 1`] = `
           />
         </div>
       </div>
+      <div
+        className="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
+      >
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+          data-shrink={false}
+        >
+          Scene Timer Duration
+        </label>
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+            disabled={false}
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="number"
+          />
+          <div
+            className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+            >
+              seconds
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
@@ -39,6 +39,42 @@ exports[`Scenario Selection page snapshot test 1`] = `
         />
       </div>
     </div>
+    <div
+      className="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
+    >
+      <label
+        className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+        data-shrink={false}
+      >
+        Scene Timer Duration
+      </label>
+      <div
+        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+        onClick={[Function]}
+      >
+        <input
+          aria-invalid={false}
+          autoFocus={false}
+          className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+          disabled={false}
+          onAnimationStart={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          required={false}
+          type="number"
+        />
+        <div
+          className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+        >
+          <p
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            seconds
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/__tests__/__snapshots__/ToolBar.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/__tests__/__snapshots__/ToolBar.test.js.snap
@@ -47,6 +47,11 @@ exports[`ToolBar component snapshot test 1`] = `
               d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
             />
           </svg>
+           
+          <p>
+            Add 
+            Image
+          </p>
           <svg
             aria-hidden={true}
             className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
@@ -98,6 +103,11 @@ exports[`ToolBar component snapshot test 1`] = `
               d="M2.5 4v3h5v12h3V7h5V4h-13zm19 5h-9v3h3v7h3v-7h3V9z"
             />
           </svg>
+           
+          <p>
+            Add 
+            Text
+          </p>
         </span>
         <span
           className="MuiTouchRipple-root"
@@ -139,6 +149,11 @@ exports[`ToolBar component snapshot test 1`] = `
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
             />
           </svg>
+           
+          <p>
+            Add 
+            Button
+          </p>
         </span>
         <span
           className="MuiTouchRipple-root"
@@ -180,6 +195,11 @@ exports[`ToolBar component snapshot test 1`] = `
               d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
             />
           </svg>
+           
+          <p>
+            Add 
+            Audio
+          </p>
           <svg
             aria-hidden={true}
             className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"

--- a/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
@@ -51,6 +51,20 @@ exports[`Authoring Tool page snapshot test 1`] = `
                 class="MuiTouchRipple-root"
               />
             </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained btn top contained white"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Save & close
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
           </li>
         </ul>
       </div>
@@ -84,6 +98,11 @@ exports[`Authoring Tool page snapshot test 1`] = `
                     d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
                   />
                 </svg>
+                 
+                <p>
+                  Add 
+                  Image
+                </p>
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
@@ -120,6 +139,11 @@ exports[`Authoring Tool page snapshot test 1`] = `
                     d="M2.5 4v3h5v12h3V7h5V4h-13zm19 5h-9v3h3v7h3v-7h3V9z"
                   />
                 </svg>
+                 
+                <p>
+                  Add 
+                  Text
+                </p>
               </span>
               <span
                 class="MuiTouchRipple-root"
@@ -146,6 +170,11 @@ exports[`Authoring Tool page snapshot test 1`] = `
                     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
                   />
                 </svg>
+                 
+                <p>
+                  Add 
+                  Button
+                </p>
               </span>
               <span
                 class="MuiTouchRipple-root"
@@ -172,6 +201,11 @@ exports[`Authoring Tool page snapshot test 1`] = `
                     d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
                   />
                 </svg>
+                 
+                <p>
+                  Add 
+                  Audio
+                </p>
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
@@ -325,6 +359,35 @@ exports[`Authoring Tool page snapshot test 1`] = `
                     type="text"
                     value=""
                   />
+                </div>
+              </div>
+              <div
+                class="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-2 MuiFormControl-fullWidth"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink="false"
+                >
+                  Scene Timer Duration
+                </label>
+                <div
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                    type="number"
+                    value=""
+                  />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      seconds
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.js
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.js
@@ -3,6 +3,7 @@ import { useGet } from "../../../hooks/crudHooks";
 import componentResolver from "./componentResolver";
 import PlayScenarioContext from "../../../context/PlayScenarioContext";
 import ProgressBar from "./progressBar";
+import CountdownTimer from "../../../components/TimerComponent";
 
 /**
  * This component displays the scene components on the screen when playing a scenario
@@ -32,7 +33,14 @@ export default function PlayScenarioCanvas() {
       {currentScene?.components?.map((component, index) =>
         componentResolver(component, index, () => componentOnClick(component))
       )}
-      <ProgressBar value={40} />
+      <ProgressBar value={80} />
+      {currentScene?.time ? (
+        <CountdownTimer
+          targetDate={new Date().setSeconds(
+            new Date().getSeconds() + currentScene?.time
+          )}
+        />
+      ) : null}
     </>
   );
 }

--- a/frontend/src/containers/pages/PlayScenarioPage/__tests__/__snapshots__/PlayScenarioCanvas.test.js.snap
+++ b/frontend/src/containers/pages/PlayScenarioPage/__tests__/__snapshots__/PlayScenarioCanvas.test.js.snap
@@ -3,21 +3,19 @@
 exports[`PlayScenarioCanvas component snapshot test 1`] = `
 <body>
   <div>
-    <div>
+    <span
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="80"
+      class="MuiLinearProgress-root MuiLinearProgress-colorInherit MuiLinearProgress-determinate css-futumu-MuiLinearProgress-root"
+      role="progressbar"
+      style="height: 10px; width: 100%; position: relative; color: rgb(0, 189, 167);"
+    >
       <span
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="40"
-        class="MuiLinearProgress-root MuiLinearProgress-colorInherit MuiLinearProgress-determinate css-futumu-MuiLinearProgress-root"
-        role="progressbar"
-        style="height: 10px; width: 100%; position: relative; color: rgb(0, 189, 167);"
-      >
-        <span
-          class="MuiLinearProgress-bar MuiLinearProgress-barColorInherit MuiLinearProgress-bar1Determinate css-1wqgwi1-MuiLinearProgress-bar1"
-          style="transform: translateX(-60%);"
-        />
-      </span>
-    </div>
+        class="MuiLinearProgress-bar MuiLinearProgress-barColorInherit MuiLinearProgress-bar1Determinate css-1wqgwi1-MuiLinearProgress-bar1"
+        style="transform: translateX(-20%);"
+      />
+    </span>
   </div>
 </body>
 `;

--- a/frontend/src/containers/pages/PlayScenarioPage/__tests__/__snapshots__/PlayScenarioPage.test.js.snap
+++ b/frontend/src/containers/pages/PlayScenarioPage/__tests__/__snapshots__/PlayScenarioPage.test.js.snap
@@ -7,21 +7,19 @@ exports[`PlayScenario page snapshot test 1`] = `
       class="makeStyles-canvasContainer-1"
     >
       <div>
-        <div>
+        <span
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="80"
+          class="MuiLinearProgress-root MuiLinearProgress-colorInherit MuiLinearProgress-determinate css-futumu-MuiLinearProgress-root"
+          role="progressbar"
+          style="height: 10px; width: 100%; position: relative; color: rgb(0, 189, 167);"
+        >
           <span
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="40"
-            class="MuiLinearProgress-root MuiLinearProgress-colorInherit MuiLinearProgress-determinate css-futumu-MuiLinearProgress-root"
-            role="progressbar"
-            style="height: 10px; width: 100%; position: relative; color: rgb(0, 189, 167);"
-          >
-            <span
-              class="MuiLinearProgress-bar MuiLinearProgress-barColorInherit MuiLinearProgress-bar1Determinate css-1wqgwi1-MuiLinearProgress-bar1"
-              style="transform: translateX(-60%);"
-            />
-          </span>
-        </div>
+            class="MuiLinearProgress-bar MuiLinearProgress-barColorInherit MuiLinearProgress-bar1Determinate css-1wqgwi1-MuiLinearProgress-bar1"
+            style="transform: translateX(-20%);"
+          />
+        </span>
       </div>
     </div>
     <div />

--- a/frontend/src/containers/pages/PlayScenarioPage/progressBar.js
+++ b/frontend/src/containers/pages/PlayScenarioPage/progressBar.js
@@ -10,14 +10,14 @@ const ProgressBar = ({ value }) => {
   };
 
   return (
-    <div>
+    <>
       <LinearProgress
         style={styles}
         variant="determinate"
         value={value}
         color="inherit"
       />
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/containers/pages/__tests__/__snapshots__/ScenarioSelectionPage.test.js.snap
+++ b/frontend/src/containers/pages/__tests__/__snapshots__/ScenarioSelectionPage.test.js.snap
@@ -99,6 +99,36 @@ exports[`Scenario Selection page snapshot test 1`] = `
               />
             </button>
           </li>
+          <li>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined btn outlined white side"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span
+                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                    />
+                  </svg>
+                </span>
+                Help
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </li>
         </ul>
       </div>
       <div

--- a/frontend/src/containers/pages/__tests__/__snapshots__/SceneSelectionPage.test.js.snap
+++ b/frontend/src/containers/pages/__tests__/__snapshots__/SceneSelectionPage.test.js.snap
@@ -109,6 +109,34 @@ exports[`Scene Selection page snapshot test 1`] = `
                 class="MuiTouchRipple-root"
               />
             </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined btn outlined white top"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span
+                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                    />
+                  </svg>
+                </span>
+                Help
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Describe the issue

To be able to add a time constant to the scene. After the timer ends, the scene can either end or prompt for restart. Based on Issue #22

## Describe the solution

MVP for this story is being able to add a timer for each scene, allowing the editor to customise how much time a user can spend on any given scene. At the end of the timer there will be a prompt (either pop-up stopping the scenario or prompting for a restart).

## Risk

Low risk

## Noted Issues
#### Some issues/concerns to take care of next time:
- **There isn't a clear way for users to indicate that they don't need a timer for the scene.** At the moment, setting it to 0 and not entering a value does this, but this could cause confusion in the future. Matthew suggested potentially adding a 'no time limit checkbox'. 
-  **Material UI Shrink label overlap.** Since the shrink is managed manually, adding any '-' or '+' symbols (which is allowed in the number field) causes the overlap to occur, so need to remove this ability. 
Also, the label doesn't move when clicked, unless you enter a value (which is inconsistent with the 'Scene Name' field shrink animation). 

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

