### PR TITLE
VPS-165/roles for scenes UI

### DIFF
--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -7,7 +7,7 @@ import {
   getGroupByScenarioId,
 } from "../../db/daos/groupDao";
 
-import { updateRoleList } from "../../db/daos/scenarioDao";
+import { retrieveRoleList, updateRoleList } from "../../db/daos/scenarioDao";
 import Group from "../../db/models/group";
 
 const router = Router();
@@ -107,6 +107,14 @@ router.post("/:scenarioId", async (req, res) => {
   await Promise.all(promises);
 
   res.status(HTTP_OK).json(output);
+});
+
+router.get("/:scenarioId/roleList", async (req, res) => {
+  const { scenarioId } = req.params;
+
+  const roleList = await retrieveRoleList(scenarioId);
+
+  res.status(HTTP_OK).json(roleList);
 });
 
 export default router;

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/CustomPropertyInputStyles/CustomCheckBoxStyles.js
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/CustomPropertyInputStyles/CustomCheckBoxStyles.js
@@ -9,6 +9,8 @@ export default function CustomCheckBoxStyles() {
       "&.Mui-checked": {
         color: "#0080a7",
       },
+      paddingLeft: "0.75em",
+      paddingRight: "0.75em",
     },
   });
 }

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -6,6 +6,7 @@ import {
   Select,
   Checkbox,
   MenuItem,
+  Typography,
 } from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
 import { withStyles } from "@material-ui/core/styles";
@@ -42,11 +43,8 @@ export default function SceneSettings() {
   const { roleList } = useContext(ScenarioContext);
 
   // TODO: Fetch actual selected roles from the backend
-  const [selectedRoles, setSelectedRoles] = useState([
-    "Doctor",
-    "Nurse",
-    "Pharmacist",
-  ]);
+  const initialSelectedRoles = roleList ? [...roleList] : [];
+  const [selectedRoles, setSelectedRoles] = useState(initialSelectedRoles);
 
   const initialCheckedState = roleList?.map((role) =>
     selectedRoles?.includes(role)
@@ -135,6 +133,9 @@ export default function SceneSettings() {
             <CustomInputLabel>Scene Role(s)</CustomInputLabel>
             <Select
               className={styles.selectInput}
+              MenuProps={{
+                getContentAnchorEl: null,
+              }}
               value={selectedRoles}
               onChange={(event) => setSelectedRoles(event.target.value)}
               renderValue={(selected) =>
@@ -169,10 +170,10 @@ export default function SceneSettings() {
                   ))}
                 </div>
               ) : (
-                <MenuItem>
+                <Typography className={styles.menuItem}>
                   This scenario currently does not accommodate roles. Please
                   upload a CSV file first under Manage Groups.
-                </MenuItem>
+                </Typography>
               )}
             </Select>
           </FormControl>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -1,11 +1,21 @@
-import { InputAdornment } from "@material-ui/core";
+import {
+  InputLabel,
+  InputAdornment,
+  FormControl,
+  FormControlLabel,
+  Select,
+  Checkbox,
+  Box,
+} from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
 import { withStyles } from "@material-ui/core/styles";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import SceneContext from "../../../../context/SceneContext";
 
 import styles from "../../../../styling/CanvasSideBar.module.scss";
+import CustomInputLabelStyles from "./CustomPropertyInputStyles/CustomInputLabelStyles";
 
+const CustomInputLabel = CustomInputLabelStyles()(InputLabel);
 const CustomTextField = withStyles({
   root: {
     marginTop: "0.5em",
@@ -26,6 +36,25 @@ const CustomTextField = withStyles({
  */
 export default function SceneSettings() {
   const { currentScene, setCurrentScene } = useContext(SceneContext);
+  const [checked, setChecked] = useState([true, true, true]);
+  const [allChecked, setAllChecked] = useState([true]);
+
+  const handleCheckboxChange = (index) => {
+    const newChecked = [...checked];
+    newChecked[index] = !checked[index];
+    setChecked(newChecked);
+
+    const isAllChecked = newChecked.every((isChecked) => isChecked);
+    setAllChecked(isAllChecked);
+  };
+
+  const handleAllToggle = () => {
+    const newAllChecked = !allChecked;
+    setAllChecked(newAllChecked);
+
+    const newChecked = allChecked ? [false, false, false] : [true, true, true];
+    setChecked(newChecked);
+  };
 
   return (
     <>
@@ -70,6 +99,53 @@ export default function SceneSettings() {
               shrink: !!currentScene?.time,
             }}
           />
+          <FormControl fullWidth>
+            <CustomInputLabel>Scene Role(s)</CustomInputLabel>
+            <Select className={styles.selectInput}>
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      defaultChecked
+                      checked={allChecked}
+                      onChange={handleAllToggle}
+                    />
+                  }
+                  label="All"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      defaultChecked
+                      checked={checked[0]}
+                      onChange={() => handleCheckboxChange(0)}
+                    />
+                  }
+                  label="Doctor"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      defaultChecked
+                      checked={checked[1]}
+                      onChange={() => handleCheckboxChange(1)}
+                    />
+                  }
+                  label="Nurse"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      defaultChecked
+                      checked={checked[2]}
+                      onChange={() => handleCheckboxChange(2)}
+                    />
+                  }
+                  label="Pharmacist"
+                />
+              </div>
+            </Select>
+          </FormControl>
         </div>
       </div>
     </>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -42,10 +42,14 @@ export default function SceneSettings() {
   const { roleList } = useContext(ScenarioContext);
 
   // TODO: Fetch actual selected roles from the backend
-  const selectedRoles = ["Doctor", "Pharmacist", "Nurse"];
+  const [selectedRoles, setSelectedRoles] = useState([
+    "Doctor",
+    "Nurse",
+    "Pharmacist",
+  ]);
 
   const initialCheckedState = roleList?.map((role) =>
-    selectedRoles.includes(role)
+    selectedRoles?.includes(role)
   );
   const initialAllCheckedState = initialCheckedState.every(
     (checked) => checked
@@ -61,6 +65,14 @@ export default function SceneSettings() {
 
     const isAllChecked = newChecked.every((isChecked) => isChecked);
     setAllChecked(isAllChecked);
+
+    const updatedSelectedRoles = newChecked.reduce((acc, isChecked, idx) => {
+      if (isChecked) {
+        acc.push(roleList[idx]);
+      }
+      return acc;
+    }, []);
+    setSelectedRoles(updatedSelectedRoles);
   };
 
   const handleAllToggle = () => {
@@ -71,6 +83,9 @@ export default function SceneSettings() {
       ? new Array(roleList.length).fill(true)
       : new Array(roleList.length).fill(false);
     setChecked(newChecked);
+
+    const newSelectedRoles = newAllChecked ? roleList : [];
+    setSelectedRoles(newSelectedRoles);
   };
 
   return (
@@ -118,7 +133,16 @@ export default function SceneSettings() {
           />
           <FormControl fullWidth>
             <CustomInputLabel>Scene Role(s)</CustomInputLabel>
-            <Select className={styles.selectInput}>
+            <Select
+              className={styles.selectInput}
+              value={selectedRoles}
+              onChange={(event) => setSelectedRoles(event.target.value)}
+              renderValue={(selected) =>
+                selected.length === roleList.length
+                  ? "All"
+                  : selected.join(", ")
+              }
+            >
               {roleList && roleList.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column" }}>
                   <FormControlLabel

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -42,7 +42,7 @@ export default function SceneSettings() {
   const { roleList } = useContext(ScenarioContext);
 
   const initialSelectedRoles = roleList ? [...roleList] : [];
-  const [selectedRoles, setSelectedRoles] = useState(initialSelectedRoles); // TODO: Retrieve selected roles from the backend
+  const [selectedRoles, setSelectedRoles] = useState(initialSelectedRoles);
 
   const initialCheckedState = roleList?.map((role) =>
     selectedRoles?.includes(role)
@@ -117,13 +117,11 @@ export default function SceneSettings() {
               });
             }}
             InputProps={{
-              // seconds adornment appears when there is input
               endAdornment: (
                 <InputAdornment position="end">seconds</InputAdornment>
               ),
             }}
             InputLabelProps={{
-              // label moves up whenever there is input
               shrink: true,
             }}
           />

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -5,7 +5,6 @@ import {
   FormControlLabel,
   Select,
   Checkbox,
-  MenuItem,
   Typography,
 } from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
@@ -49,7 +48,7 @@ export default function SceneSettings() {
   const initialCheckedState = roleList?.map((role) =>
     selectedRoles?.includes(role)
   );
-  const initialAllCheckedState = initialCheckedState.every(
+  const initialAllCheckedState = initialCheckedState?.every(
     (checked) => checked
   );
 

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -42,11 +42,17 @@ export default function SceneSettings() {
   const { roleList } = useContext(ScenarioContext);
 
   // TODO: Fetch actual selected roles from the backend
-  const selectedRoles = ["Doctor", "Pharmacist"];
-  const [checked, setChecked] = useState(
-    roleList.map((role) => selectedRoles.includes(role))
+  const selectedRoles = ["Doctor", "Pharmacist", "Nurse"];
+
+  const initialCheckedState = roleList?.map((role) =>
+    selectedRoles.includes(role)
   );
-  const [allChecked, setAllChecked] = useState([true]);
+  const initialAllCheckedState = initialCheckedState.every(
+    (checked) => checked
+  );
+
+  const [checked, setChecked] = useState(initialCheckedState);
+  const [allChecked, setAllChecked] = useState(initialAllCheckedState);
 
   const handleCheckboxChange = (index) => {
     const newChecked = [...checked];

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -41,9 +41,8 @@ export default function SceneSettings() {
   const { currentScene, setCurrentScene } = useContext(SceneContext);
   const { roleList } = useContext(ScenarioContext);
 
-  // TODO: Fetch actual selected roles from the backend
   const initialSelectedRoles = roleList ? [...roleList] : [];
-  const [selectedRoles, setSelectedRoles] = useState(initialSelectedRoles);
+  const [selectedRoles, setSelectedRoles] = useState(initialSelectedRoles); // TODO: Retrieve selected roles from the backend
 
   const initialCheckedState = roleList?.map((role) =>
     selectedRoles?.includes(role)
@@ -106,7 +105,7 @@ export default function SceneSettings() {
           <CustomTextField
             label="Scene Timer Duration"
             type="number"
-            value={currentScene?.time || ""}
+            value={currentScene?.time ?? 0}
             fullWidth
             onChange={(event) => {
               // limiting scene timer duration
@@ -119,22 +118,23 @@ export default function SceneSettings() {
             }}
             InputProps={{
               // seconds adornment appears when there is input
-              endAdornment: currentScene?.time ? (
+              endAdornment: (
                 <InputAdornment position="end">seconds</InputAdornment>
-              ) : null,
+              ),
             }}
             InputLabelProps={{
               // label moves up whenever there is input
-              shrink: !!currentScene?.time,
+              shrink: true,
             }}
           />
-          <FormControl fullWidth>
+          <FormControl fullWidth className={styles.formControl}>
             <CustomInputLabel>Scene Role(s)</CustomInputLabel>
             <Select
               className={styles.selectInput}
               MenuProps={{
                 getContentAnchorEl: null,
               }}
+              multiple
               value={selectedRoles}
               onChange={(event) => setSelectedRoles(event.target.value)}
               renderValue={(selected) =>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/SceneSettings.jsx
@@ -5,17 +5,20 @@ import {
   FormControlLabel,
   Select,
   Checkbox,
-  Box,
+  MenuItem,
 } from "@material-ui/core";
 import TextField from "@material-ui/core/TextField";
 import { withStyles } from "@material-ui/core/styles";
 import { useContext, useState } from "react";
+import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "../../../../context/SceneContext";
 
 import styles from "../../../../styling/CanvasSideBar.module.scss";
 import CustomInputLabelStyles from "./CustomPropertyInputStyles/CustomInputLabelStyles";
+import CustomCheckBoxStyles from "./CustomPropertyInputStyles/CustomCheckBoxStyles";
 
 const CustomInputLabel = CustomInputLabelStyles()(InputLabel);
+const CustomCheckBox = CustomCheckBoxStyles()(Checkbox);
 const CustomTextField = withStyles({
   root: {
     marginTop: "0.5em",
@@ -36,7 +39,13 @@ const CustomTextField = withStyles({
  */
 export default function SceneSettings() {
   const { currentScene, setCurrentScene } = useContext(SceneContext);
-  const [checked, setChecked] = useState([true, true, true]);
+  const { roleList } = useContext(ScenarioContext);
+
+  // TODO: Fetch actual selected roles from the backend
+  const selectedRoles = ["Doctor", "Pharmacist"];
+  const [checked, setChecked] = useState(
+    roleList.map((role) => selectedRoles.includes(role))
+  );
   const [allChecked, setAllChecked] = useState([true]);
 
   const handleCheckboxChange = (index) => {
@@ -52,7 +61,9 @@ export default function SceneSettings() {
     const newAllChecked = !allChecked;
     setAllChecked(newAllChecked);
 
-    const newChecked = allChecked ? [false, false, false] : [true, true, true];
+    const newChecked = newAllChecked
+      ? new Array(roleList.length).fill(true)
+      : new Array(roleList.length).fill(false);
     setChecked(newChecked);
   };
 
@@ -102,48 +113,37 @@ export default function SceneSettings() {
           <FormControl fullWidth>
             <CustomInputLabel>Scene Role(s)</CustomInputLabel>
             <Select className={styles.selectInput}>
-              <div style={{ display: "flex", flexDirection: "column" }}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      defaultChecked
-                      checked={allChecked}
-                      onChange={handleAllToggle}
+              {roleList && roleList.length > 0 ? (
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                  <FormControlLabel
+                    control={
+                      <CustomCheckBox
+                        defaultChecked
+                        checked={allChecked}
+                        onChange={handleAllToggle}
+                      />
+                    }
+                    label="All"
+                  />
+                  {roleList.map((role, index) => (
+                    <FormControlLabel
+                      control={
+                        <CustomCheckBox
+                          defaultChecked
+                          checked={checked[index]}
+                          onChange={() => handleCheckboxChange(index)}
+                        />
+                      }
+                      label={role}
                     />
-                  }
-                  label="All"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      defaultChecked
-                      checked={checked[0]}
-                      onChange={() => handleCheckboxChange(0)}
-                    />
-                  }
-                  label="Doctor"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      defaultChecked
-                      checked={checked[1]}
-                      onChange={() => handleCheckboxChange(1)}
-                    />
-                  }
-                  label="Nurse"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      defaultChecked
-                      checked={checked[2]}
-                      onChange={() => handleCheckboxChange(2)}
-                    />
-                  }
-                  label="Pharmacist"
-                />
-              </div>
+                  ))}
+                </div>
+              ) : (
+                <MenuItem>
+                  This scenario currently does not accommodate roles. Please
+                  upload a CSV file first under Manage Groups.
+                </MenuItem>
+              )}
             </Select>
           </FormControl>
         </div>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
@@ -70,6 +70,58 @@ exports[`Scenario Selection page snapshot test 1`] = `
           />
         </div>
       </div>
+      <div
+        className="MuiFormControl-root MuiFormControl-fullWidth"
+      >
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 MuiInputLabel-formControl MuiInputLabel-animated"
+          data-shrink={false}
+        >
+          Scene Role(s)
+        </label>
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <div
+            aria-haspopup="listbox"
+            className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&#8203;",
+                }
+              }
+            />
+          </div>
+          <input
+            aria-hidden={true}
+            className="MuiSelect-nativeInput"
+            onAnimationStart={[Function]}
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            value=""
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/CanvasSideBar.test.js.snap
@@ -46,19 +46,19 @@ exports[`Scenario Selection page snapshot test 1`] = `
         className="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-          data-shrink={false}
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink={true}
         >
           Scene Timer Duration
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
           onClick={[Function]}
         >
           <input
             aria-invalid={false}
             autoFocus={false}
-            className="MuiInputBase-input MuiInput-input"
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
             disabled={false}
             onAnimationStart={[Function]}
             onBlur={[Function]}
@@ -66,12 +66,21 @@ exports[`Scenario Selection page snapshot test 1`] = `
             onFocus={[Function]}
             required={false}
             type="number"
-            value=""
+            value={0}
           />
+          <div
+            className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+            >
+              seconds
+            </p>
+          </div>
         </div>
       </div>
       <div
-        className="MuiFormControl-root MuiFormControl-fullWidth"
+        className="MuiFormControl-root formControl MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 MuiInputLabel-formControl MuiInputLabel-animated"

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
@@ -43,19 +43,19 @@ exports[`Scenario Selection page snapshot test 1`] = `
       className="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
     >
       <label
-        className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-        data-shrink={false}
+        className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+        data-shrink={true}
       >
         Scene Timer Duration
       </label>
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
         onClick={[Function]}
       >
         <input
           aria-invalid={false}
           autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
+          className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
           disabled={false}
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -63,12 +63,21 @@ exports[`Scenario Selection page snapshot test 1`] = `
           onFocus={[Function]}
           required={false}
           type="number"
-          value=""
+          value={0}
         />
+        <div
+          className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+        >
+          <p
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+          >
+            seconds
+          </p>
+        </div>
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiFormControl-fullWidth"
+      className="MuiFormControl-root formControl MuiFormControl-fullWidth"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 MuiInputLabel-formControl MuiInputLabel-animated"

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/__tests__/__snapshots__/SceneSettings.test.js.snap
@@ -67,6 +67,58 @@ exports[`Scenario Selection page snapshot test 1`] = `
         />
       </div>
     </div>
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <label
+        className="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 MuiInputLabel-formControl MuiInputLabel-animated"
+        data-shrink={false}
+      >
+        Scene Role(s)
+      </label>
+      <div
+        className="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
+        onClick={[Function]}
+      >
+        <div
+          aria-haspopup="listbox"
+          className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "&#8203;",
+              }
+            }
+          />
+        </div>
+        <input
+          aria-hidden={true}
+          className="MuiSelect-nativeInput"
+          onAnimationStart={[Function]}
+          onChange={[Function]}
+          required={false}
+          tabIndex={-1}
+          value=""
+        />
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
@@ -452,24 +452,33 @@ exports[`Authoring Tool page snapshot test 1`] = `
                 class="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-2 MuiFormControl-fullWidth"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-                  data-shrink="false"
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                  data-shrink="true"
                 >
                   Scene Timer Duration
                 </label>
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
                 >
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input"
+                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
                     type="number"
-                    value=""
+                    value="0"
                   />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
+                    >
+                      seconds
+                    </p>
+                  </div>
                 </div>
               </div>
               <div
-                class="MuiFormControl-root MuiFormControl-fullWidth"
+                class="MuiFormControl-root formControl MuiFormControl-fullWidth"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-3 MuiInputLabel-formControl MuiInputLabel-animated"

--- a/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
@@ -468,6 +468,46 @@ exports[`Authoring Tool page snapshot test 1`] = `
                   />
                 </div>
               </div>
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-3 MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink="false"
+                >
+                  Scene Role(s)
+                </label>
+                <div
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    tabindex="-1"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                </div>
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/context/ScenarioContextProvider.jsx
+++ b/frontend/src/context/ScenarioContextProvider.jsx
@@ -23,8 +23,8 @@ export default function ScenarioContextProvider({ children }) {
   );
 
   const { reFetch: reFetch3 } = useGet(
-    `api/group/${currentScenario._id}/roleList`,
-    setRoleList
+    currentScenario ? `api/group/${currentScenario._id}/roleList` : null,
+    currentScenario ? setRoleList : () => {}
   );
 
   return (

--- a/frontend/src/context/ScenarioContextProvider.jsx
+++ b/frontend/src/context/ScenarioContextProvider.jsx
@@ -14,11 +14,17 @@ export default function ScenarioContextProvider({ children }) {
   );
   const [scenarios, setScenarios] = useState();
   const [assignedScenarios, setAssignedScenarios] = useState();
+  const [roleList, setRoleList] = useState();
 
   const { reFetch } = useGet(`api/scenario`, setScenarios);
   const { reFetch: reFetch2 } = useGet(
     `api/scenario/assigned`,
     setAssignedScenarios
+  );
+
+  const { reFetch: reFetch3 } = useGet(
+    `api/group/${currentScenario._id}/roleList`,
+    setRoleList
   );
 
   return (
@@ -30,8 +36,10 @@ export default function ScenarioContextProvider({ children }) {
         assignedScenarios,
         setAssignedScenarios,
         reFetch2,
+        reFetch3,
         currentScenario,
         setCurrentScenario,
+        roleList,
       }}
     >
       {children}

--- a/frontend/src/styling/CanvasSideBar.module.scss
+++ b/frontend/src/styling/CanvasSideBar.module.scss
@@ -73,5 +73,12 @@
 }
 
 .menuItem {
-  width: calc(18.5vw - 2em) !important;
+  width: calc(18.5vw - 4em) !important;
+  padding-left: 0.5em;
+  padding-right: 1em;
+}
+
+.formControl {
+  margin-top: 0.5em !important;
+  margin-bottom: 1em !important;
 }

--- a/frontend/src/styling/CanvasSideBar.module.scss
+++ b/frontend/src/styling/CanvasSideBar.module.scss
@@ -71,3 +71,7 @@
   font-size: 12px;
   opacity: 0.6;
 }
+
+.menuItem {
+  width: calc(18.5vw - 2em) !important;
+}


### PR DESCRIPTION
## Describe the issue

Need to implement a UI to select roles for a scenario which takes in roles that have been given.

## Describe the solution

**Backend**

- Created a backend API endpoint at `api/group/scenario/:scenarioId/roleList` which gets the role list for a specific scenario.

**Frontend**

- Created a frontend request that retrieves the role list from `api/group/scenario/:scenarioId/roleList` and gives it in the scenario context provider.

_Usage of API endpoint_
![image](https://github.com/UoaWDCC/VPS/assets/161205868/ae10d49e-790f-42e3-9db6-f7b327223398)
_Usage of role list context_
![image](https://github.com/UoaWDCC/VPS/assets/161205868/b77b8d8b-b42f-4934-b39f-94239ac67868)

- In the scene settings, there is a `Select` dropdown with checkboxes for every role which allows users to select what roles can participate in the scene. The roles that are selected are displayed. If no roles are available, the user is prompted with a message.
 
_Checkbox  example_
![image](https://github.com/UoaWDCC/VPS/assets/161205868/ba8d73a5-bc28-41b3-b771-bf9c7a126145)
_Select Display example_
![image](https://github.com/UoaWDCC/VPS/assets/161205868/b36a0461-5c81-4a97-95b4-6bbad7e165c7)
_No Roles Message example_
![image](https://github.com/UoaWDCC/VPS/assets/161205868/0b1d1f6c-2d14-49a0-afd0-071f7b2166ed)

## Risk

May have merge conflicts. 
Implemented new frontend which shouldn't cause risk elsewhere.
SceneSettings is the only thing using the new backend endpoint so shouldn't cause problems elsewhere.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
