### PR TITLE
VPS-35/Reset button desync

### DIFF
--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPage.jsx
@@ -70,11 +70,15 @@ export default function PlayScenarioPage() {
   if (!currScene) return <LoadingPage text="Loading Scene..." />;
 
   const reset = async () => {
-    await usePost(
+    const res = await usePost(
       `api/navigate/user/reset/${scenarioId}`,
       { currentScene: sceneId },
       user.getIdToken.bind(user)
     );
+    if (res.status) {
+      setError(res);
+      return;
+    }
 
     console.log("reset");
     setPrevious(null);

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
@@ -81,11 +81,15 @@ export default function PlayScenarioPageMulti({ group }) {
   }
 
   const reset = async () => {
-    await usePost(
+    const res = await usePost(
       `api/navigate/group/reset/${group._id}`,
       { currentScene: sceneId },
       user.getIdToken.bind(user)
     );
+    if (res.status) {
+      setError(res);
+      return;
+    }
 
     console.log("reset");
     setPrevious(null);


### PR DESCRIPTION
## Describe the issue

When a user clicks the reset button, and another user also clicks it just after, they aren't desynced.

## Describe the solution

Correctly handle the 409 conflict response sent by the backend when desync occurs, so that it sets it as an error state in the component and hence reroutes the user to the desync page on the next render.

## Risk

No risks.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
