### PR TITLE
Vps 32/UI button for flags

### DIFF
--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -40,19 +40,28 @@ export default function ButtonPropertiesComponent({
   };
 
   const handleAddFlag = () => {
-    if (Object.keys(component.flagList).includes(`add ${newFlag}`)) {
+    if (!component.flagAdditions) {
+      updateComponentProperty(componentIndex, "flagAdditions", {});
+    }
+    if (!component.flagDeletions) {
+      updateComponentProperty(componentIndex, "flagDeletions", {});
+    }
+
+    if (Object.keys(component.flagAdditions).includes(`${newFlag}`)) {
       setOpen(true);
       return;
     }
 
     if (newFlag.trim() !== "") {
-      const newFlagList = {
-        ...component.flagList,
-        [`add ${newFlag}`]: false,
-        [`remove ${newFlag}`]: false,
-      };
       setNewFlag("");
-      updateComponentProperty(componentIndex, "flagList", newFlagList);
+      updateComponentProperty(componentIndex, "flagAdditions", {
+        ...component.flagAdditions,
+        [newFlag]: false,
+      });
+      updateComponentProperty(componentIndex, "flagDeletions", {
+        ...component.flagDeletions,
+        [newFlag]: false,
+      });
     }
   };
 
@@ -60,17 +69,18 @@ export default function ButtonPropertiesComponent({
     setOpen(false);
   };
 
-  const handleCheckboxChange = (flag) => {
-    const newFlagList = {
-      ...component.flagList,
-      [`${flag}`]: !component.flagList[flag],
-    };
-    updateComponentProperty(componentIndex, "flagList", newFlagList);
-
-    // TODO:
-    // Need to implement the functionality when
-    // a checkbox is checked, the labelled flag should be
-    // added to the groups active flag list
+  const handleCheckboxChange = (flag, adding) => {
+    if (adding) {
+      updateComponentProperty(componentIndex, "flagAdditions", {
+        ...component.flagAdditions,
+        [flag]: !component.flagAdditions[flag],
+      });
+    } else {
+      updateComponentProperty(componentIndex, "flagDeletions", {
+        ...component.flagDeletions,
+        [flag]: !component.flagDeletions[flag],
+      });
+    }
   };
 
   return (
@@ -155,29 +165,80 @@ export default function ButtonPropertiesComponent({
           />
           <Button onClick={handleAddFlag}>Add</Button>
         </div>
+      </FormControl>
 
+      <FormControl fullWidth className={styles.componentProperty}>
+        <CustomInputLabel shrink className={styles.plusLabel}>
+          Select flags to be added
+        </CustomInputLabel>
         <Select
-          style={{ marginTop: "10px" }}
           multiple
           className={styles.selectInput}
-          value={Object.keys(component.flagList || {})}
+          value={Object.keys(component.flagAdditions || {})}
+          // renderValue={(selected) =>
+          //   selected.filter((flag) => component.flagAdditions[flag]).length > 0
+          //     ? selected.filter((flag) => component.flagAdditions[flag]).join(", ")
+          //     : "Select flags to be added"
+          // }
           renderValue={(selected) =>
-            selected.filter((flag) => component.flagList[flag]).join(", ")
+            selected.filter((flag) => component.flagAdditions[flag]).join(", ")
           }
           displayEmpty
         >
-          {Object.keys(component.flagList || {}).length > 0 ? (
+          {Object.keys(component.flagAdditions || {}).length > 0 ? (
             <div style={{ display: "flex", flexDirection: "column" }}>
-              {Object.keys(component.flagList).map((flag) => (
+              {Object.keys(component.flagAdditions).map((flag) => (
                 <FormControlLabel
                   key={flag}
                   control={
                     <CustomCheckBox
-                      checked={component.flagList[flag]}
-                      onChange={() => handleCheckboxChange(flag)}
+                      checked={component.flagAdditions[flag]}
+                      onChange={() => handleCheckboxChange(flag, true)}
                     />
                   }
-                  label={flag}
+                  label={<span className={styles.plusLabel}>{flag}</span>}
+                />
+              ))}
+            </div>
+          ) : (
+            <Typography className={styles.menuItem}>
+              This button property currently does not have any flags. Please add
+              flags first using the text field above.
+            </Typography>
+          )}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth className={styles.componentProperty}>
+        <CustomInputLabel shrink className={styles.minusLabel}>
+          Select flags to be removed
+        </CustomInputLabel>
+        <Select
+          // style={{ marginTop: "10px" }}
+          multiple
+          className={styles.selectInput}
+          value={Object.keys(component.flagDeletions || {})}
+          // renderValue={(selected) =>
+          //   selected.filter((flag) => component.flagDeletions[flag]).length > 0
+          //     ? selected.filter((flag) => component.flagDeletions[flag]).join(", ")
+          //     : "Select flags to be removed"
+          // }
+          renderValue={(selected) =>
+            selected.filter((flag) => component.flagDeletions[flag]).join(", ")
+          }
+          displayEmpty
+        >
+          {Object.keys(component.flagDeletions || {}).length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {Object.keys(component.flagDeletions).map((flag) => (
+                <FormControlLabel
+                  key={flag}
+                  control={
+                    <CustomCheckBox
+                      checked={component.flagDeletions[flag]}
+                      onChange={() => handleCheckboxChange(flag, false)}
+                    />
+                  }
+                  label={<span className={styles.minusLabel}>{flag}</span>}
                 />
               ))}
             </div>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -52,7 +52,7 @@ export default function ButtonPropertiesComponent({
       return;
     }
 
-    if (newFlag.trim() !== "") {
+    if (newFlag.trim().length !== 0) {
       setNewFlag("");
       updateComponentProperty(componentIndex, "flagAdditions", {
         ...component.flagAdditions,
@@ -175,11 +175,6 @@ export default function ButtonPropertiesComponent({
           multiple
           className={styles.selectInput}
           value={Object.keys(component.flagAdditions || {})}
-          // renderValue={(selected) =>
-          //   selected.filter((flag) => component.flagAdditions[flag]).length > 0
-          //     ? selected.filter((flag) => component.flagAdditions[flag]).join(", ")
-          //     : "Select flags to be added"
-          // }
           renderValue={(selected) =>
             selected.filter((flag) => component.flagAdditions[flag]).join(", ")
           }
@@ -213,15 +208,9 @@ export default function ButtonPropertiesComponent({
           Select flags to be removed
         </CustomInputLabel>
         <Select
-          // style={{ marginTop: "10px" }}
           multiple
           className={styles.selectInput}
           value={Object.keys(component.flagDeletions || {})}
-          // renderValue={(selected) =>
-          //   selected.filter((flag) => component.flagDeletions[flag]).length > 0
-          //     ? selected.filter((flag) => component.flagDeletions[flag]).join(", ")
-          //     : "Select flags to be removed"
-          // }
           renderValue={(selected) =>
             selected.filter((flag) => component.flagDeletions[flag]).join(", ")
           }

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -1,19 +1,24 @@
 import {
+  Button,
+  Checkbox,
   FormControl,
+  FormControlLabel,
   InputLabel,
   MenuItem,
   Select,
   TextField,
 } from "@material-ui/core";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import SceneContext from "../../../../../context/SceneContext";
 import CustomInputLabelStyles from "../CustomPropertyInputStyles/CustomInputLabelStyles";
 import CustomTextFieldStyles from "../CustomPropertyInputStyles/CustomTextFieldStyles";
+import CustomCheckBoxStyles from "../CustomPropertyInputStyles/CustomCheckBoxStyles";
 
 import styles from "../../../../../styling/CanvasSideBar.module.scss";
 
 const CustomTextField = CustomTextFieldStyles()(TextField);
 const CustomInputLabel = CustomInputLabelStyles()(InputLabel);
+const CustomCheckBox = CustomCheckBoxStyles()(Checkbox);
 
 /**
  * This component displays the properties in the sidebar for a button scene component.
@@ -24,6 +29,46 @@ export default function ButtonPropertiesComponent({
   componentIndex,
 }) {
   const { scenes, updateComponentProperty } = useContext(SceneContext);
+
+  const [newFlag, setNewFlag] = useState("New Flag");
+  const [flagList, setFlags] = useState(
+    () =>
+      component.flags || [
+        "add flag_1",
+        "remove flag_1",
+        "add flag_2",
+        "remove flag_2",
+      ]
+  );
+  const [checked, setChecked] = useState(
+    () => component.flagStates || [false, false, false, false]
+  );
+
+  const handleInputChange = (event) => {
+    setNewFlag(event.target.value);
+  };
+
+  const handleAddFlag = () => {
+    if (newFlag.trim() !== "") {
+      const newFlagList = [...flagList, `add ${newFlag}`, `remove ${newFlag}`];
+      setFlags(newFlagList);
+      setChecked([...checked, false, false]);
+      setNewFlag("");
+      updateComponentProperty(componentIndex, "flags", newFlagList);
+    }
+  };
+
+  const handleCheckboxChange = (index) => {
+    const newChecked = [...checked];
+    newChecked[index] = !checked[index];
+    setChecked(newChecked);
+    updateComponentProperty(componentIndex, "flagStates", newChecked);
+
+    // TODO:
+    // Need to implement the functionality when
+    // a checkbox is checked, the labelled flag should be
+    // added to the groups active flag list
+  };
 
   return (
     <>
@@ -96,6 +141,43 @@ export default function ButtonPropertiesComponent({
           })}
         </Select>
       </FormControl>
+
+      <FormControl fullWidth className={styles.componentProperty}>
+        <div style={{ display: "flex" }}>
+          <CustomTextField
+            label="New Flag"
+            value={newFlag}
+            fullWidth
+            onChange={handleInputChange}
+          />
+          <Button onClick={handleAddFlag}>Add</Button>
+        </div>
+
+        <Select
+          style={{ marginTop: "10px" }}
+          multiple
+          className={styles.selectInput}
+          value={flagList}
+          renderValue={(selected) => selected.join(", ")}
+          displayEmpty
+        >
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {flagList.map((flag, index) => (
+              <FormControlLabel
+                key={componentIndex + flag}
+                control={
+                  <CustomCheckBox
+                    checked={checked[index] || false}
+                    onChange={() => handleCheckboxChange(index)}
+                  />
+                }
+                label={flag}
+              />
+            ))}
+          </div>
+        </Select>
+      </FormControl>
+
       <FormControl fullWidth className={styles.componentProperty}>
         <CustomTextField
           label="Z Axis Position"

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -6,6 +6,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Snackbar,
   TextField,
   Typography,
 } from "@material-ui/core";
@@ -32,6 +33,7 @@ export default function ButtonPropertiesComponent({
   const { scenes, updateComponentProperty } = useContext(SceneContext);
 
   const [newFlag, setNewFlag] = useState("");
+  const [open, setOpen] = useState(false);
 
   const handleInputChange = (event) => {
     setNewFlag(event.target.value);
@@ -39,7 +41,7 @@ export default function ButtonPropertiesComponent({
 
   const handleAddFlag = () => {
     if (Object.keys(component.flagList).includes(`add ${newFlag}`)) {
-      alert("Flag already exists in the flag list.");
+      setOpen(true);
       return;
     }
 
@@ -52,6 +54,10 @@ export default function ButtonPropertiesComponent({
       setNewFlag("");
       updateComponentProperty(componentIndex, "flagList", newFlagList);
     }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
   };
 
   const handleCheckboxChange = (flag) => {
@@ -154,13 +160,13 @@ export default function ButtonPropertiesComponent({
           style={{ marginTop: "10px" }}
           multiple
           className={styles.selectInput}
-          value={Object.keys(component.flagList)}
+          value={Object.keys(component.flagList || {})}
           renderValue={(selected) =>
             selected.filter((flag) => component.flagList[flag]).join(", ")
           }
           displayEmpty
         >
-          {Object.keys(component.flagList).length > 0 ? (
+          {Object.keys(component.flagList || {}).length > 0 ? (
             <div style={{ display: "flex", flexDirection: "column" }}>
               {Object.keys(component.flagList).map((flag) => (
                 <FormControlLabel
@@ -182,6 +188,12 @@ export default function ButtonPropertiesComponent({
             </Typography>
           )}
         </Select>
+        <Snackbar
+          open={open}
+          autoHideDuration={3000}
+          onClose={handleClose}
+          message="Flag already exists"
+        />
       </FormControl>
 
       <FormControl fullWidth className={styles.componentProperty}>

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Select,
   TextField,
+  Typography,
 } from "@material-ui/core";
 import { useContext, useState } from "react";
 import SceneContext from "../../../../../context/SceneContext";
@@ -30,39 +31,35 @@ export default function ButtonPropertiesComponent({
 }) {
   const { scenes, updateComponentProperty } = useContext(SceneContext);
 
-  const [newFlag, setNewFlag] = useState("New Flag");
-  const [flagList, setFlags] = useState(
-    () =>
-      component.flags || [
-        "add flag_1",
-        "remove flag_1",
-        "add flag_2",
-        "remove flag_2",
-      ]
-  );
-  const [checked, setChecked] = useState(
-    () => component.flagStates || [false, false, false, false]
-  );
+  const [newFlag, setNewFlag] = useState("");
 
   const handleInputChange = (event) => {
     setNewFlag(event.target.value);
   };
 
   const handleAddFlag = () => {
+    if (Object.keys(component.flagList).includes(`add ${newFlag}`)) {
+      alert("Flag already exists in the flag list.");
+      return;
+    }
+
     if (newFlag.trim() !== "") {
-      const newFlagList = [...flagList, `add ${newFlag}`, `remove ${newFlag}`];
-      setFlags(newFlagList);
-      setChecked([...checked, false, false]);
+      const newFlagList = {
+        ...component.flagList,
+        [`add ${newFlag}`]: false,
+        [`remove ${newFlag}`]: false,
+      };
       setNewFlag("");
-      updateComponentProperty(componentIndex, "flags", newFlagList);
+      updateComponentProperty(componentIndex, "flagList", newFlagList);
     }
   };
 
-  const handleCheckboxChange = (index) => {
-    const newChecked = [...checked];
-    newChecked[index] = !checked[index];
-    setChecked(newChecked);
-    updateComponentProperty(componentIndex, "flagStates", newChecked);
+  const handleCheckboxChange = (flag) => {
+    const newFlagList = {
+      ...component.flagList,
+      [`${flag}`]: !component.flagList[flag],
+    };
+    updateComponentProperty(componentIndex, "flagList", newFlagList);
 
     // TODO:
     // Need to implement the functionality when
@@ -157,24 +154,33 @@ export default function ButtonPropertiesComponent({
           style={{ marginTop: "10px" }}
           multiple
           className={styles.selectInput}
-          value={flagList}
-          renderValue={(selected) => selected.join(", ")}
+          value={Object.keys(component.flagList)}
+          renderValue={(selected) =>
+            selected.filter((flag) => component.flagList[flag]).join(", ")
+          }
           displayEmpty
         >
-          <div style={{ display: "flex", flexDirection: "column" }}>
-            {flagList.map((flag, index) => (
-              <FormControlLabel
-                key={componentIndex + flag}
-                control={
-                  <CustomCheckBox
-                    checked={checked[index] || false}
-                    onChange={() => handleCheckboxChange(index)}
-                  />
-                }
-                label={flag}
-              />
-            ))}
-          </div>
+          {Object.keys(component.flagList).length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {Object.keys(component.flagList).map((flag) => (
+                <FormControlLabel
+                  key={flag}
+                  control={
+                    <CustomCheckBox
+                      checked={component.flagList[flag]}
+                      onChange={() => handleCheckboxChange(flag)}
+                    />
+                  }
+                  label={flag}
+                />
+              ))}
+            </div>
+          ) : (
+            <Typography className={styles.menuItem}>
+              This button property currently does not have any flags. Please add
+              flags first using the text field above.
+            </Typography>
+          )}
         </Select>
       </FormControl>
 

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
@@ -180,9 +180,58 @@ exports[`Button properties component snapshot test 1`] = `
           />
         </button>
       </div>
+    </div>
+    <div
+      class="MuiFormControl-root componentProperty MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 plusLabel MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+        data-shrink="true"
+      >
+        Select flags to be added
+      </label>
       <div
         class="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
-        style="margin-top: 10px;"
+      >
+        <div
+          aria-haspopup="listbox"
+          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+          role="button"
+          tabindex="0"
+        >
+          <span>
+            ​
+          </span>
+        </div>
+        <input
+          aria-hidden="true"
+          class="MuiSelect-nativeInput"
+          tabindex="-1"
+          value=""
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="MuiFormControl-root componentProperty MuiFormControl-fullWidth"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root WithStyles(ForwardRef(InputLabel))-root-2 minusLabel MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+        data-shrink="true"
+      >
+        Select flags to be removed
+      </label>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
       >
         <div
           aria-haspopup="listbox"

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
@@ -149,8 +149,8 @@ exports[`Button properties component snapshot test 1`] = `
           class="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            data-shrink="false"
           >
             New Flag
           </label>
@@ -161,7 +161,7 @@ exports[`Button properties component snapshot test 1`] = `
               aria-invalid="false"
               class="MuiInputBase-input MuiInput-input"
               type="text"
-              value="New Flag"
+              value=""
             />
           </div>
         </div>
@@ -190,13 +190,15 @@ exports[`Button properties component snapshot test 1`] = `
           role="button"
           tabindex="0"
         >
-          add flag_1, remove flag_1, add flag_2, remove flag_2
+          <span>
+            ​
+          </span>
         </div>
         <input
           aria-hidden="true"
           class="MuiSelect-nativeInput"
           tabindex="-1"
-          value="add flag_1,remove flag_1,add flag_2,remove flag_2"
+          value=""
         />
         <svg
           aria-hidden="true"

--- a/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
+++ b/frontend/src/containers/pages/AuthoringTool/CanvasSideBar/ComponentProperties/__tests__/__snapshots__/ButtonPropertiesComponent.test.js.snap
@@ -143,6 +143,77 @@ exports[`Button properties component snapshot test 1`] = `
       class="MuiFormControl-root componentProperty MuiFormControl-fullWidth"
     >
       <div
+        style="display: flex;"
+      >
+        <div
+          class="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+            data-shrink="true"
+          >
+            New Flag
+          </label>
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiInput-input"
+              type="text"
+              value="New Flag"
+            />
+          </div>
+        </div>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Add
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline selectInput MuiInputBase-formControl MuiInput-formControl"
+        style="margin-top: 10px;"
+      >
+        <div
+          aria-haspopup="listbox"
+          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+          role="button"
+          tabindex="0"
+        >
+          add flag_1, remove flag_1, add flag_2, remove flag_2
+        </div>
+        <input
+          aria-hidden="true"
+          class="MuiSelect-nativeInput"
+          tabindex="-1"
+          value="add flag_1,remove flag_1,add flag_2,remove flag_2"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="MuiFormControl-root componentProperty MuiFormControl-fullWidth"
+    >
+      <div
         class="MuiFormControl-root MuiTextField-root WithStyles(ForwardRef(TextField))-root-1 MuiFormControl-fullWidth"
       >
         <label

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
@@ -33,7 +33,8 @@ function addButton(currentScene, setCurrentScene) {
     width: 20, // as percentage
     id: v4(),
     zPosition: 0,
-    flagList: {},
+    flagAdditions: {},
+    flagDeletions: {},
   };
 
   addComponent(newButton, currentScene, setCurrentScene);

--- a/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
+++ b/frontend/src/containers/pages/AuthoringTool/ToolBar/ToolBarActions.jsx
@@ -33,6 +33,7 @@ function addButton(currentScene, setCurrentScene) {
     width: 20, // as percentage
     id: v4(),
     zPosition: 0,
+    flagList: {},
   };
 
   addComponent(newButton, currentScene, setCurrentScene);

--- a/frontend/src/styling/CanvasSideBar.module.scss
+++ b/frontend/src/styling/CanvasSideBar.module.scss
@@ -82,3 +82,17 @@
   margin-top: 0.5em !important;
   margin-bottom: 1em !important;
 }
+
+.plusLabel::before {
+  content: "+";
+  color: green;
+  margin-right: 8px;
+  font-weight: bold;
+}
+
+.minusLabel::before {
+  content: "-";
+  color: red;
+  margin-right: 8px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Describe the issue

In the authoring tool, the "Button" component should have a new property called "Flags" where the author can update the flag actions that a button causes when it is pressed. It should have a dropdown list, where all possible flags are displayed and can be selected. 

If there are no flags, there should be a text prompting the user to add flags.

## Describe the solution

Added the property and made it a dropdown list where the author can choose which flag action is active for that button:

<img width="282" alt="image" src="https://github.com/user-attachments/assets/a2e95440-a1d9-42f6-8fad-6df979fb4be8">

The user is also able to add flags themselves. When a new flag is added, two new options are added to the dropdown list (`add {newFlag}` and `remove {newFlag}`). 

<img width="268" alt="image" src="https://github.com/user-attachments/assets/f641b5cd-19ad-4c7e-a669-7b9c3d349e53">

If there are no flags, then a text prompting the user to add flags is shown:

<img width="276" alt="image" src="https://github.com/user-attachments/assets/b6fa99df-f890-422f-838d-f37f80e525ec">

## Risk

Not too many risks, this one is relatively isolated and only the button component was changed.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
