### PR TITLE
chore: disable compile errors on prettier error.

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -15,7 +15,7 @@
   },
   "rules": {
     "prettier/prettier": [
-      "error",
+      "warn",
       {
         "endOfLine": "auto"
       }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -36,7 +36,7 @@
     "jest/no-identical-title": "error",
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
-    "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "prettier/prettier": ["warn", { "endOfLine": "auto" }],
     "no-unused-vars": "warn",
     "no-underscore-dangle": "off"
   },


### PR DESCRIPTION
This PR aims to disable compile errors on Prettier errors.

The reasoning being that refusing to compile on prettier errors only serves to slow down dev.

