### PR TITLE
Vps 17/user reset button

### DIFF
--- a/backend/src/routes/api/navigate/index.js
+++ b/backend/src/routes/api/navigate/index.js
@@ -2,18 +2,34 @@ import { Router } from "express";
 import auth from "../../../middleware/firebaseAuth";
 
 import handle from "../../../error/handle";
-import groupNavigate from "./group";
-import userNavigate from "./user";
+import { groupNavigate, groupReset } from "./group";
+import { userNavigate, userReset } from "./user";
 
 const router = Router();
 
 router.use(auth);
 
 router.post(
+  "/group/reset/:groupId",
+  handle(async (req, res) => {
+    const response = await groupReset(req);
+    return res.status(response.status);
+  })
+);
+
+router.post(
   "/group/:groupId",
   handle(async (req, res) => {
     const response = await groupNavigate(req);
     return res.status(response.status).json(response.json);
+  })
+);
+
+router.post(
+  "/user/reset/:scenarioId",
+  handle(async (req, res) => {
+    const response = await userReset(req);
+    return res.status(response.status);
   })
 );
 

--- a/backend/src/routes/api/navigate/index.js
+++ b/backend/src/routes/api/navigate/index.js
@@ -13,7 +13,7 @@ router.post(
   "/group/reset/:groupId",
   handle(async (req, res) => {
     const response = await groupReset(req);
-    return res.status(response.status);
+    return res.status(response.status).send();
   })
 );
 
@@ -29,7 +29,7 @@ router.post(
   "/user/reset/:scenarioId",
   handle(async (req, res) => {
     const response = await userReset(req);
-    return res.status(response.status);
+    return res.status(response.status).send();
   })
 );
 

--- a/backend/src/routes/api/navigate/user.js
+++ b/backend/src/routes/api/navigate/user.js
@@ -95,7 +95,7 @@ export const userReset = async (req) => {
 
   await User.findOneAndUpdate(
     { _id: user._id },
-    { $set: { [`paths.${scenarioId}`]: [] } }
+    { $unset: { [`paths.${scenarioId}`]: "" } }
   );
 
   return { status: STATUS.OK };

--- a/frontend/src/containers/pages/AuthoringTool/Canvas/componentResolver.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/Canvas/componentResolver.jsx
@@ -26,6 +26,15 @@ export default function componentResolver(component, index, onClick) {
           component={component}
         />
       );
+    case "RESET_BUTTON":
+      return (
+        <ButtonComponent
+          key={component.id}
+          id={index}
+          onClick={onClick}
+          component={component}
+        />
+      );
     case "SPEECHTEXT":
       return (
         <SpeechTextComponent

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
@@ -7,6 +7,8 @@ import { v4 } from "uuid";
 function addComponent(component, currentScene, setCurrentScene) {
   const updatedComponents = currentScene.components;
 
+  console.log(component);
+
   updatedComponents.push(component);
 
   setCurrentScene({
@@ -34,6 +36,27 @@ function addButton(currentScene, setCurrentScene) {
   };
 
   addComponent(newButton, currentScene, setCurrentScene);
+}
+
+/**
+ * function to be put into ToolBarData when button is added
+ */
+function addResetButton(currentScene, setCurrentScene) {
+  const newResetButton = {
+    type: "RESET_BUTTON",
+    text: "Reset",
+    variant: "contained",
+    colour: "red",
+    nextScene: "",
+    left: 0, // as percentage
+    top: 0, // as percentage
+    height: 6, // as percentage
+    width: 20, // as percentage
+    id: v4(),
+    zPosition: 0,
+  };
+
+  addComponent(newResetButton, currentScene, setCurrentScene);
 }
 
 /**
@@ -144,6 +167,7 @@ function addFirebaseAudio(currentScene, setCurrentScene, fileObject, url) {
 
 export {
   addButton,
+  addResetButton,
   addFirebaseAudio,
   addFirebaseImage,
   addImage,

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarData.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarData.jsx
@@ -6,7 +6,12 @@ import VolumeUpIcon from "@material-ui/icons/VolumeUp";
 import UploadAudio from "./Audio/UploadAudio";
 import ChooseBackgroundSubMenu from "./Background/ChooseBackgroundSubMenu";
 import UploadImage from "./Background/UploadImage";
-import { addButton, addSpeechText, addText } from "./ToolBarActions";
+import {
+  addButton,
+  addResetButton,
+  addSpeechText,
+  addText,
+} from "./ToolBarActions";
 
 /**
  * This file contains the data for the add component icons to be added into the ToolBar
@@ -33,6 +38,11 @@ const toolBarData = [
     title: "Button",
     icon: <ButtonIcon fontSize="medium" />,
     onClick: addButton,
+  },
+  {
+    title: "Reset",
+    icon: <ButtonIcon fontSize="medium" />,
+    onClick: addResetButton,
   },
   {
     title: "Audio",

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/__tests__/__snapshots__/ToolBar.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/__tests__/__snapshots__/ToolBar.test.js.snap
@@ -179,6 +179,52 @@ exports[`ToolBar component snapshot test 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex={0}
+        title="Reset"
+        type="button"
+      >
+        <span
+          className="MuiButton-label"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+            />
+          </svg>
+           
+          <p>
+            Add 
+            Reset
+          </p>
+        </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div>
+      <button
+        aria-describedby={null}
+        className="MuiButtonBase-root MuiButton-root MuiButton-text menuItem"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
         title="Audio"
         type="button"
       >

--- a/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/__tests__/__snapshots__/AuthoringToolPage.test.js.snap
@@ -241,6 +241,37 @@ exports[`Authoring Tool page snapshot test 1`] = `
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-text menuItem"
               tabindex="0"
+              title="Reset"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                  />
+                </svg>
+                 
+                <p>
+                  Add 
+                  Reset
+                </p>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text menuItem"
+              tabindex="0"
               title="Audio"
               type="button"
             >

--- a/frontend/src/containers/pages/DesyncPage.jsx
+++ b/frontend/src/containers/pages/DesyncPage.jsx
@@ -1,12 +1,11 @@
 import { Grid, Typography, Button } from "@material-ui/core";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 export default function DesyncPage() {
-  const { scenarioId } = useParams();
   const history = useHistory();
 
   const onBack = () => {
-    history.push(`/play/${scenarioId}`);
+    history.go(0);
   };
 
   return (

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
@@ -1,8 +1,3 @@
-import { usePost } from "hooks/crudHooks";
-import { useContext } from "react";
-import { useParams } from "react-router-dom";
-import AuthenticationContext from "../../../context/AuthenticationContext";
-
 import CountdownTimer from "../../../components/TimerComponent";
 import componentResolver from "./componentResolver";
 
@@ -12,29 +7,14 @@ import componentResolver from "./componentResolver";
  * @component
  */
 
-export default function PlayScenarioCanvas({ scene, incrementor }) {
-  const { sceneId } = useParams();
-  const { user, getUserIdToken } = useContext(AuthenticationContext);
-
-  // Define the reset function inside the component
-  const reset = async () => {
-    const userId = user.uid;
-    const reqBody = { userId, currentScene: sceneId };
-    console.log("resetting");
-
-    await usePost(`api/navigate/group/reset/:groupId`, reqBody, getUserIdToken);
-    await usePost(`api/navigate/user/reset/:scenarioId`, reqBody, getUserIdToken);
-
-    console.log("reset");
-    // window.location.reload();
-  };
-
+export default function PlayScenarioCanvas({ scene, incrementor, reset }) {
   return (
     <>
       {scene.components?.map((component, index) => {
-        const action = component.type === "RESET_BUTTON"
-          ? reset
-          : () => component.nextScene && incrementor(component.nextScene);
+        const action =
+          component.type === "RESET_BUTTON"
+            ? reset
+            : () => component.nextScene && incrementor(component.nextScene);
 
         return componentResolver(component, index, action);
       })}

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
@@ -1,3 +1,8 @@
+import { usePost } from "hooks/crudHooks";
+import { useContext } from "react";
+import { useParams } from "react-router-dom";
+import AuthenticationContext from "../../../context/AuthenticationContext";
+
 import CountdownTimer from "../../../components/TimerComponent";
 import componentResolver from "./componentResolver";
 
@@ -6,16 +11,33 @@ import componentResolver from "./componentResolver";
  *
  * @component
  */
+
 export default function PlayScenarioCanvas({ scene, incrementor }) {
+  const { sceneId } = useParams();
+  const { user, getUserIdToken } = useContext(AuthenticationContext);
+
+  // Define the reset function inside the component
+  const reset = async () => {
+    const userId = user.uid;
+    const reqBody = { userId, currentScene: sceneId };
+    console.log("resetting");
+
+    await usePost(`api/navigate/group/reset/:groupId`, reqBody, getUserIdToken);
+    await usePost(`api/navigate/user/reset/:scenarioId`, reqBody, getUserIdToken);
+
+    console.log("reset");
+    // window.location.reload();
+  };
+
   return (
     <>
-      {scene.components?.map((component, index) =>
-        componentResolver(
-          component,
-          index,
-          () => component.nextScene && incrementor(component.nextScene)
-        )
-      )}
+      {scene.components?.map((component, index) => {
+        const action = component.type === "RESET_BUTTON"
+          ? reset
+          : () => component.nextScene && incrementor(component.nextScene);
+
+        return componentResolver(component, index, action);
+      })}
       {scene.time && (
         <CountdownTimer
           targetDate={new Date().setSeconds(

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
@@ -2,7 +2,9 @@ import { useContext, useState, useEffect } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import AuthenticationContext from "context/AuthenticationContext";
 import axios from "axios";
+import { usePost } from "hooks/crudHooks";
 import LoadingPage from "../LoadingPage";
+
 // import ScenarioPreloader from "./Components/ScenarioPreloader";
 import PlayScenarioCanvas from "./PlayScenarioCanvas";
 import useStyles from "./playScenarioPage.styles";
@@ -32,7 +34,12 @@ const navigate = async (user, scenarioId, currentScene, nextScene) => {
  * @container
  */
 export default function PlayScenarioPage() {
-  const { user, loading, error: authError } = useContext(AuthenticationContext);
+  const {
+    user,
+    loading,
+    error: authError,
+    getUserIdToken,
+  } = useContext(AuthenticationContext);
 
   const { scenarioId, sceneId } = useParams();
   const history = useHistory();
@@ -67,6 +74,21 @@ export default function PlayScenarioPage() {
 
   console.log(currScene);
 
+  const reset = async () => {
+    const userId = user.uid;
+    const reqBody = { userId, currentScene: sceneId };
+    console.log("resetting");
+
+    await usePost(
+      `api/navigate/user/reset/${scenarioId}`,
+      reqBody,
+      getUserIdToken
+    );
+
+    console.log("reset");
+    window.location.reload();
+  };
+
   const incrementor = (id) => {
     setPrevious(sceneId);
     history.push(`/play/${scenarioId}/singleplayer/${id}`);
@@ -76,7 +98,11 @@ export default function PlayScenarioPage() {
     <>
       <div className={styles.canvasContainer}>
         <div className={styles.canvas}>
-          <PlayScenarioCanvas scene={currScene} incrementor={incrementor} />
+          <PlayScenarioCanvas
+            scene={currScene}
+            incrementor={incrementor}
+            reset={reset}
+          />
         </div>
       </div>
       {/* {window.location === window.parent.location && (

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useEffect } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import AuthenticationContext from "context/AuthenticationContext";
+import { usePost } from "hooks/crudHooks";
 import axios from "axios";
 import LoadingPage from "../LoadingPage";
 import NotesDisplayCard from "../../../components/NotesDisplayCard";
@@ -34,7 +35,12 @@ const navigate = async (user, groupId, currentScene, nextScene) => {
  * @container
  */
 export default function PlayScenarioPageMulti({ group }) {
-  const { user, loading, error: authError } = useContext(AuthenticationContext);
+  const {
+    user,
+    loading,
+    error: authError,
+    getUserIdToken,
+  } = useContext(AuthenticationContext);
 
   const { scenarioId, sceneId } = useParams();
   const history = useHistory();
@@ -80,6 +86,21 @@ export default function PlayScenarioPageMulti({ group }) {
     );
   }
 
+  const reset = async () => {
+    const userId = user.uid;
+    const reqBody = { userId, currentScene: sceneId };
+    console.log("resetting");
+
+    await usePost(
+      `api/navigate/group/reset/${group._id}`,
+      reqBody,
+      getUserIdToken
+    );
+
+    console.log("reset");
+    window.location.reload();
+  };
+
   const incrementor = (id) => {
     setPrevious(sceneId);
     history.push(`/play/${scenarioId}/multiplayer/${id}`);
@@ -89,7 +110,11 @@ export default function PlayScenarioPageMulti({ group }) {
     <>
       <div className={styles.canvasContainer}>
         <div className={styles.canvas}>
-          <PlayScenarioCanvas scene={currScene} incrementor={incrementor} />
+          <PlayScenarioCanvas
+            scene={currScene}
+            incrementor={incrementor}
+            reset={reset}
+          />
         </div>
       </div>
       {/* {window.location === window.parent.location && (

--- a/frontend/src/containers/pages/PlayScenarioPage/componentResolver.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/componentResolver.jsx
@@ -26,15 +26,15 @@ export default function componentResolver(component, index, onClick) {
           component={component}
         />
       );
-      case "RESET_BUTTON":
-        return (
-          <ButtonComponent
-            key={component.id}
-            id={index}
-            onClick={onClick}
-            component={component}
-          />
-        );
+    case "RESET_BUTTON":
+      return (
+        <ButtonComponent
+          key={component.id}
+          id={index}
+          onClick={onClick}
+          component={component}
+        />
+      );
     case "SPEECHTEXT":
     case "TEXT":
       return (

--- a/frontend/src/containers/pages/PlayScenarioPage/componentResolver.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/componentResolver.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable no-param-reassign */
-
-// Shared components from authoring canvas
 import ButtonComponent from "../AuthoringTool/Components/ButtonComponent";
 import FirebaseImageComponent from "../AuthoringTool/Components/FirebaseImageComponent";
 import ImageComponent from "../AuthoringTool/Components/ImageComponent";
@@ -29,6 +26,15 @@ export default function componentResolver(component, index, onClick) {
           component={component}
         />
       );
+      case "RESET_BUTTON":
+        return (
+          <ButtonComponent
+            key={component.id}
+            id={index}
+            onClick={onClick}
+            component={component}
+          />
+        );
     case "SPEECHTEXT":
     case "TEXT":
       return (


### PR DESCRIPTION
## Describe the issue

There isn't a way for users to reset their progress in scenarios

## Describe the solution

### Backend
Created two new endpoints `/navigate/user/reset` and `/navigate/group/reset` for singleplayer and multiplayer mode respectively. These endpoints perform some validation, the same as the other navigate endpoints plus a check for whether the scene actually has a reset button, and then set the pointers back to empty (as if the scenarios haven't been accessed yet).

### Frontend
Added the ability to add a reset button the authoring tool:
![reset button](https://github.com/user-attachments/assets/8b202d57-f8e1-403d-8f76-99e6a07bd902)


## Risk

May risk breaking playing the scenarios

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
