### PR TITLE
fix: add missing `.js` extension to imports

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,5 +1,5 @@
-import { HttpError } from "../util/error";
-import status from "../util/status";
+import { HttpError } from "../util/error.js";
+import status from "../util/status.js";
 
 // eslint-disable-next-line
 function errorHandler(err, req, res, next) {

--- a/backend/src/routes/api/navigate/group.js
+++ b/backend/src/routes/api/navigate/group.js
@@ -1,11 +1,11 @@
-import Scene from "../../../db/models/scene";
-import User from "../../../db/models/user";
-import Group from "../../../db/models/group";
-import Scenario from "../../../db/models/scenario";
-import Note from "../../../db/models/note";
-import Resource from "../../../db/models/resource";
-import { HttpError } from "../../../util/error";
-import STATUS from "../../../util/status";
+import Scene from "../../../db/models/scene.js";
+import User from "../../../db/models/user.js";
+import Group from "../../../db/models/group.js";
+import Scenario from "../../../db/models/scenario.js";
+import Note from "../../../db/models/note.js";
+import Resource from "../../../db/models/resource.js";
+import { HttpError } from "../../../util/error.js";
+import STATUS from "../../../util/status.js";
 
 const createInvalidError = (roles) =>
   new HttpError("Invalid role to access this scene", STATUS.FORBIDDEN, {

--- a/backend/src/routes/api/navigate/index.js
+++ b/backend/src/routes/api/navigate/index.js
@@ -1,9 +1,9 @@
 import { Router } from "express";
 import auth from "../../../middleware/firebaseAuth.js";
 
-import { handle } from "../../../util/error";
-import { groupNavigate, groupReset, groupGetResources } from "./group";
-import { userNavigate, userReset } from "./user";
+import { handle } from "../../../util/error.js";
+import { groupNavigate, groupReset, groupGetResources } from "./group.js";
+import { userNavigate, userReset } from "./user.js";
 
 const router = Router();
 

--- a/backend/src/routes/api/navigate/user.js
+++ b/backend/src/routes/api/navigate/user.js
@@ -1,8 +1,8 @@
 import Scene from "../../../db/models/scene.js";
 import User from "../../../db/models/user.js";
 
-import { HttpError } from "../../../util/error";
-import STATUS from "../../../util/status";
+import { HttpError } from "../../../util/error.js";
+import STATUS from "../../../util/status.js";
 
 import { getScenarioFirstScene, getSimpleScene } from "./group.js";
 

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
-import auth from "../../middleware/firebaseAuth";
-import { handle } from "../../util/error";
+import auth from "../../middleware/firebaseAuth.js";
+import { handle } from "../../util/error.js";
 
 import {
   createResource,

--- a/backend/src/routes/api/user.js
+++ b/backend/src/routes/api/user.js
@@ -13,8 +13,8 @@ import User from "../../db/models/user.js";
 import Group from "../../db/models/group.js";
 import auth from "../../middleware/firebaseAuth.js";
 
-import STATUS from "../../util/status";
-import { handle, HttpError } from "../../util/error";
+import STATUS from "../../util/status.js";
+import { handle, HttpError } from "../../util/error.js";
 
 const router = Router();
 


### PR DESCRIPTION
## Describe the issue

import statements were causing errors due to missing js exts.

## Describe the solution

added them

## Risk

No risk

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
