### PR TITLE
fix: pathname used in express initialisation

### DIFF
--- a/backend/src/db/db-connect.js
+++ b/backend/src/db/db-connect.js
@@ -12,5 +12,5 @@ const DEFAULT_CONNECTION_STRING = `mongodb+srv://${process.env.MONGODB_USER}:${p
 export default function connectToDatabase(
   connectionString = DEFAULT_CONNECTION_STRING
 ) {
-  return mongoose.connect(connectionString);
+  return mongoose.connect(connectionString, { useNewUrlParser: true });
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import connectToDatabase from "./db/db-connect.js";
 
 // Setup our routes.
@@ -18,8 +19,9 @@ app.use(express.json());
 app.use("/", routes);
 app.use(errorHandler);
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 // Make the "public" folder available statically
-app.use(express.static(join(import.meta.dirname, "../public")));
+app.use(express.static(join(__dirname, "../public")));
 
 // Serve up the frontend's "build" directory, if we're running in production mode.
 if (process.env.NODE_ENV === "production") {


### PR DESCRIPTION
## Describe the issue

The backend was crashing because the pathname was still using the old commonjs way and didnt work with esm.

## Describe the solution

changed it to use functions built with esm.

## Risk

None.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
