### PR TITLE
Vps 39/reset confirmation modal

### DIFF
--- a/frontend/src/components/ResetConfirmationModal.jsx
+++ b/frontend/src/components/ResetConfirmationModal.jsx
@@ -12,7 +12,10 @@ import { withStyles } from "@material-ui/core/styles";
 export default function ResetConfirmationModal({ isOpen, onClose, onConfirm }) {
   const DialogActions = withStyles(() => ({
     root: {
-      justifyContent: "space-between",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center", // Center the text and buttons horizontally
+      gap: "16px",
     },
   }))(MuiDialogActions);
 
@@ -28,7 +31,6 @@ export default function ResetConfirmationModal({ isOpen, onClose, onConfirm }) {
       <DialogActions>
         <Button
           className="btn contained red"
-          autoFocus
           color="primary"
           onClick={onConfirm}
         >
@@ -36,7 +38,6 @@ export default function ResetConfirmationModal({ isOpen, onClose, onConfirm }) {
         </Button>
         <Button
           className="btn contained white"
-          autoFocus
           color="primary"
           onClick={onClose}
         >

--- a/frontend/src/components/ResetConfirmationModal.jsx
+++ b/frontend/src/components/ResetConfirmationModal.jsx
@@ -1,0 +1,48 @@
+import { DialogContent, DialogTitle } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import MuiDialogActions from "@material-ui/core/DialogActions";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+
+/**
+ * This component shows a confirmation modal when the user attempts to reset the scenario.
+ * @component
+ */
+export default function ResetConfirmationModal({ isOpen, onClose, onConfirm }) {
+  const DialogActions = withStyles(() => ({
+    root: {
+      justifyContent: "space-between",
+    },
+  }))(MuiDialogActions);
+
+  return (
+    <Dialog onClose={onClose} open={isOpen} maxWidth="xs">
+      <DialogTitle>Confirm Reset</DialogTitle>
+      <DialogContent>
+        <Typography>
+          This will reset your whole group’s progress to the beginning. You will
+          have to notify your group members to re-play through the scenario.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          className="btn contained red"
+          autoFocus
+          color="primary"
+          onClick={onConfirm}
+        >
+          Reset Scenario
+        </Button>
+        <Button
+          className="btn contained white"
+          autoFocus
+          color="primary"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioCanvas.jsx
@@ -1,3 +1,5 @@
+import ResetConfirmationModal from "components/ResetConfirmationModal";
+import { useState } from "react";
 import CountdownTimer from "../../../components/TimerComponent";
 import componentResolver from "./componentResolver";
 
@@ -8,12 +10,26 @@ import componentResolver from "./componentResolver";
  */
 
 export default function PlayScenarioCanvas({ scene, incrementor, reset }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleResetClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleConfirmReset = () => {
+    setIsModalOpen(false);
+    reset();
+  };
+
+  const handleCancelReset = () => {
+    setIsModalOpen(false);
+  };
   return (
     <>
       {scene.components?.map((component, index) => {
         const action =
           component.type === "RESET_BUTTON"
-            ? reset
+            ? handleResetClick
             : () => component.nextScene && incrementor(component.nextScene);
 
         return componentResolver(component, index, action);
@@ -26,6 +42,11 @@ export default function PlayScenarioCanvas({ scene, incrementor, reset }) {
           sceneTime={scene.time}
         />
       )}
+      <ResetConfirmationModal
+        isOpen={isModalOpen}
+        onConfirm={handleConfirmReset}
+        onClose={handleCancelReset}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Describe the issue

The reset button currently allows players to reset the scenario without confirmation, risking accidental resets that affect the whole team.

## Describe the solution

Add a confirmation modal that appears when a player clicks the "Reset" button. The modal informs the player that if you click reset, the entire scenario will restart from the beginning, and all team members will need to go through the scenario again.

The two buttons would be:
- Reset Scenario: Resets the scenario as intended.
- Cancel: Closes the modal with no further action.

<img width="392" alt="resetConfirmationModal" src="https://github.com/user-attachments/assets/45411537-d00f-4474-b52d-32ff91d8e13a">

## Risk

There would still be a slight risk that players could mistakenly confirm the reset.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
