### PR TITLE
fix(frontend/authoring-tool): deleted the timer component that was not used in the authoring tool

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -137,30 +137,7 @@ export default function SceneSettings() {
               });
             }}
           />
-          {/* input for scene timer duration */}
-          <CustomTextField
-            label="Scene Timer Duration"
-            type="number"
-            value={currentScene?.time ?? 0}
-            fullWidth
-            onChange={(event) => {
-              // limiting scene timer duration
-              const timeInput = event.target.value < 0 ? 0 : event.target.value;
-
-              setCurrentScene({
-                ...currentScene,
-                time: timeInput,
-              });
-            }}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">seconds</InputAdornment>
-              ),
-            }}
-            InputLabelProps={{
-              shrink: true,
-            }}
-          />
+          {/* input for scene roles */}
           <FormControl fullWidth className={styles.formControl}>
             <CustomInputLabel>Scene Role(s)</CustomInputLabel>
             <Select


### PR DESCRIPTION
## Describe the issue

The Dashboard Timer was not removed from the Scene view in the authoring tool despite it not being used anymore.

## Describe the solution

Removed the dashboard timer from the authoring tool side bar.

## Risk

Could potentially break components that rely on the timer attribute.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
