### PR TITLE
VPS-155/manage-groups-UI

### DIFF
--- a/frontend/src/containers/App.jsx
+++ b/frontend/src/containers/App.jsx
@@ -37,20 +37,18 @@ export default function App() {
                 </ScenarioContextProvider>
               </ProtectedRoute>
 
-              <ProtectedRoute path="/scenario/:scenarioId">
-                <ScenarioContextProvider>
-                  <Switch>
-                    <ProtectedRoute exact path="/scenario/:scenarioId">
-                      <SceneContextProvider>
-                        <ScenePage />
-                      </SceneContextProvider>
-                    </ProtectedRoute>
+              <ScenarioContextProvider>
+                <Switch>
+                  <ProtectedRoute index path="/scenario/:scenarioId">
+                    <SceneContextProvider>
+                      <ScenePage />
+                    </SceneContextProvider>
                     <ProtectedRoute path="/scenario/:scenarioId/manage-groups">
                       <ManageGroupsPage />
                     </ProtectedRoute>
-                  </Switch>
-                </ScenarioContextProvider>
-              </ProtectedRoute>
+                  </ProtectedRoute>
+                </Switch>
+              </ScenarioContextProvider>
 
               <ProtectedRoute
                 path="/dashboard"

--- a/frontend/src/containers/App.jsx
+++ b/frontend/src/containers/App.jsx
@@ -12,6 +12,7 @@ import DashboardPage from "./pages/Dashboard/DashboardPage";
 import LoginPage from "./pages/LoginPage";
 import PlayScenarioPage from "./pages/PlayScenarioPage/PlayScenarioPage";
 import ScenarioSelectionPage from "./pages/ScenarioSelectionPage";
+import ManageGroupsPage from "./pages/ManageGroups/ManageGroupsPage";
 import { ScenePage } from "./pages/SceneSelectionPage";
 import theme from "./theme/App.theme";
 
@@ -38,9 +39,16 @@ export default function App() {
 
               <ProtectedRoute path="/scenario/:scenarioId">
                 <ScenarioContextProvider>
-                  <SceneContextProvider>
-                    <ScenePage />
-                  </SceneContextProvider>
+                  <Switch>
+                    <ProtectedRoute exact path="/scenario/:scenarioId">
+                      <SceneContextProvider>
+                        <ScenePage />
+                      </SceneContextProvider>
+                    </ProtectedRoute>
+                    <ProtectedRoute path="/scenario/:scenarioId/manage-groups">
+                      <ManageGroupsPage />
+                    </ProtectedRoute>
+                  </Switch>
                 </ScenarioContextProvider>
               </ProtectedRoute>
 

--- a/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
+++ b/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
@@ -1,0 +1,7 @@
+export default function GroupsTable() {
+    return (
+      <div>
+        <h1>Put group table here</h1>
+      </div>
+    );
+  }

--- a/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
+++ b/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
@@ -10,11 +10,36 @@
  */
 
 export default function GroupsTable({
-  data = [],
+  data = [
+    { groupNumber: 1, nurse: "Alice", doctor: "Bob", pharmacist: "Charlie" },
+    { groupNumber: 2, nurse: "David", doctor: "Eve", pharmacist: "Frank" },
+    { groupNumber: 3, nurse: "Grace", doctor: "Henry", pharmacist: "Ivy" },
+    { groupNumber: 4, nurse: "Jack", doctor: "Kelly", pharmacist: "Liam" },
+  ],
 }) {
   return (
-      <div>
-        <h1>Put group table here, just place it with some mock data for now, do according to figma design</h1>
-      </div>
-    );
-  }
+    <div className="relative overflow-x-auto justify-center">
+      <h1 className="text-2xl font-bold mb-4 text-center">Group Table</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Group Number</th>
+            <th>Nurse</th>
+            <th>Doctor</th>
+            <th>Pharmacist</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((group) => (
+            <tr key={group.groupNumber}>
+              <td>{group.groupNumber}</td>
+              <td>{group.nurse}</td>
+              <td>{group.doctor}</td>
+              <td>{group.pharmacist}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
+++ b/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
@@ -1,7 +1,20 @@
-export default function GroupsTable() {
-    return (
+/**
+ * Component displaying groups in a table format
+ *
+ * @component
+ * @example
+ * return (
+ *   <GroupsTable data={csv_data}>
+ *   </GroupsTable>
+ * )
+ */
+
+export default function GroupsTable({
+  data = [],
+}) {
+  return (
       <div>
-        <h1>Put group table here</h1>
+        <h1>Put group table here, just place it with some mock data for now, do according to figma design</h1>
       </div>
     );
   }

--- a/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
+++ b/frontend/src/containers/pages/ManageGroups/GroupTable.jsx
@@ -9,37 +9,72 @@
  * )
  */
 
-export default function GroupsTable({
-  data = [
-    { groupNumber: 1, nurse: "Alice", doctor: "Bob", pharmacist: "Charlie" },
-    { groupNumber: 2, nurse: "David", doctor: "Eve", pharmacist: "Frank" },
-    { groupNumber: 3, nurse: "Grace", doctor: "Henry", pharmacist: "Ivy" },
-    { groupNumber: 4, nurse: "Jack", doctor: "Kelly", pharmacist: "Liam" },
-  ],
-}) {
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: "5vh",
+    display: "flex",
+    justifyContent: "center",
+    overflowX: "auto",
+    width: "100vw",
+  },
+  table: {
+    minWidth: "90vw",
+  },
+  heading: {
+    fontWeight: "bold",
+    marginBottom: "1rem",
+    textAlign: "center",
+  },
+});
+
+export default function GroupTable({ data }) {
+  const classes = useStyles();
+
   return (
-    <div className="relative overflow-x-auto justify-center">
-      <h1 className="text-2xl font-bold mb-4 text-center">Group Table</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>Group Number</th>
-            <th>Nurse</th>
-            <th>Doctor</th>
-            <th>Pharmacist</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((group) => (
-            <tr key={group.groupNumber}>
-              <td>{group.groupNumber}</td>
-              <td>{group.nurse}</td>
-              <td>{group.doctor}</td>
-              <td>{group.pharmacist}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className={classes.root}>
+      <Paper>
+        <Typography variant="h5" component="h1" className={classes.heading}>
+          Group Table
+        </Typography>
+        <TableContainer>
+          <Table className={classes.table} aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                <TableCell>Group Number</TableCell>
+                <TableCell align="right">Nurse</TableCell>
+                <TableCell align="right">Doctor</TableCell>
+                <TableCell align="right">Pharmacist</TableCell>
+                <TableCell align="right">Progress</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((group) => (
+                <TableRow key={group.groupNumber}>
+                  <TableCell component="th" scope="row">
+                    {group.groupNumber}
+                  </TableCell>
+                  <TableCell align="right">{group.nurse}</TableCell>
+                  <TableCell align="right">{group.doctor}</TableCell>
+                  <TableCell align="right">{group.pharmacist}</TableCell>
+                  <TableCell align="right">{group.progress}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
     </div>
   );
 }

--- a/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
+++ b/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
@@ -18,17 +18,34 @@ import TopBar from "./TopBar";
 
 export default function ManageGroupsPage() {
   const { scenarioId } = useParams();
+
+  // File input is a hidden input element that is activated via a click handler
+  // This allows us to have an UI button that acts like a file <input> element.
+  const fileInputRef = useRef(null);
+  const upload = () => {
+    fileInputRef.current.click();
+  };
+
+  const handleFileUpload = (event) => {
+    // Handle file upload logic here
+    console.log("File uploaded:", event.target.files[0]);
+  };
+
   function download() {
     console.log("downloading current group config as .CSV");
   }
 
-  function upload() {
-    console.log("csv upload pressed");
-  }
 
   return (
     <ScreenContainer vertical>
       <TopBar back = {`/scenario/${scenarioId}`}>
+        <input
+            type="file"
+            ref={fileInputRef}
+            accept=".csv"
+            style={{ display: "none" }}
+            onChange={handleFileUpload}
+        />
         <Button
           className="btn top contained white"
           color="default"

--- a/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
+++ b/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
@@ -1,3 +1,15 @@
+import { Button } from "@material-ui/core";
+import { useContext, useEffect, useRef, useState } from "react";
+import {
+  Route,
+  Switch,
+  useHistory,
+  useParams,
+  useRouteMatch,
+} from "react-router-dom";
+import ScreenContainer from "components/ScreenContainer";
+import TopBar from "./TopBar";
+
 /**
  * Page that shows the groups that the admin can manipulate
  *
@@ -5,9 +17,39 @@
  */
 
 export default function ManageGroupsPage() {
+  const { scenarioId } = useParams();
+  function download() {
+    console.log("downloading current group config as .CSV");
+  }
+
+  function upload() {
+    console.log("csv upload pressed");
+  }
+
   return (
-    <div>
-      <h1>Manage Groups</h1>
-    </div>
+    <ScreenContainer vertical>
+      <TopBar back = {`/scenario/${scenarioId}`}>
+        <Button
+          className="btn top contained white"
+          color="default"
+          variant="contained"
+          onClick={upload}
+        >
+          Upload
+        </Button>
+        <Button
+          className="btn top contained white"
+          color="default"
+          variant="contained"
+          onClick={download}
+        >
+          Download
+        </Button>
+      </TopBar>
+
+      {/* On top of the action button available in the top menu bar, we also override user's rightclick context menu to offer the same functionality. */}
+      {/* <div onContextMenu={handleContextMenu}>
+      </div> */}
+    </ScreenContainer>
   );
 }

--- a/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
+++ b/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
@@ -1,0 +1,13 @@
+/**
+ * Page that shows the groups that the admin can manipulate
+ *
+ * @container
+ */
+
+export default function ManageGroupsPage() {
+  return (
+    <div>
+      <h1>Manage Groups</h1>
+    </div>
+  );
+}

--- a/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
+++ b/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
@@ -19,6 +19,36 @@ import GroupsTable from "./GroupTable";
 
 export default function ManageGroupsPage() {
   const { scenarioId } = useParams();
+  const tableData = [
+    {
+      groupNumber: 1,
+      nurse: "Alice Cheng",
+      doctor: "Bob Marley",
+      pharmacist: "Charlie Puth",
+      progress: "50%",
+    },
+    {
+      groupNumber: 2,
+      nurse: "Alice Cheng",
+      doctor: "Bob Marley",
+      pharmacist: "Charlie Puth",
+      progress: "20%",
+    },
+    {
+      groupNumber: 3,
+      nurse: "Alice Cheng",
+      doctor: "Bob Marley",
+      pharmacist: "Charlie Puth",
+      progress: "0%",
+    },
+    {
+      groupNumber: 4,
+      nurse: "Alice Cheng",
+      doctor: "Bob Marley",
+      pharmacist: "Charlie Puth",
+      progress: "300%",
+    },
+  ];
 
   // File input is a hidden input element that is activated via a click handler
   // This allows us to have an UI button that acts like a file <input> element.
@@ -64,11 +94,8 @@ export default function ManageGroupsPage() {
         </Button>
       </TopBar>
 
-      <GroupsTable />
-
-      {/* On top of the action button available in the top menu bar, we also override user's rightclick context menu to offer the same functionality. */}
-      {/* <div onContextMenu={handleContextMenu}>
-      </div> */}
+      <GroupsTable data={tableData} />
+      
     </ScreenContainer>
   );
 }

--- a/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
+++ b/frontend/src/containers/pages/ManageGroups/ManageGroupsPage.jsx
@@ -9,6 +9,7 @@ import {
 } from "react-router-dom";
 import ScreenContainer from "components/ScreenContainer";
 import TopBar from "./TopBar";
+import GroupsTable from "./GroupTable";
 
 /**
  * Page that shows the groups that the admin can manipulate
@@ -35,16 +36,15 @@ export default function ManageGroupsPage() {
     console.log("downloading current group config as .CSV");
   }
 
-
   return (
     <ScreenContainer vertical>
-      <TopBar back = {`/scenario/${scenarioId}`}>
+      <TopBar back={`/scenario/${scenarioId}`}>
         <input
-            type="file"
-            ref={fileInputRef}
-            accept=".csv"
-            style={{ display: "none" }}
-            onChange={handleFileUpload}
+          type="file"
+          ref={fileInputRef}
+          accept=".csv"
+          style={{ display: "none" }}
+          onChange={handleFileUpload}
         />
         <Button
           className="btn top contained white"
@@ -63,6 +63,8 @@ export default function ManageGroupsPage() {
           Download
         </Button>
       </TopBar>
+
+      <GroupsTable />
 
       {/* On top of the action button available in the top menu bar, we also override user's rightclick context menu to offer the same functionality. */}
       {/* <div onContextMenu={handleContextMenu}>

--- a/frontend/src/containers/pages/ManageGroups/TopBar.jsx
+++ b/frontend/src/containers/pages/ManageGroups/TopBar.jsx
@@ -1,0 +1,66 @@
+import Button from "@material-ui/core/Button";
+import { Link, useHistory } from "react-router-dom";
+
+import styles from "../../../styling/TopBar.module.scss";
+
+/**
+ * Component used for navigation and executing actions located at the top of the screen.
+ *
+ * @component
+ * @example
+ * const back = "/"
+ * const confirmModel = true
+ * return (
+ *   <TopBar back={back} confirmModel={confirmModel}>
+ *     { ... }
+ *   </TopBar>
+ * )
+ */
+export default function TopBar({
+  back = "/",
+  children = [],
+  confirmModal = false,
+}) {
+  const history = useHistory();
+
+  /**
+   * Function for changing variables to their appropriate states when the back button is pressed.
+   */
+  function handleLeaveAuthoringTool() {
+    history.push("/");
+  }
+
+  return (
+    <>
+      <div className={styles.topBar}>
+        <ul className={styles.leftTopBarList}>
+          <li className={styles.listItem}>
+            {confirmModal ? (
+              <Button
+                className="btn top outlined white"
+                color="default"
+                variant="outlined"
+                onClick={handleLeaveAuthoringTool}
+              >
+                Back
+              </Button>
+            ) : (
+              <Button
+                className="btn top outlined white"
+                color="default"
+                variant="outlined"
+                component={Link}
+                to={back}
+              >
+                Back
+              </Button>
+            )}
+          </li>
+        </ul>
+        <ul className={styles.rightTopBarList}>
+          <li className={styles.listItem}>{children}</li>
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/containers/pages/SceneSelectionPage.jsx
+++ b/frontend/src/containers/pages/SceneSelectionPage.jsx
@@ -149,14 +149,13 @@ export function SceneSelectionPage({ data = null }) {
   function playScenario() {
     window.open(`/play/${scenarioId}`, "_blank");
   }
-  
+
   /** called when Groups button is clicked */
   function manageGroups() {
     console.log(url, scenarioId);
     history.push({
       pathname: `${url}/manage-groups`,
     });
-
   }
 
   /** called when user unfocuses from a scene name */

--- a/frontend/src/containers/pages/SceneSelectionPage.jsx
+++ b/frontend/src/containers/pages/SceneSelectionPage.jsx
@@ -10,7 +10,6 @@ import {
   useRouteMatch,
 } from "react-router-dom";
 import ContextMenu from "../../components/ContextMenu";
-import DeleteButton from "../../components/DeleteButton";
 import HelpButton from "../../components/HelpButton";
 import ScreenContainer from "../../components/ScreenContainer";
 import ShareModal from "../../components/ShareModal";
@@ -150,6 +149,15 @@ export function SceneSelectionPage({ data = null }) {
   function playScenario() {
     window.open(`/play/${scenarioId}`, "_blank");
   }
+  
+  /** called when Groups button is clicked */
+  function manageGroups() {
+    console.log(url, scenarioId);
+    history.push({
+      pathname: `${url}/manage-groups`,
+    });
+
+  }
 
   /** called when user unfocuses from a scene name */
   async function changeSceneName({ target }) {
@@ -184,37 +192,6 @@ export function SceneSelectionPage({ data = null }) {
   return (
     <ScreenContainer vertical>
       <TopBar>
-        <DeleteButton
-          className={`btn top contained ${currentScene ? "" : "disabled"}  `}
-          color="default"
-          variant="contained"
-          disabled={!currentScene}
-          onClick={deleteScene}
-        >
-          Delete
-        </DeleteButton>
-        <Button
-          className={`btn top contained white ${
-            currentScene ? "" : "disabled"
-          }  `}
-          color="default"
-          variant="contained"
-          disabled={!currentScene}
-          onClick={editScene}
-        >
-          Edit
-        </Button>
-        <Button
-          className={`btn top contained white ${
-            currentScene ? "" : "disabled"
-          }  `}
-          color="default"
-          variant="contained"
-          disabled={!currentScene}
-          onClick={duplicateScene}
-        >
-          Duplicate
-        </Button>
         {VpsUser.role === AccessLevel.STAFF ? (
           <Button
             className="btn top contained white"
@@ -227,6 +204,14 @@ export function SceneSelectionPage({ data = null }) {
         ) : (
           ""
         )}
+        <Button
+          className="btn top contained white"
+          color="default"
+          variant="contained"
+          onClick={manageGroups}
+        >
+          Groups
+        </Button>
         <Button
           className="btn top contained white"
           color="default"


### PR DESCRIPTION
## Describe the issue

We need a page accessible from the scene selection page, where users can view and manage the groups that will be using the scenario. 

## Describe the solution

Created a folder called `ManageGroups` located at `frontend/src/containers/pages/ManageGroups` contains the files to the page where you can view and manage the groups. Added a button in the scene selection pages topbar as well that takes us to the ManageGroups page.

## Risk

Since it is a new page there shouldn't be any problems that arise with other areas because of this code as of yet.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
