### PR TITLE
fix: fix multiplayer scenarios not displaying in home page.

### DIFF
--- a/frontend/src/components/ListContainer/ListContainer.jsx
+++ b/frontend/src/components/ListContainer/ListContainer.jsx
@@ -153,7 +153,7 @@ export default function ListContainer({
             : null}
         </ImageList>
 
-        {assignedScenarios ? (
+        {assignedScenarios.length ? (
           <>
             {!sceneSelectionPage && (
               <h1 className="text-3xl font-bold my-3">Assigned scenarios</h1>


### PR DESCRIPTION
# Description
Multiplayer scenario are being omitted from the the “Assigned scenarios” section of the main home page.

**Expected Behaviour:**
Both singleplayer and multiplayer scenarios show up as long as the user is assigned to that scenario (either directly or via a group).

## Implementation Notes:
The API responsible for fetching the assigned scenario have been fixed to correctly capture both singleplayer _and_ multiplayer scenarios. 
