### PR TITLE
[VPS-037] - Created empty scene when scenario is created

### DIFF
--- a/frontend/src/components/SideBar.js
+++ b/frontend/src/components/SideBar.js
@@ -35,6 +35,13 @@ export default function SideBar() {
       },
       getUserIdToken
     );
+    await usePost(
+      `/api/scenario/${newScenario._id}/scene`,
+      {
+        name: `Scene 0`,
+      },
+      getUserIdToken
+    );
     setCurrentScenario(newScenario);
     // eslint-disable-next-line no-underscore-dangle
     history.push(`/scenario/${newScenario._id}`);


### PR DESCRIPTION
In Sidebar.js Under createScenario function, called extra endpoint to create an empty scene. By having an empty scene the thumbnail of the scenario would be fine.

## Describe the issue

Empty Scenario's thumbnail would be an error page.

## Describe the solution

On creation of a new scenario also create an empty scene,

## Risk

No potential risk.
One thing to note is user can still delete their scenes and leave a scenario empty and cause the same issue.
This solution is under the assumption user will not do that

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
