### PR TITLE
Vps 24/adding flags to groups

### DIFF
--- a/backend/src/db/models/group.js
+++ b/backend/src/db/models/group.js
@@ -16,6 +16,7 @@ const groupSchema = new Schema({
   scenarioId: {
     type: String,
   },
+  currentFlags: [String],
 });
 
 const Group = mongoose.model("Group", groupSchema, "groups");

--- a/backend/src/db/models/resource.js
+++ b/backend/src/db/models/resource.js
@@ -13,7 +13,7 @@ const resourceSchema = new Schema({
   imageContent: {
     type: String,
   },
-  required_flags: [String],
+  requiredFlags: [String],
 });
 
 const Resource = mongoose.model("Resource", resourceSchema, "resources");

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -71,13 +71,15 @@ router.post("/:scenarioId", async (req, res) => {
 
       const role = user.role.toLowerCase();
       if (roles.includes(role)) {
-        res.status(HTTP_CONFLICT).send("Conflict");
+        res
+          .status(HTTP_CONFLICT)
+          .send("Conflict - Duplicate roles in the same group!");
       }
       roles.push(role);
     });
 
     if (roles.length !== roleList.length) {
-      res.status(HTTP_CONFLICT).send("Conflict");
+      res.status(HTTP_CONFLICT).send("Conflict - Different number of roles!");
     }
   });
 


### PR DESCRIPTION
## Describe the issue

There was no way of checking the current active flags of a group.

## Describe the solution

Added a property called `currentFlags` to the group schema so that each group can keep track of their currently active flags.

## Risk

Minimal risk as no code depends on the `currentFlags` property and the property is not required.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
