### PR TITLE
Vps 066/scene scenario double click

### DIFF
--- a/frontend/src/components/ListContainer.js
+++ b/frontend/src/components/ListContainer.js
@@ -19,6 +19,9 @@ import useStyles from "./component.styles";
  * function onItemSelected() {
  *   console.log("Selected.")
  * }
+ * function onItemDoubleClick() {
+ *   console.log("Double clicked.")
+ * }
  * function addCard() {
  *   console.log("Card Added.")
  * }
@@ -32,6 +35,7 @@ import useStyles from "./component.styles";
  *     sceneSelectionPage={sceneSelectionPage}
  *     scenarioId={scenarioId}
  *     onItemSelected={onItemSelected}
+ *     onItemDoubleClick={onDoubleClick}
  *     addCard={addCard}
  *     onItemBlur={onItemBlur}
  *   />
@@ -40,6 +44,7 @@ import useStyles from "./component.styles";
 export default function ListContainer({
   data,
   onItemSelected,
+  onItemDoubleClick,
   wide,
   addCard,
   onItemBlur,
@@ -51,9 +56,13 @@ export default function ListContainer({
   const columns = wide ? 5 : 4;
 
   /** Function which executes when an image in the image list is clicked. */
-  const onItemClick = (item) => {
-    setSelected(item._id);
-    onItemSelected(item);
+  const onItemClick = (event, item) => {
+    if (event.detail === 2) {
+      onItemDoubleClick(item);
+    } else {
+      setSelected(item._id);
+      onItemSelected(item);
+    }
   };
 
   return (
@@ -81,7 +90,7 @@ export default function ListContainer({
                   key={item._id}
                   cols={1}
                   height={200}
-                  onClick={() => onItemClick(item)}
+                  onClick={(event) => onItemClick(event, item)}
                 >
                   <div
                     className={

--- a/frontend/src/containers/pages/ScenarioSelectionPage.js
+++ b/frontend/src/containers/pages/ScenarioSelectionPage.js
@@ -31,9 +31,11 @@ export default function ScenarioSelectionPage({ data = null }) {
     reFetch();
   }
 
-  /** function is called when the user double clicks */
+  /** function is called when the user double clicks a scenario */
   async function editScenario() {
-    history.push(`/scenario/${currentScenario._id}`);
+    if (currentScenario != null) { // should be set on the first click, but check to be sure anyway
+      history.push(`/scenario/${currentScenario._id}`);
+    }
   }
 
   useEffect(() => {

--- a/frontend/src/containers/pages/ScenarioSelectionPage.js
+++ b/frontend/src/containers/pages/ScenarioSelectionPage.js
@@ -33,7 +33,8 @@ export default function ScenarioSelectionPage({ data = null }) {
 
   /** function is called when the user double clicks a scenario */
   async function editScenario() {
-    if (currentScenario != null) { // should be set on the first click, but check to be sure anyway
+    // should be set on the first click, but check to be sure anyway
+    if (currentScenario != null) {
       history.push(`/scenario/${currentScenario._id}`);
     }
   }

--- a/frontend/src/containers/pages/ScenarioSelectionPage.js
+++ b/frontend/src/containers/pages/ScenarioSelectionPage.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect } from "react";
+import { useHistory } from "react-router-dom";
 import SideBar from "../../components/SideBar";
 import ListContainer from "../../components/ListContainer";
 import ScreenContainer from "../../components/ScreenContainer";
@@ -15,6 +16,7 @@ export default function ScenarioSelectionPage({ data = null }) {
   const { scenarios, currentScenario, setCurrentScenario, reFetch } =
     useContext(ScenarioContext);
   const { getUserIdToken } = useContext(AuthenticationContext);
+  const history = useHistory();
 
   /** function is called when the user unfocuses from a scenario name */
   async function changeScenarioName({ target }) {
@@ -29,6 +31,11 @@ export default function ScenarioSelectionPage({ data = null }) {
     reFetch();
   }
 
+  /** function is called when the user double clicks */
+  async function editScenario() {
+    history.push(`/scenario/${currentScenario._id}`);
+  }
+
   useEffect(() => {
     setCurrentScenario(null);
     reFetch();
@@ -40,6 +47,7 @@ export default function ScenarioSelectionPage({ data = null }) {
       <ListContainer
         data={data || scenarios}
         onItemSelected={setCurrentScenario}
+        onItemDoubleClick={editScenario}
         onItemBlur={changeScenarioName}
       />
     </ScreenContainer>

--- a/frontend/src/containers/pages/SceneSelectionPage.js
+++ b/frontend/src/containers/pages/SceneSelectionPage.js
@@ -178,6 +178,7 @@ export function SceneSelectionPage({ data = null }) {
       <ListContainer
         data={data || scenes}
         onItemSelected={setCurrentScene}
+        onItemDoubleClick={editScene}
         addCard={createNewScene}
         wide
         onItemBlur={changeSceneName}


### PR DESCRIPTION
## Describe the issue
As described in tasks #66 , #67, we want to be able to double click the previews for a scene or scenario to edit it.

## Describe the solution
- Added new property `onItemDoubleClick` to `ListContainer` component.
- Changed `ListContainer`'s click handling to call above method when double clicked (determined by [event.default](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) = 2)
- Added function `editScenario()` in `ScenarioSelectionPage`, parallelling `editScene()` in `SceneSelectionPage`
- Set `onItemDoubleClick` of the `ListContainer`s in the SelectionPages to the above methods respectively.

## Risk

Any other code that uses the `ListContainer` component may need to adjust its behavior, providing an `onItemDoubleClick` method. This doesn't occur anywhere else in the codebase though.
Also there is slight duplication of functionality with the edit (scenario) button of the SideBar being defined entirely separately (as a `Link` with `to`).

## Definition of Done

- [x] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By
to be reviewed