### PR TITLE
fix: Fix invalid roles page not displaying

### DIFF
--- a/frontend/src/components/ListContainer/ListContainer.jsx
+++ b/frontend/src/components/ListContainer/ListContainer.jsx
@@ -153,7 +153,7 @@ export default function ListContainer({
             : null}
         </ImageList>
 
-        {assignedScenarios.length ? (
+        {assignedScenarios && assignedScenarios.length ? (
           <>
             {!sceneSelectionPage && (
               <h1 className="text-3xl font-bold my-3">Assigned scenarios</h1>
@@ -171,14 +171,15 @@ export default function ListContainer({
                 </ImageListItem>
               ) : null}
               {assignedScenarios && assignedScenarios.length > 0
-                ? assignedScenarios.map(({ _id, name }) => (
+                ? assignedScenarios.map((item) => (
                     <ImageListItem
                       className={classes.listContainerItem}
-                      key={_id}
+                      key={item._id}
                       cols={1}
                       height={200}
-                      onClick={(event) => onItemClick(event, { _id })}
-                      onContextMenu={() => onItemRightClick({ _id })}
+                      onClick={() => {
+                        window.open(`/play/${item._id}`, "_blank");
+                      }}
                     >
                       <div
                         className={
@@ -189,7 +190,9 @@ export default function ListContainer({
                           height={160}
                           border={5}
                           borderRadius={10}
-                          borderColor={_id === selected ? "#035084" : "#747474"}
+                          borderColor={
+                            item._id === selected ? "#035084" : "#747474"
+                          }
                           overflow="hidden"
                           textAlign="center"
                           sx={{
@@ -199,20 +202,22 @@ export default function ListContainer({
                             },
                           }}
                         >
-                          {sceneSelectionPage ? (
-                            <Thumbnail url={`/play/${scenarioId}/${_id}`} />
-                          ) : (
-                            <Thumbnail url={`/play/${_id}`} />
-                          )}
+                          <Thumbnail
+                            components={
+                              sceneSelectionPage
+                                ? item.components
+                                : item.thumbnail?.components || []
+                            }
+                          />
                         </Box>
                         <input
                           className={styles.text}
-                          defaultValue={name}
+                          defaultValue={item.name}
                           onBlur={onItemBlur}
-                          key={_id}
+                          key={item._id}
                         />
                       </div>
-                      {invalidNameId === _id && (
+                      {invalidNameId === item._id && (
                         <p1 className="nullNameWarning">invalid null name</p1>
                       )}
                     </ImageListItem>

--- a/frontend/src/features/status/InvalidRolePage.jsx
+++ b/frontend/src/features/status/InvalidRolePage.jsx
@@ -1,8 +1,8 @@
 import { Button } from "@mui/material";
 import { useContext, useState } from "react";
 import { useLocation } from "react-router-dom";
-import NotesDisplayCard from "../playScenario/modals/NotesModal/NotesModal";
 import AuthenticationContext from "../../context/AuthenticationContext";
+import NotesDisplayCard from "../playScenario/modals/NotesModal/NotesModal";
 
 function InvalidRolePage({ group }) {
   const { user } = useContext(AuthenticationContext);
@@ -61,8 +61,8 @@ function InvalidRolePage({ group }) {
         — or —
       </p>
       <button
+        className="btn btn-neutral"
         type="button"
-        style={buttonStyle}
         onClick={() => window.location.reload()}
       >
         Try Access Scenario

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "contributors:generate": "all-contributors generate"
   },
   "dependencies": {
-    "concurrently": "^8.2.2",
+    "concurrently": "^9.0.1",
     "npm": "6.14",
     "papaparse": "^5.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.18.9", "@babel/runtime@^7.21.0", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
   integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
@@ -549,17 +549,15 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concurrently@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-8.2.2.tgz#353141985c198cfa5e4a3ef90082c336b5851784"
-  integrity sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==
+concurrently@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-9.0.1.tgz#01e171bf6c7af0c022eb85daef95bff04d8185aa"
+  integrity sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==
   dependencies:
     chalk "^4.1.2"
-    date-fns "^2.30.0"
     lodash "^4.17.21"
     rxjs "^7.8.1"
     shell-quote "^1.8.1"
-    spawn-command "0.0.2"
     supports-color "^8.1.1"
     tree-kill "^1.2.2"
     yargs "^17.7.2"
@@ -670,13 +668,6 @@ data-view-byte-offset@^1.0.0:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
-
-date-fns@^2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
 
 debug@3.1.0:
   version "3.1.0"
@@ -3150,11 +3141,6 @@ sorted-union-stream@~2.1.3:
   dependencies:
     from2 "^1.3.0"
     stream-iterate "^1.1.0"
-
-spawn-command@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
-  integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
 
 spdx-correct@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Fixes unintended behaviour where the a white screen is shown instead of the invalid roles page.

## Addressing the _"Also"_ tag:
_"Also, refreshing causes you to get stuck on the invalid role page, and doesn’t allow you to move on even if another group member plays through their part (hack is to remove that part from the url but that won’t work for a test class for obvs reasons)."_

The invalid roles page does provide a button to attempt to play the scenario again - we essentially bypass the need for a manual browser refresh.


### Side note:
- This PR bundles in a tiny fix to make the thumbnails display correctly on the **Assigned scenarios** list. Furthermore - assigned scenarios will open the scenario when clicked, instead of giving the option to be edited (which would be an invalid action).