### PR TITLE
Vps 157/track-group-path

### DIFF
--- a/backend/src/db/daos/groupDao.js
+++ b/backend/src/db/daos/groupDao.js
@@ -1,0 +1,31 @@
+import Group from '../models/group';
+
+const getGroup = async (groupId) => {
+    return await Group.findById(groupId);
+}
+
+const getCurrentScene = async (groupId) => {
+    //
+}
+
+const addSceneToPath = async (groupId, sceneId) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
+  try {
+    const group = await Group.findById(groupId).session(session);
+    if (!group) {
+      throw new Error('Group not found');
+    }
+    group.scenes.push(sceneId);
+    await group.save({ session });
+    await session.commitTransaction();
+  } catch (error) {
+    // if another transaction has been commited, abort 
+    await session.abortTransaction();
+    throw error;
+  } finally {
+    session.endSession();
+  }
+};
+
+export { getGroup, getCurrentScene, addSceneToPath };

--- a/backend/src/db/daos/groupDao.js
+++ b/backend/src/db/daos/groupDao.js
@@ -6,19 +6,24 @@ const getGroup = async (groupId) => {
 }
 
 const getCurrentScene = async (groupId) => {
+  try {
     const group = await Group.findById(groupId);
-    if(!group) {
-      throw new Error('Group not Found');
+    if (!group) {
+      throw new Error('Group not found');
     }
-    const currentSceneId = group.currentScene;
-    if(!currentSceneId) {
-      throw new Error('Current Scene not set for this group');
+    const path = group.path;
+    if (!path || path.length === 0) {
+      throw new Error('Path not set for this group');
     }
+    const currentSceneId = path[path.length - 1];
     const currentScene = await Scene.findById(currentSceneId);
-    if(!currentScene) {
+    if (!currentScene) {
       throw new Error('Current scene not found');
     }
     return currentScene;
+  } catch(error) {
+    throw error;
+  }
 };
 
 const addSceneToPath = async (groupId, sceneId) => {

--- a/backend/src/db/daos/groupDao.js
+++ b/backend/src/db/daos/groupDao.js
@@ -1,12 +1,25 @@
 import Group from '../models/group';
+import Scene from '../models/scene';
 
 const getGroup = async (groupId) => {
     return await Group.findById(groupId);
 }
 
 const getCurrentScene = async (groupId) => {
-    //
-}
+    const group = await Group.findById(groupId);
+    if(!group) {
+      throw new Error('Group not Found');
+    }
+    const currentSceneId = group.currentScene;
+    if(!currentSceneId) {
+      throw new Error('Current Scene not set for this group');
+    }
+    const currentScene = await Scene.findById(currentSceneId);
+    if(!currentScene) {
+      throw new Error('Current scene not found');
+    }
+    return currentScene;
+};
 
 const addSceneToPath = async (groupId, sceneId) => {
   const session = await mongoose.startSession();

--- a/backend/src/db/daos/groupDao.js
+++ b/backend/src/db/daos/groupDao.js
@@ -1,16 +1,17 @@
-import Group from '../models/group';
-import Scene from '../models/scene';
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
+
+import Group from "../models/group";
+import Scene from "../models/scene";
 
 const getGroup = async (groupId) => {
-    return await Group.findById(groupId);
-}
+  return Group.findById(groupId);
+};
 
 const getCurrentScene = async (groupId) => {
-    const group = await Group.findById(groupId);
-    const path = group.path;
-    if (!path.length) return null;
-    return await Scene.findById(path[path.length - 1]);
+  const group = await Group.findById(groupId);
+  const { path } = group;
+  if (!path.length) return null;
+  return Scene.findById(path[path.length - 1]);
 };
 
 const addSceneToPath = async (groupId, sceneId) => {
@@ -22,7 +23,7 @@ const addSceneToPath = async (groupId, sceneId) => {
     await group.save({ session });
     await session.commitTransaction();
   } catch (error) {
-    // if another transaction is happening, abort 
+    // if another transaction is happening, abort
     await session.abortTransaction();
     throw error;
   } finally {

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -1,0 +1,30 @@
+import { Router } from "express";
+
+import { addSceneToPath, getCurrentScene } from "../../db/daos/groupDao";
+
+const router = Router();
+
+const HTTP_OK = 200;
+const HTTP_CONFLICT = 409
+
+// add a scene to the group's shared path
+router.post("/path/:groupId", async (req, res) => {
+  const { currentSceneId, nextSceneId } = req.body;
+  // in case someone's still behind the current scene
+  if (!currentSceneId === getCurrentScene()._id) {
+    return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
+  }
+  try {
+    await addSceneToPath(req.params.groupId, nextSceneId);
+    return res.status(HTTP_OK).json("Scene added to path");
+  } catch (error) {
+    return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
+  }
+});
+
+// get the current scene of the group
+router.get("/path/:groupId", async (req, res) => {
+    //
+});
+
+export default router;

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -24,7 +24,13 @@ router.post("/path/:groupId", async (req, res) => {
 
 // get the current scene of the group
 router.get("/path/:groupId", async (req, res) => {
-    //
+    try {
+      const groupId = req.params.groupId;
+      const currentScene = await getCurrentScene(groupId);
+      return res.status(HTTP_OK).json(currentScene);
+    } catch(error) {
+      return res.status(HTTP_CONFLICT).json({ error: 'Error getting current scene' });
+    }
 });
 
 export default router;

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -6,16 +6,20 @@ const router = Router();
 
 const HTTP_OK = 200;
 const HTTP_CONFLICT = 409
+const HTTP_NOT_FOUND = 404;
 
 // add a scene to the group's shared path
 router.post("/path/:groupId", async (req, res) => {
   const { currentSceneId, nextSceneId } = req.body;
+  const groupId = req.params.groupId;
+
   // in case someone's still behind the current scene
-  if (!currentSceneId === getCurrentScene()._id) {
+  const storedCurrScene = await getCurrentScene(groupId);
+  if (storedCurrScene !== null && currentSceneId !== storedCurrScene._id.toString()) {
     return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
   }
   try {
-    await addSceneToPath(req.params.groupId, nextSceneId);
+    await addSceneToPath(groupId, nextSceneId);
     return res.status(HTTP_OK).json("Scene added to path");
   } catch (error) {
     return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
@@ -29,7 +33,7 @@ router.get("/path/:groupId", async (req, res) => {
       const currentScene = await getCurrentScene(groupId);
       return res.status(HTTP_OK).json(currentScene);
     } catch(error) {
-      return res.status(HTTP_CONFLICT).json({ error: 'Error getting current scene' });
+      return res.status(HTTP_NOT_FOUND).json({ error: error.message });
     }
 });
 

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -5,36 +5,44 @@ import { addSceneToPath, getCurrentScene } from "../../db/daos/groupDao";
 const router = Router();
 
 const HTTP_OK = 200;
-const HTTP_CONFLICT = 409
+const HTTP_CONFLICT = 409;
 const HTTP_NOT_FOUND = 404;
 
 // add a scene to the group's shared path
 router.post("/path/:groupId", async (req, res) => {
   const { currentSceneId, nextSceneId } = req.body;
-  const groupId = req.params.groupId;
+  const { groupId } = req.params;
 
   // in case someone's still behind the current scene
   const storedCurrScene = await getCurrentScene(groupId);
-  if (storedCurrScene !== null && currentSceneId !== storedCurrScene._id.toString()) {
-    return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
+  if (
+    storedCurrScene !== null &&
+    // eslint-disable-next-line no-underscore-dangle
+    currentSceneId !== storedCurrScene._id.toString()
+  ) {
+    return res
+      .status(HTTP_CONFLICT)
+      .json({ error: "Scene mismatch b/w client and server" });
   }
   try {
     await addSceneToPath(groupId, nextSceneId);
     return res.status(HTTP_OK).json("Scene added to path");
   } catch (error) {
-    return res.status(HTTP_CONFLICT).json({ error: 'Scene mismatch b/w client and server' });
+    return res
+      .status(HTTP_CONFLICT)
+      .json({ error: "Scene mismatch b/w client and server" });
   }
 });
 
 // get the current scene of the group
 router.get("/path/:groupId", async (req, res) => {
-    try {
-      const groupId = req.params.groupId;
-      const currentScene = await getCurrentScene(groupId);
-      return res.status(HTTP_OK).json(currentScene);
-    } catch(error) {
-      return res.status(HTTP_NOT_FOUND).json({ error: error.message });
-    }
+  try {
+    const { groupId } = req.params;
+    const currentScene = await getCurrentScene(groupId);
+    return res.status(HTTP_OK).json(currentScene);
+  } catch (error) {
+    return res.status(HTTP_NOT_FOUND).json({ error: error.message });
+  }
 });
 
 export default router;

--- a/backend/src/routes/api/index.js
+++ b/backend/src/routes/api/index.js
@@ -4,6 +4,7 @@ import scenario from "./scenario";
 import image from "./image";
 import staff from "./staff";
 import user from "./user";
+import group from "./group";
 
 const router = Router();
 
@@ -11,5 +12,6 @@ router.use("/scenario", scenario);
 router.use("/image", image);
 router.use("/staff", staff);
 router.use("/user", user);
+router.use("/group", group);
 
 export default router;


### PR DESCRIPTION
## Describe the issue

We need to track the path of a group within a scenario, so that when users open the scenario they are given the correct current scene that their group has reached.

## Describe the solution

Created a new API endpoint at `/group/path` with both a post and get request, the first of which adds a scene to the path and the second of which retrieves the most recent scene of that path. To make sure users don't overwrite each other, added simple checking and race condition handling using transactions.

## Risk

Could introduce conflicts with branch [VPS-154/csv-to-groups](https://github.com/UoaWDCC/VPS/tree/VPS-154/csv-to-groups) that will need to be resolved.

## Definition of Done

- [x] Code peer-reviewed
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [x] Continuous Integration build passing
- [x] Acceptance criteria met
- [x] Deployed to production environment

## Reviewed By

Jordan, Jin
