### PR TITLE
Fix for the bug: when renaming a scene, the scene breaks (scene.component becomes null)

### DIFF
--- a/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
+++ b/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
@@ -180,6 +180,7 @@ export function SceneSelectionPage({ data = null }) {
       `/api/scenario/${scenarioId}/scene/${currentScene._id}`,
       {
         name: target.value,
+        components: currentScene.components,
       },
       getUserIdToken
     );


### PR DESCRIPTION
## Describe the issue

When renaming a scene from the scene selection page in the authoring tool, the scene breaks (all components deleted and components cannot be added). This was because `scene.component` became `NULL` when renaming a scene from the scene selection page.

## Describe the solution

The solution was to pass through the `component` field in the PUT request so that components is also updated in the renamed scene.

## Risk

Should not break anything as the component properties already existed (we just didn't update it)

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
