### PR TITLE
Vps 174/single scenario last scene

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -26,6 +26,7 @@
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
     "no-unused-vars": "warn",
-    "func-names": "off"
+    "func-names": "off",
+    "no-underscore-dangle": "off"
   }
 }

--- a/backend/src/db/daos/groupDao.js
+++ b/backend/src/db/daos/groupDao.js
@@ -8,19 +8,20 @@ const getGroup = async (groupId) => {
 };
 
 const getCurrentScene = async (groupId) => {
-  const group = await Group.findById(groupId);
-  const { path } = group;
+  const { path } = await Group.findById(groupId, "path");
   if (!path.length) return null;
-  return Scene.findById(path[path.length - 1]);
+  return Scene.findById(path[0]);
 };
 
 const addSceneToPath = async (groupId, sceneId) => {
   const session = await mongoose.startSession();
   session.startTransaction();
   try {
-    const group = await Group.findById(groupId).session(session);
-    group.path.push(sceneId);
-    await group.save({ session });
+    await Group.findByIdAndUpdate(
+      groupId,
+      { $push: { path: { $each: [sceneId], $position: 0 } } },
+      { session }
+    );
     await session.commitTransaction();
   } catch (error) {
     // if another transaction is happening, abort

--- a/backend/src/db/daos/userDao.js
+++ b/backend/src/db/daos/userDao.js
@@ -140,6 +140,11 @@ const retrieveAssignedScenarioList = async (userId) => {
   return retrieveScenarios(user.assigned);
 };
 
+const fetchScene = async (email, scenarioId) => {
+  const user = await User.findOne({ email }, { [`paths.${scenarioId}`]: 1 });
+  return (user && user.paths && user.paths.get(scenarioId)[0]) || null;
+};
+
 export {
   retrieveAllUser,
   createUser,
@@ -150,4 +155,5 @@ export {
   retrievePlayedUsers,
   assignScenarioToUsers,
   retrieveAssignedScenarioList,
+  fetchScene,
 };

--- a/backend/src/db/models/user.js
+++ b/backend/src/db/models/user.js
@@ -29,6 +29,11 @@ const userSchema = new Schema({
       type: String,
     },
   ],
+  // Map of scenarioId to path (sceneIds)
+  paths: {
+    type: Map,
+    of: [String],
+  },
 });
 
 const User = mongoose.model("model", userSchema, "users");

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -1,10 +1,6 @@
 import { Router } from "express";
 
-import {
-  addSceneToPath,
-  getCurrentScene,
-  createGroup,
-} from "../../db/daos/groupDao";
+import { addSceneToPath, createGroup } from "../../db/daos/groupDao";
 import { updateRoleList } from "../../db/daos/scenarioDao";
 import Group from "../../db/models/group";
 
@@ -12,7 +8,6 @@ const router = Router();
 
 const HTTP_OK = 200;
 const HTTP_CONFLICT = 409;
-const HTTP_NOT_FOUND = 404;
 const HTTP_NO_CONTENT = 204;
 
 // add a scene to the group's shared path
@@ -20,35 +15,13 @@ router.post("/path/:groupId", async (req, res) => {
   const { currentSceneId, nextSceneId } = req.body;
   const { groupId } = req.params;
 
-  // in case someone's still behind the current scene
-  const storedCurrScene = await getCurrentScene(groupId);
-  if (
-    storedCurrScene !== null &&
-    // eslint-disable-next-line no-underscore-dangle
-    currentSceneId !== storedCurrScene._id.toString()
-  ) {
-    return res
-      .status(HTTP_CONFLICT)
-      .json({ error: "Scene mismatch b/w client and server" });
-  }
   try {
-    await addSceneToPath(groupId, nextSceneId);
+    await addSceneToPath(groupId, currentSceneId, nextSceneId);
     return res.status(HTTP_OK).json("Scene added to path");
   } catch (error) {
     return res
       .status(HTTP_CONFLICT)
       .json({ error: "Scene mismatch b/w client and server" });
-  }
-});
-
-// get the current scene of the group
-router.get("/path/:groupId", async (req, res) => {
-  try {
-    const { groupId } = req.params;
-    const currentScene = await getCurrentScene(groupId);
-    return res.status(HTTP_OK).json(currentScene);
-  } catch (error) {
-    return res.status(HTTP_NOT_FOUND).json({ error: error.message });
   }
 });
 

--- a/backend/src/routes/api/user.js
+++ b/backend/src/routes/api/user.js
@@ -8,6 +8,7 @@ import {
   addPlayed,
   retrievePlayedUsers,
   assignScenarioToUsers,
+  fetchScene,
 } from "../../db/daos/userDao";
 import User from "../../db/models/user";
 import Group from "../../db/models/group";
@@ -86,19 +87,34 @@ router.put("/:uid", async (req, res) => {
   }
 });
 
-router.get("/:email/:scenarioId/group", async (req, res) => {
-  const groups = await Group.find({ scenarioId: req.params.scenarioId });
-  if (!groups.length) return res.json({ group: null });
+// fetch all the data needed for a scenario upfront
+// return format: { group: Group | null, current: SceneId | null }
+router.get("/:email/:scenarioId/data", async (req, res) => {
+  const { email, scenarioId } = req.params;
+  // TODO: filter to only what we need
+  const group = await Group.findOne({ scenarioId, "users.email": email });
 
-  const group = await groups.find((g) =>
-    g.users.find((u) => u.email === req.params.email)
+  const current = group
+    ? group.path[group.path.length - 1]
+    : await fetchScene(email, scenarioId);
+
+  return res.status(HTTP_OK).json({ group, current });
+});
+
+router.post("/:uid/:scenarioId/path", async (req, res) => {
+  const { nextSceneId } = req.body;
+  const { uid, scenarioId } = req.params;
+
+  await User.findOneAndUpdate(
+    { uid },
+    {
+      $push: {
+        [`paths.${scenarioId}`]: { $each: [nextSceneId], $position: 0 },
+      },
+    }
   );
-  if (!group) return res.json({ group: null });
 
-  return res.json({
-    group,
-    current: group.path[group.path.length - 1],
-  });
+  res.sendStatus(HTTP_OK);
 });
 
 export default router;

--- a/backend/src/routes/api/user.js
+++ b/backend/src/routes/api/user.js
@@ -91,13 +91,14 @@ router.put("/:uid", async (req, res) => {
 // return format: { group: Group | null, current: SceneId | null }
 router.get("/:email/:scenarioId/data", async (req, res) => {
   const { email, scenarioId } = req.params;
-  // TODO: filter to only what we need
+  // TODO: filter to only what we need (depends on role info required etc.)
   const group = await Group.findOne({ scenarioId, "users.email": email });
   const current = group ? group.path[0] : await fetchScene(email, scenarioId);
 
   return res.status(HTTP_OK).json({ group, current });
 });
 
+// add a scene to the user's path
 router.post("/:uid/:scenarioId/path", async (req, res) => {
   const { nextSceneId } = req.body;
   const { uid, scenarioId } = req.params;

--- a/backend/src/routes/api/user.js
+++ b/backend/src/routes/api/user.js
@@ -93,10 +93,7 @@ router.get("/:email/:scenarioId/data", async (req, res) => {
   const { email, scenarioId } = req.params;
   // TODO: filter to only what we need
   const group = await Group.findOne({ scenarioId, "users.email": email });
-
-  const current = group
-    ? group.path[group.path.length - 1]
-    : await fetchScene(email, scenarioId);
+  const current = group ? group.path[0] : await fetchScene(email, scenarioId);
 
   return res.status(HTTP_OK).json({ group, current });
 });

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import AuthenticationContext from "context/AuthenticationContext";
-import { usePut } from "hooks/crudHooks";
+import { usePost, usePut } from "hooks/crudHooks";
 import LoadingPage from "../LoadingPage";
 import ScenarioPreloader from "./Components/ScenarioPreloader";
 import PlayScenarioCanvas from "./PlayScenarioCanvas";
@@ -31,6 +31,7 @@ export default function PlayScenarioPage({ graph }) {
         usePut(`/api/scenario/${scenarioId}/scene/visited/${id}`, {}, token);
       });
     }
+    usePost(`/api/user/${user.uid}/${scenarioId}/path`, { nextSceneId }, token);
     history.replace(`/play/${scenarioId}/${nextSceneId}`);
   };
 

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioResolver.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioResolver.jsx
@@ -41,7 +41,7 @@ export default function PlayScenarioResolver() {
   useEffect(async () => {
     if (!(graph && (isMain || (isMulti && !group)))) return;
 
-    const res = await get(`/api/user/${user.email}/${scenarioId}/group`, token);
+    const res = await get(`/api/user/${user.email}/${scenarioId}/data`, token);
     const sceneId = res?.data?.current || graph.getScenes()[0]._id;
     const scenarioPath = res?.data?.group
       ? `${scenarioId}/multiplayer`


### PR DESCRIPTION
## Describe the issue

A user's last visited scene doesn't save, so they cant play through a scenario across different times or across different devices.

## Describe the solution

- Add a new field on the user db schema that stores the path for multiple scenarios
- Add a route for updating this path as the user moves across scenes
- Change the user/scenario/data route to give the current scene for users as well as groups 

## Risk

Shouldn't bring any risks, as the existing route is only used in one place which has been updated accordingly.

## Definition of Done

- [x] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [x] Unit tests written and passing
- [x] Integration tests written and passing
- [x] Continuous Integration build passing
- [x] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
