### PR TITLE
Vps 46/linking resources to flags

### DIFF
--- a/backend/src/routes/api/navigate/group.js
+++ b/backend/src/routes/api/navigate/group.js
@@ -190,3 +190,20 @@ export const groupReset = async (req) => {
 
   return { status: STATUS.OK };
 };
+
+// Fetches groups flags and returns resources
+export const groupGetResources = async (req, res) => {
+  const group = await Group.findById(req.params.groupId);
+
+  if (!group) {
+    throw new HttpError("Group not found", STATUS.NOT_FOUND);
+  }
+
+  const flags = group.currentFlags || [];
+  let resources = [];
+  if (flags) {
+      // TODO: add logic to map certain flags to groups here  
+      resources = [];
+  }
+  return { status: STATUS.OK, json: resources }
+};

--- a/backend/src/routes/api/navigate/group.js
+++ b/backend/src/routes/api/navigate/group.js
@@ -100,8 +100,6 @@ const addFlagsToGroup = async (groupId, newFlags) => {
   } catch (error) {
     throw new Error("Error updating group flags:", error);
   }
-
-
 };
 
 // Remove flags to group on scene change
@@ -192,7 +190,7 @@ export const groupReset = async (req) => {
 };
 
 // Fetches groups flags and returns resources
-export const groupGetResources = async (req, res) => {
+export const groupGetResources = async (req) => {
   const group = await Group.findById(req.params.groupId);
 
   if (!group) {
@@ -202,8 +200,8 @@ export const groupGetResources = async (req, res) => {
   const flags = group.currentFlags || [];
   let resources = [];
   if (flags) {
-      // TODO: add logic to map certain flags to groups here  
-      resources = [];
+    // TODO: add logic to map certain flags to groups here
+    resources = [];
   }
-  return { status: STATUS.OK, json: resources }
+  return { status: STATUS.OK, json: resources };
 };

--- a/backend/src/routes/api/navigate/index.js
+++ b/backend/src/routes/api/navigate/index.js
@@ -2,7 +2,7 @@ import { Router } from "express";
 import auth from "../../../middleware/firebaseAuth";
 
 import handle from "../../../error/handle";
-import { groupNavigate, groupReset } from "./group";
+import { groupNavigate, groupReset, groupGetResources } from "./group";
 import { userNavigate, userReset } from "./user";
 
 const router = Router();
@@ -24,6 +24,14 @@ router.post(
     return res.status(response.status).json(response.json);
   })
 );
+
+router.get(
+  "/group/resources/:groupId",
+  handle(async (req, res) => {
+    const response = await groupGetResources(req);
+    return res.status(response.status).json(response.json);
+  })
+)
 
 router.post(
   "/user/reset/:scenarioId",

--- a/backend/src/routes/api/navigate/index.js
+++ b/backend/src/routes/api/navigate/index.js
@@ -31,7 +31,7 @@ router.get(
     const response = await groupGetResources(req);
     return res.status(response.status).json(response.json);
   })
-)
+);
 
 router.post(
   "/user/reset/:scenarioId",

--- a/backend/src/routes/api/scene.js
+++ b/backend/src/routes/api/scene.js
@@ -20,9 +20,9 @@ const HTTP_NO_CONTENT = 204;
 const HTTP_NOT_FOUND = 404;
 
 // Apply auth middleware to all routes below this point
-router.use(auth);
+// router.use(auth);
 // Apply scenario auth middleware
-router.use(scenarioAuth);
+// router.use(scenarioAuth);
 
 // Get scene infromation
 router.get("/full/:sceneId", async (req, res) => {
@@ -115,23 +115,5 @@ router.put("/visited/:sceneId", async (req, res) => {
   const scene = await incrementVisisted(req.params.sceneId);
   res.status(HTTP_OK).json(scene);
 });
-
-
-// Get a list of the current flags
-router.get("/:sceneId", async (req, res) => {
-  try {
-    const group = await Group.findOne({ sceneID: req.params.sceneId });
-
-    if (!group) {
-      return res.sendStatus(HTTP_NOT_FOUND);
-    }
-
-    const flags = group.currentFlags || [];
-    res.status(HTTP_OK).json(flags);
-  } catch (err) {
-    res.status(HTTP_NOT_FOUND).send(err.message);
-  }
-});
-
 
 export default router;

--- a/backend/src/routes/api/scene.js
+++ b/backend/src/routes/api/scene.js
@@ -11,7 +11,6 @@ import {
 } from "../../db/daos/sceneDao";
 import auth from "../../middleware/firebaseAuth";
 import scenarioAuth from "../../middleware/scenarioAuth";
-import Group from "../../db/models/group";
 
 const router = Router({ mergeParams: true });
 
@@ -20,9 +19,9 @@ const HTTP_NO_CONTENT = 204;
 const HTTP_NOT_FOUND = 404;
 
 // Apply auth middleware to all routes below this point
-// router.use(auth);
+router.use(auth);
 // Apply scenario auth middleware
-// router.use(scenarioAuth);
+router.use(scenarioAuth);
 
 // Get scene infromation
 router.get("/full/:sceneId", async (req, res) => {

--- a/backend/src/routes/api/scene.js
+++ b/backend/src/routes/api/scene.js
@@ -11,6 +11,7 @@ import {
 } from "../../db/daos/sceneDao";
 import auth from "../../middleware/firebaseAuth";
 import scenarioAuth from "../../middleware/scenarioAuth";
+import Group from "../../db/models/group";
 
 const router = Router({ mergeParams: true });
 
@@ -114,5 +115,23 @@ router.put("/visited/:sceneId", async (req, res) => {
   const scene = await incrementVisisted(req.params.sceneId);
   res.status(HTTP_OK).json(scene);
 });
+
+
+// Get a list of the current flags
+router.get("/:sceneId", async (req, res) => {
+  try {
+    const group = await Group.findOne({ sceneID: req.params.sceneId });
+
+    if (!group) {
+      return res.sendStatus(HTTP_NOT_FOUND);
+    }
+
+    const flags = group.currentFlags || [];
+    res.status(HTTP_OK).json(flags);
+  } catch (err) {
+    res.status(HTTP_NOT_FOUND).send(err.message);
+  }
+});
+
 
 export default router;

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
@@ -99,6 +99,7 @@ export default function PlayScenarioPageMulti({ group }) {
         );
         const newResources = await getResources(user, group._id);
         setResources(newResources);
+        console.log(resources);
         if (!sceneId)
           history.replace(`/play/${scenarioId}/multiplayer/${newSceneId}`);
       } catch (e) {

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
@@ -45,12 +45,13 @@ const getResources = async (
   const token = await user.getIdToken();
   const config = {
     method: "get",
-    url: `/api/resources/${groupId}`,
+    url: `/api/navigate/group/resources/${groupId}`,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     }
   };
+  console.log(config);
   const res = await axios.request(config);
   console.log(res);
   return res.data.active;

--- a/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
+++ b/frontend/src/containers/pages/PlayScenarioPage/PlayScenarioPageMulti.jsx
@@ -38,10 +38,7 @@ const navigate = async (
 };
 
 // returns resources in the scene
-const getResources = async (
-  user,
-  groupId
-) => {
+const getResources = async (user, groupId) => {
   const token = await user.getIdToken();
   const config = {
     method: "get",
@@ -49,7 +46,7 @@ const getResources = async (
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
-    }
+    },
   };
   console.log(config);
   const res = await axios.request(config);
@@ -100,10 +97,7 @@ export default function PlayScenarioPageMulti({ group }) {
           addFlags,
           removeFlags
         );
-        const newResources = await getResources( 
-          user,
-          group._id
-        );
+        const newResources = await getResources(user, group._id);
         setResources(newResources);
         if (!sceneId)
           history.replace(`/play/${scenarioId}/multiplayer/${newSceneId}`);


### PR DESCRIPTION
## Describe the issue

When we navigate between scenes, we don't know which resources are visible to that group at that point in time.

## Describe the solution

- When we reset the scenario, the current flags field in the group schema is updated to an empty list.
- When the scene change happens, the API endpoint to get the list of visible resources is called.
- A new API endpoint was added at `/api/navigate/group/resources/:groupId` to get the list of currently visible resources for that group.

TODO:
- the logic for adding the visible resources to the list needs to be implemented (currently returns just an empty list)

## Risk

- Could break scene crawling

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
