### PR TITLE
[VPS-121] Frontend bit for assigning tags for scenes

### DIFF
--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneListItem.js
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneListItem.js
@@ -1,0 +1,59 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+
+import React, { useRef } from "react";
+import styles from "styling/SceneNavigator.module.scss";
+import { tagColours, tagOptions } from "./SceneTagCustomization";
+
+const SceneListItem = ({
+  sceneId,
+  tag,
+  thumbnail,
+  showingTagInputFor,
+  showTagInputFor,
+  selectTagEl,
+}) => {
+  const tagRef = useRef(null);
+  const fullTagRef = useRef(null);
+
+  function toggleTagOnHover() {
+    const tagEl = tagRef.current;
+    const fullTagEl = fullTagRef.current;
+
+    tagEl.classList.toggle(styles.hidden);
+    fullTagEl.classList.toggle(styles.showing);
+  }
+
+  function toggleInputBox() {
+    showTagInputFor(showingTagInputFor === sceneId ? null : sceneId);
+    selectTagEl(showingTagInputFor === sceneId ? null : tagRef.current);
+  }
+
+  return (
+    <li key={sceneId}>
+      {thumbnail}
+      <p
+        className={styles.playersTag}
+        style={{ borderColor: tagColours[tag] || "black" }}
+        onMouseEnter={() => toggleTagOnHover(sceneId)}
+        onClick={() => toggleInputBox(sceneId)}
+        ref={tagRef}
+      >
+        {tag}
+      </p>
+
+      <p
+        className={styles.playersTagFull}
+        style={{ borderColor: tagColours[tag] || "black" }}
+        onMouseLeave={() => toggleTagOnHover(sceneId)}
+        onClick={() => toggleInputBox(sceneId)}
+        ref={fullTagRef}
+      >
+        {tagOptions[tag]}
+      </p>
+    </li>
+  );
+};
+
+export default SceneListItem;

--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneNavigator.js
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneNavigator.js
@@ -1,61 +1,121 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useRef } from "react";
 import { useParams, useHistory } from "react-router-dom";
-import SceneContext from "../../../../context/SceneContext";
-import Thumbnail from "../../../../components/Thumbnail";
-import styles from "../../../../styling/SceneNavigator.module.scss";
+import SceneContext from "context/SceneContext";
+import Thumbnail from "components/Thumbnail";
+import styles from "styling/SceneNavigator.module.scss";
+import SceneListItem from "./SceneListItem";
+import SceneTagInput from "./SceneTagInput";
 
-const SceneNavigator = (props) => {
+const SceneNavigator = ({ saveScene }) => {
   const [thumbnails, setThumbnails] = useState(null);
   const { scenes, currentScene, currentSceneRef, setCurrentScene } =
     useContext(SceneContext);
   const { scenarioId } = useParams();
   const history = useHistory();
-  const { saveScene } = props;
+
+  // showing tag modal
+
+  const [showingTagInputFor, showTagInputFor] = useState(null);
+
+  function getIndexOfSceneId(sceneId) {
+    if (!thumbnails) return -1;
+    return thumbnails.findIndex((thumbnail) => thumbnail.sceneId === sceneId);
+  }
+
+  function changeTag(sceneId, newTag) {
+    const sceneIndex = getIndexOfSceneId(sceneId);
+
+    // console.table({ sceneIndex, newTag });
+    setThumbnails((currentThumbnails) => {
+      currentThumbnails[sceneIndex].tag = newTag;
+      return [...currentThumbnails];
+    });
+  }
 
   useEffect(() => {
     if (scenes !== undefined) {
       setThumbnails(
-        scenes.map((scene, index) => (
-          <button
-            type="button"
-            onClick={() => {
-              if (currentSceneRef.current._id === scene._id) return;
-              setCurrentScene(scene);
-              saveScene();
-              history.push({
-                pathname: `/scenario/${scenarioId}/scene/${scene._id}`,
-              });
-            }}
-            className={styles.sceneButton}
-            style={
-              currentScene._id === scene._id
-                ? {
-                    border: "3px solid #035084",
-                  }
-                : null
-            }
-            key={scene._id}
-          >
-            <p
-              className={styles.sceneText}
-              style={
-                currentScene._id === scene._id ? { color: "#035084" } : null
-              }
-            >
-              {index + 1}
-            </p>
-            <Thumbnail
-              url={`${process.env.PUBLIC_URL}/play/${scenarioId}/${scene._id}`}
-              width="160"
-              height="90"
-            />
-          </button>
-        ))
+        scenes.map((scene, index) => ({
+          sceneId: scene._id,
+          tag: "D",
+          sceneListItem: (
+            <>
+              <p
+                className={styles.sceneText}
+                style={
+                  currentScene._id === scene._id ? { color: "#035084" } : null
+                }
+              >
+                {index + 1}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  if (currentSceneRef.current._id === scene._id) return;
+                  setCurrentScene(scene);
+                  saveScene();
+                  history.push({
+                    pathname: `/scenario/${scenarioId}/scene/${scene._id}`,
+                  });
+                }}
+                className={styles.sceneButton}
+                style={
+                  currentScene._id === scene._id
+                    ? {
+                        border: "3px solid #035084",
+                      }
+                    : null
+                }
+                key={scene._id}
+              >
+                <Thumbnail
+                  url={`${process.env.PUBLIC_URL}/play/${scenarioId}/${scene._id}`}
+                  width="160"
+                  height="90"
+                />
+              </button>
+            </>
+          ),
+        }))
       );
     }
   }, [scenes, currentScene]);
 
-  return <div className={styles.sceneNavigator}>{thumbnails}</div>;
+  // for the scene/tag inputs
+  const [selectedTagEl, selectTagEl] = useState(null);
+
+  return (
+    thumbnails && (
+      <div style={{ display: "flex", position: "relative" }}>
+        <ul className={styles.sceneNavigator}>
+          {thumbnails.map(({ sceneListItem: thumbnail, sceneId, tag }) => (
+            <SceneListItem
+              {...{
+                thumbnail,
+                sceneId,
+                tag,
+                showingTagInputFor,
+                showTagInputFor,
+                selectTagEl,
+                key: sceneId,
+              }}
+            />
+          ))}
+        </ul>
+
+        {showingTagInputFor && (
+          <SceneTagInput
+            {...{
+              selectedTagEl,
+              changeTag,
+              showTagInputFor,
+              showingTagInputFor,
+            }}
+          />
+        )}
+      </div>
+    )
+  );
 };
 
 export default SceneNavigator;

--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneNavigator.js
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneNavigator.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useRef } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import SceneContext from "context/SceneContext";
 import Thumbnail from "components/Thumbnail";

--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneTagCustomization.js
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneTagCustomization.js
@@ -1,0 +1,2 @@
+export const tagOptions = { D: "Doctor", P: "Pharmacist", N: "Nurse" };
+export const tagColours = { D: "magenta", P: "blue", N: "green" };

--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneTagInput.js
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/SceneTagInput.js
@@ -1,0 +1,46 @@
+import React from "react";
+import styles from "styling/SceneNavigator.module.scss";
+import { tagOptions } from "./SceneTagCustomization";
+
+const SceneTagInput = ({
+  selectedTagEl,
+  changeTag,
+  showingTagInputFor,
+  showTagInputFor,
+}) => {
+  const selectedValue = tagOptions[selectedTagEl?.innerHTML] || "";
+
+  const verticalPos = selectedTagEl
+    ? `${selectedTagEl.getBoundingClientRect().top.toString()}px`
+    : "50%";
+
+  return (
+    <div
+      className={styles.popupForSceneTagInput}
+      style={{
+        "--vertical-pos": verticalPos,
+      }}
+    >
+      <select
+        defaultValue={selectedValue}
+        onChange={(e) =>
+          changeTag(showingTagInputFor, e.target.selectedOptions[0].value)
+        }
+      >
+        {Object.keys(tagOptions).map((tagSymbol) => {
+          return (
+            <option key={tagSymbol} value={tagSymbol}>
+              {tagOptions[tagSymbol]}
+            </option>
+          );
+        })}
+      </select>
+
+      <button type="button" onClick={() => showTagInputFor(null)}>
+        Close
+      </button>
+    </div>
+  );
+};
+
+export default SceneTagInput;

--- a/frontend/src/containers/pages/AuthoringTool/SceneNavigator/__tests__/__snapshots__/SceneNavigator.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/SceneNavigator/__tests__/__snapshots__/SceneNavigator.test.js.snap
@@ -2,10 +2,6 @@
 
 exports[`Authoring Tool page snapshot test 1`] = `
 <body>
-  <div>
-    <div
-      class="sceneNavigator"
-    />
-  </div>
+  <div />
 </body>
 `;

--- a/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
@@ -316,9 +316,6 @@ exports[`Authoring Tool page snapshot test 1`] = `
         style="height: 100%; overflow: hidden;"
       >
         <div
-          class="sceneNavigator"
-        />
-        <div
           class="moveable-control-box    rCSuehiy8"
           data-able-draggable="true"
           data-able-origin="true"

--- a/frontend/src/styling/SceneNavigator.module.scss
+++ b/frontend/src/styling/SceneNavigator.module.scss
@@ -4,14 +4,52 @@
   padding: 1rem 1rem 1rem 2rem;
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+
+  position: relative;
+  z-index: 10;
+
+  overflow-y: auto;
+  overflow-x: hidden;
   gap: 1rem;
+  align-items: flex-start;
+  justify-content: stretch;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .playersTag,
+  .playersTagFull {
+    border: 1.8px solid magenta;
+    background-color: rgb(218, 209, 209);
+    border-radius: 15px;
+    padding: 5px 10px;
+    cursor: pointer;
+    height: 20px;
+
+    &.hidden {
+      visibility: hidden;
+    }
+
+    &.showing {
+      display: initial;
+    }
+  }
+
+  .playersTagFull {
+    display: none;
+    position: absolute;
+    right: 16px;
+  }
 
   .sceneButton {
     border: 3px solid transparent;
     width: max-content;
     background-color: transparent;
     position: relative;
+    overflow: hidden;
 
     .sceneText {
       font-size: small;
@@ -25,5 +63,39 @@
 
   .sceneButton:hover {
     border: 3px solid #cfcfcf;
+  }
+}
+
+.popupForSceneTagInput {
+  z-index: 2;
+
+  position: absolute;
+  left: calc(100% + 10px);
+  --vertical-pos: 50%;
+  top: calc(var(--vertical-pos) + 100% - 100vh - 10px);
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  background-color: white;
+  border: 2px solid black;
+  padding: 10px 20px;
+  border-radius: 10px;
+
+  label {
+    display: flex;
+    flex: 1;
+    gap: 10px;
+    text-wrap: nowrap;
+  }
+
+  button {
+    outline: none;
+    border: none;
+    cursor: pointer;
+    align-self: flex-end;
+    background: none;
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
## Describe the issue

A clear and concise description of what the issue is.
#124 

## Describe the solution

A clear and concise description of what the solution is.

implemented:
- new components for each `SceneListItem` and the `SceneTagInput`
- currently only demo purposes so tags are stored on the frontend
- user can click a tag to show the change tag input box
- currently the new tag doesn't get saved anywhere
- styles for everything

Functionality looks like this:
![Screenshot (28)](https://github.com/UoaWDCC/VPS/assets/78939786/bfeefe7b-b5a9-4606-9407-ada2a4c2dbdf)

0. default state: show shortened 'symbol' for tag e.g. 'D'
1. on hover: display full name of tag e.g. 'Doctor'
2. on clicking tag: display input for changing tag next to it
    1. on changing the tag via the input: change the tag next to the scene
    2. clicking close or the tag again will hide the input box

## Risk

Potential risks that this PR might brings
Doesn't yet store the tags anywhere other than user's device.
Will complete in next pull request.

## Definition of Done

- [ ] Code peer-reviewed
- [x] Wiki Documentation is written and up to date
- [x] Unit tests written and passing
- [x] Integration tests written and passing
- [x] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
