### PR TITLE
[VPS-110] For assigned scenarios, show limited actions

### DIFF
--- a/frontend/src/components/ListContainer.js
+++ b/frontend/src/components/ListContainer.js
@@ -43,7 +43,6 @@ import useStyles from "./component.styles";
  */
 export default function ListContainer({
   data, // could be scenarios or scenes data
-  assignedScenarios,
   onItemSelected,
   onItemDoubleClick,
   wide,
@@ -52,10 +51,17 @@ export default function ListContainer({
   sceneSelectionPage,
   scenarioId,
   invalidNameId,
+  readOnly, // for scenes/scenarios that can't be edited/deleted by user
 }) {
   const classes = useStyles();
   const [selected, setSelected] = useState();
   const columns = wide ? 5 : 4;
+
+  if (readOnly) {
+    data = data.map((item) => {
+      return { ...item, isAssigned: true };
+    });
+  }
 
   /** Function which executes when an image in the image list is clicked. */
   const onItemClick = (event, item) => {
@@ -80,8 +86,6 @@ export default function ListContainer({
           wide ? styles.scenarioListContainerWide : styles.scenarioListContainer
         }
       >
-        {!sceneSelectionPage && <h1>Created scenarios</h1>}
-
         <ImageList rowHeight={210} cols={columns} gap={30}>
           {addCard ? (
             <ImageListItem
@@ -93,6 +97,7 @@ export default function ListContainer({
               <DashedCard onClick={addCard} />
             </ImageListItem>
           ) : null}
+
           {data && data.length > 0
             ? data.map((item) => (
                 <ImageListItem
@@ -148,83 +153,6 @@ export default function ListContainer({
               ))
             : null}
         </ImageList>
-
-        {assignedScenarios ? (
-          <>
-            {!sceneSelectionPage && <h1>Assigned scenarios</h1>}
-
-            <ImageList rowHeight={210} cols={columns} gap={30}>
-              {addCard ? (
-                <ImageListItem
-                  className={classes.listContainerItem}
-                  key={-1}
-                  cols={1}
-                  height={200}
-                >
-                  <DashedCard onClick={addCard} />
-                </ImageListItem>
-              ) : null}
-
-              {assignedScenarios && assignedScenarios.length > 0
-                ? assignedScenarios.map(({ _id, name }) => (
-                    <ImageListItem
-                      className={classes.listContainerItem}
-                      key={_id}
-                      cols={1}
-                      height={200}
-                      onClick={(event) =>
-                        onItemClick(event, { _id, isAssigned: true })
-                      }
-                      onContextMenu={() =>
-                        onItemRightClick({ _id, isAssigned: true })
-                      }
-                    >
-                      <div
-                        className={
-                          wide ? styles.imageListItemWide : styles.imageListItem
-                        }
-                      >
-                        <Box
-                          height={160}
-                          border={5}
-                          borderRadius={10}
-                          borderColor={_id === selected ? "#035084" : "#747474"}
-                          overflow="hidden"
-                          textAlign="center"
-                          sx={{
-                            background: "#f1f1f1",
-                            "&:hover": {
-                              background: "#cccccc",
-                            },
-                          }}
-                        >
-                          {sceneSelectionPage ? (
-                            <Thumbnail
-                              url={`${process.env.PUBLIC_URL}/play/${scenarioId}/${_id}`}
-                            />
-                          ) : (
-                            <Thumbnail
-                              url={`${process.env.PUBLIC_URL}/play/${_id}`}
-                            />
-                          )}
-                        </Box>
-                        <input
-                          className={styles.text}
-                          defaultValue={name}
-                          onBlur={onItemBlur}
-                          key={_id}
-                        />
-                      </div>
-
-                      {invalidNameId === _id && (
-                        <p1 className="nullNameWarning">invalid null name</p1>
-                      )}
-                    </ImageListItem>
-                  ))
-                : null}
-            </ImageList>
-          </>
-        ) : null}
       </div>
     </>
   );

--- a/frontend/src/components/ListContainer.js
+++ b/frontend/src/components/ListContainer.js
@@ -60,7 +60,7 @@ export default function ListContainer({
   /** Function which executes when an image in the image list is clicked. */
   const onItemClick = (event, item) => {
     if (event.detail === 2) {
-      onItemDoubleClick(item);
+      if (!item.isAssigned) onItemDoubleClick(item);
     } else {
       setSelected(item._id);
       onItemSelected(item);

--- a/frontend/src/components/ListContainer.js
+++ b/frontend/src/components/ListContainer.js
@@ -164,6 +164,7 @@ export default function ListContainer({
                   <DashedCard onClick={addCard} />
                 </ImageListItem>
               ) : null}
+
               {assignedScenarios && assignedScenarios.length > 0
                 ? assignedScenarios.map(({ _id, name }) => (
                     <ImageListItem
@@ -171,8 +172,12 @@ export default function ListContainer({
                       key={_id}
                       cols={1}
                       height={200}
-                      onClick={(event) => onItemClick(event, { _id })}
-                      onContextMenu={() => onItemRightClick({ _id })}
+                      onClick={(event) =>
+                        onItemClick(event, { _id, isAssigned: true })
+                      }
+                      onContextMenu={() =>
+                        onItemRightClick({ _id, isAssigned: true })
+                      }
                     >
                       <div
                         className={
@@ -210,6 +215,7 @@ export default function ListContainer({
                           key={_id}
                         />
                       </div>
+
                       {invalidNameId === _id && (
                         <p1 className="nullNameWarning">invalid null name</p1>
                       )}

--- a/frontend/src/components/SideBar.js
+++ b/frontend/src/components/SideBar.js
@@ -26,6 +26,8 @@ export default function SideBar() {
   );
   const history = useHistory();
 
+  const isAssigned = currentScenario?.isAssigned || false;
+
   /** Calls backend end point to create a new empty scenario. */
   async function createScenario(name = "no name") {
     const newScenario = await usePost(
@@ -119,7 +121,7 @@ export default function SideBar() {
           <li>
             <Button
               className={`btn side contained white ${
-                currentScenario ? "" : "disabled"
+                currentScenario && !isAssigned ? "" : "disabled"
               }  `}
               color="default"
               variant="contained"
@@ -129,7 +131,7 @@ export default function SideBar() {
                   ? `/scenario/${currentScenario._id}`
                   : "/scenario/null"
               }
-              disabled={!currentScenario}
+              disabled={!currentScenario || isAssigned}
             >
               Edit
             </Button>
@@ -139,7 +141,7 @@ export default function SideBar() {
               className="btn side contained"
               color="default"
               variant="contained"
-              disabled={!currentScenario}
+              disabled={!currentScenario || isAssigned}
               onClick={deleteScenario}
             >
               Delete

--- a/frontend/src/components/__tests__/__snapshots__/ListContainer.test.js.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ListContainer.test.js.snap
@@ -4,9 +4,6 @@ exports[`ListContainer component snapshot test 1`] = `
 <div
   className="scenarioListContainer"
 >
-  <h1>
-    Created scenarios
-  </h1>
   <ul
     className="MuiImageList-root"
     style={

--- a/frontend/src/containers/pages/ScenarioSelectionPage.js
+++ b/frontend/src/containers/pages/ScenarioSelectionPage.js
@@ -24,7 +24,6 @@ export default function ScenarioSelectionPage({ data = null }) {
     currentScenario,
     setCurrentScenario,
   } = useContext(ScenarioContext);
-  console.log(assignedScenarios);
   const { getUserIdToken, VpsUser } = useContext(AuthenticationContext);
   const history = useHistory();
 
@@ -112,12 +111,19 @@ export default function ScenarioSelectionPage({ data = null }) {
           <MenuItem onClick={playScenario} disabled={!currentScenario}>
             Play
           </MenuItem>
-          <MenuItem onClick={editScenario} disabled={!currentScenario}>
-            Edit
-          </MenuItem>
-          <MenuItem onClick={deleteScenario} disabled={!currentScenario}>
-            Delete
-          </MenuItem>
+
+          {(!currentScenario || !currentScenario?.isAssigned) && (
+            <MenuItem onClick={editScenario} disabled={!currentScenario}>
+              Edit
+            </MenuItem>
+          )}
+
+          {(!currentScenario || !currentScenario?.isAssigned) && (
+            <MenuItem onClick={deleteScenario} disabled={!currentScenario}>
+              Delete
+            </MenuItem>
+          )}
+
           {VpsUser.role === AccessLevel.STAFF ? (
             <MenuItem onClick={openDashboard} disabled={!currentScenario}>
               Dashboard

--- a/frontend/src/containers/pages/ScenarioSelectionPage.js
+++ b/frontend/src/containers/pages/ScenarioSelectionPage.js
@@ -1,13 +1,15 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
+import "styling/ScenarioSelectionPage.module.scss";
+
 import MenuItem from "@material-ui/core/MenuItem";
-import ContextMenu from "../../components/ContextMenu";
-import SideBar from "../../components/SideBar";
-import ListContainer from "../../components/ListContainer";
-import ScreenContainer from "../../components/ScreenContainer";
-import ScenarioContext from "../../context/ScenarioContext";
-import { usePut, useDelete } from "../../hooks/crudHooks";
-import AuthenticationContext from "../../context/AuthenticationContext";
+import ContextMenu from "components/ContextMenu";
+import SideBar from "components/SideBar";
+import ListContainer from "components/ListContainer";
+import ScreenContainer from "components/ScreenContainer";
+import ScenarioContext from "context/ScenarioContext";
+import { usePut, useDelete } from "hooks/crudHooks";
+import AuthenticationContext from "context/AuthenticationContext";
 import AccessLevel from "../../enums/route.access.level";
 
 /**
@@ -132,14 +134,29 @@ export default function ScenarioSelectionPage({ data = null }) {
             ""
           )}
         </ContextMenu>
+
+        <h1>Created scenarios</h1>
         <ListContainer
           data={data || scenarios}
-          assignedScenarios={assignedScenarios || []}
           onItemSelected={setCurrentScenario}
           onItemDoubleClick={editScenario}
           onItemBlur={changeScenarioName}
           invalidNameId={invalidNameId}
         />
+
+        <h1>Assigned scenarios</h1>
+        {assignedScenarios && assignedScenarios.length ? (
+          <ListContainer
+            data={assignedScenarios || []}
+            onItemSelected={setCurrentScenario}
+            onItemDoubleClick={() => {}}
+            onItemBlur={() => {}}
+            invalidNameId={invalidNameId}
+            readOnly
+          />
+        ) : (
+          <p>You have no assigned scenarios</p>
+        )}
       </div>
     </ScreenContainer>
   );

--- a/frontend/src/containers/pages/__tests__/__snapshots__/ScenarioSelectionPage.test.js.snap
+++ b/frontend/src/containers/pages/__tests__/__snapshots__/ScenarioSelectionPage.test.js.snap
@@ -134,12 +134,12 @@ exports[`Scenario Selection page snapshot test 1`] = `
         </ul>
       </div>
       <div>
+        <h1>
+          Created scenarios
+        </h1>
         <div
           class="scenarioListContainer"
         >
-          <h1>
-            Created scenarios
-          </h1>
           <ul
             class="MuiImageList-root"
             style="margin: -15px;"
@@ -251,14 +251,13 @@ exports[`Scenario Selection page snapshot test 1`] = `
               </div>
             </li>
           </ul>
-          <h1>
-            Assigned scenarios
-          </h1>
-          <ul
-            class="MuiImageList-root"
-            style="margin: -15px;"
-          />
         </div>
+        <h1>
+          Assigned scenarios
+        </h1>
+        <p>
+          You have no assigned scenarios
+        </p>
       </div>
     </div>
   </div>

--- a/frontend/src/styling/ListContainer.module.scss
+++ b/frontend/src/styling/ListContainer.module.scss
@@ -1,7 +1,7 @@
 .scenarioListContainer {
   width: 85vw;
-  height: 100vh;
-  overflow-y: scroll;
+  // height: 100vh;
+  overflow-y: auto;
   overflow-x: hidden;
   padding-right: 30px;
   padding-left: 30px;

--- a/frontend/src/styling/ScenarioSelectionPage.module.scss
+++ b/frontend/src/styling/ScenarioSelectionPage.module.scss
@@ -1,0 +1,3 @@
+h1 {
+    margin-left: 15px;
+}

--- a/frontend/src/styling/ScenarioSelectionPage.module.scss
+++ b/frontend/src/styling/ScenarioSelectionPage.module.scss
@@ -1,3 +1,3 @@
 h1 {
-    margin-left: 15px;
+  margin-left: 15px;
 }


### PR DESCRIPTION
in the toolbar & in the context menu (right-click menu)

## Describe the issue
From the previous PR:

> Potential risks that this PR might brings 
> currently, the student can do the following for an assigned scenario:
> - open the scenario
> - see all the scenes
> - open a scene
> - ⚠️ from the perspective of the student, it feels like they can edit the scene but even when the changes are 'saved', they don't actually get saved. refreshing or reloading the scene from the student or lecturer's end will not show the changes made by the student to the scene. (which is probably a good thing)
> - so for ☝️, it should be made more obvious that the student can't edit the assigned scenario/scene but this can be in the next PR.
> - also shouldn't be able to delete either so delete & edit buttons shouldn't be active in sidebar when a assigned scenario is selected. ALSO in next PR.


## Describe the solution

A clear and concise description of what the solution is.

Remove those actions from the toolbar and context menu so what was:
![image](https://github.com/UoaWDCC/VPS/assets/78939786/a4a6a2e9-2408-4b02-9d3b-40f8730a8653)

![image](https://github.com/UoaWDCC/VPS/assets/78939786/4a0d802f-239c-4f9b-9671-bee5da5bc36e)

will now simply show:
![image](https://github.com/UoaWDCC/VPS/assets/78939786/38d5bb35-2b0e-4867-8b04-f7a6c508d18a)


## Risk

Potential risks that this PR might brings

## Definition of Done

- [ ] Code peer-reviewed
- [x] Wiki Documentation is written and up to date
- [x] Unit tests written and passing
- [x] Integration tests written and passing
- [x] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
