### PR TITLE
fix: fix server crash on invalid scenario id role list req

### DIFF
--- a/backend/src/db/daos/scenarioDao.js
+++ b/backend/src/db/daos/scenarioDao.js
@@ -77,7 +77,7 @@ const retrieveScenarios = async (scenarioIds) => {
  */
 const retrieveRoleList = async (scenarioId) => {
   const scenario = await Scenario.findById(scenarioId);
-  return scenario.roleList;
+  return scenario?.roleList ?? [];
 };
 
 /**
@@ -162,12 +162,12 @@ const deleteScenario = async (scenarioId) => {
 
 export {
   createScenario,
-  retrieveScenarioList,
-  retrieveScenario,
-  retrieveScenarios,
-  retrieveRoleList,
-  updateScenario,
   deleteScenario,
+  retrieveRoleList,
+  retrieveScenario,
+  retrieveScenarioList,
+  retrieveScenarios,
   updateDurations,
   updateRoleList,
+  updateScenario,
 };

--- a/frontend/src/context/ScenarioContextProvider.jsx
+++ b/frontend/src/context/ScenarioContextProvider.jsx
@@ -23,10 +23,11 @@ export default function ScenarioContextProvider({ children }) {
     true
   );
 
-  const { reFetch: reFetch3 } = useGet(
-    currentScenario ? `api/group/${currentScenario._id}/roleList` : null,
-    currentScenario ? setRoleList : () => {},
-    true
+  useGet(
+    `api/group/${currentScenario?._id}/roleList`,
+    setRoleList,
+    true,
+    !currentScenario // Skip request if there is no current scenario.
   );
 
   return (
@@ -38,7 +39,6 @@ export default function ScenarioContextProvider({ children }) {
         assignedScenarios,
         setAssignedScenarios,
         reFetch2,
-        reFetch3,
         currentScenario,
         setCurrentScenario,
         roleList,

--- a/frontend/src/features/scenarioSelection/ScenarioSelectionPage.jsx
+++ b/frontend/src/features/scenarioSelection/ScenarioSelectionPage.jsx
@@ -24,7 +24,6 @@ export default function ScenarioSelectionPage({ data = null }) {
     currentScenario,
     setCurrentScenario,
   } = useContext(ScenarioContext);
-  console.log(assignedScenarios);
   const { getUserIdToken, VpsUser } = useContext(AuthenticationContext);
   const history = useHistory();
 

--- a/frontend/src/hooks/crudHooks.jsx
+++ b/frontend/src/hooks/crudHooks.jsx
@@ -220,8 +220,10 @@ if (import.meta.env.VITE_REACT_APP_SERVER_URL === undefined) {
  * A custom hook which fetches data from the given URL. Includes functionality to determine
  * whether the data is still being loaded or not.
  * Code adapted from SOFTENG750 lab4 https://gitlab.com/cs732-s1c/cs732-labs/cs732-lab-04/-/blob/master/frontend/src/hooks/useGet.js
+ *
+ * skipRequest: a boolean that skips the request if set to true.
  */
-export function useGet(url, setData, requireAuth = true) {
+export function useGet(url, setData, requireAuth = true, skipRequest = false) {
   const [isLoading, setLoading] = useState(false);
   const [version, setVersion] = useState(0);
   const { getUserIdToken } = useContext(AuthenticationContext);
@@ -256,7 +258,11 @@ export function useGet(url, setData, requireAuth = true) {
 
       setLoading(false);
     }
-    fetchData();
+
+    // Only execute request if skipRequest is false!
+    if (!skipRequest) {
+      fetchData();
+    }
   }, [url, version]);
 
   return { isLoading, reFetch };


### PR DESCRIPTION
- Fixes a server crash when making a role list query for an invalid scenario ID.
- Removes redundant console log (logging assigned scenarios) that was spamming console on every rerender.

This is a _potential_ fix for the following bug bounty:
![image](https://github.com/user-attachments/assets/29d0a44a-2f5d-444f-96f8-34af8ea3eb79)
However, as backend nor network request logs were gathered, **we cannot verify for sure**.
Current thinking is that an invalid role list request was made on login, crashing the backend. Consequently, this makes subsequent requests fail with a `ERR_CONNECTION_REFUSED`, before the HTTP protocol can even send a request.
