### PR TITLE
fix: remove `DesyncPage` route being defined in app

### DIFF
--- a/frontend/src/features/playScenario/PlayScenarioResolver.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioResolver.jsx
@@ -4,7 +4,6 @@ import { Route, Switch, useHistory, useParams } from "react-router-dom";
 
 import AuthenticationContext from "context/AuthenticationContext";
 
-import DesyncPage from "../status/DesyncPage";
 import InvalidRolePage from "../status/InvalidRolePage";
 import GenericErrorPage from "../status/GenericErrorPage";
 import LoadingPage from "../status/LoadingPage";
@@ -54,9 +53,6 @@ export default function PlayScenarioResolver() {
       </Route>
       <Route exact path="/play/:scenarioId/invalid-role">
         <InvalidRolePage group={group} />
-      </Route>
-      <Route exact path="/play/:scenarioId/desync">
-        <DesyncPage />
       </Route>
       <Route path="/play/:scenarioId/multiplayer/:sceneId?">
         <PlayScenarioPageMulti group={group} />


### PR DESCRIPTION
## Describe the issue

Route was still defined and imported the non-existent page

## Describe the solution

removed the import and route

## Risk

None

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
