### PR TITLE
[VPS-52] fix: evergreen resources are fetched even when the group flag list is empty

### DIFF
--- a/backend/src/routes/api/navigate/group.js
+++ b/backend/src/routes/api/navigate/group.js
@@ -221,17 +221,16 @@ export const groupGetResources = async (req) => {
   const flags = group.currentFlags || [];
   const resources = [];
 
-  if (flags.length > 0) {
-    // Fetch all resources from the database
-    const allResources = await Resource.find({});
+  // Fetch all resources from the database
+  const allResources = await Resource.find({});
 
-    // Filter resources where all requiredFlags are present in the group's current flags
-    const matchingResources = allResources.filter((resource) =>
-      resource.requiredFlags.every((flag) => flags.includes(flag))
-    );
+  // Filter resources where all requiredFlags are present in the group's current flags
+  const matchingResources = allResources.filter((resource) =>
+    resource.requiredFlags.every((flag) => flags.includes(flag))
+  );
 
-    // Push the filtered resources to the resources array
-    resources.push(...matchingResources);
-  }
+  // Push the filtered resources to the resources array
+  resources.push(...matchingResources);
+
   return { status: STATUS.OK, json: resources };
 };


### PR DESCRIPTION
## Describe the issue

Evergreen flags are not considered if the group flag list is empty (the resources were only fetched when there were flags in the group list).

## Describe the solution

Removed the condition of group flags being non-empty for the resource fetch to occur.

## Risk

Should not conflict with anything in the code base

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
