### PR TITLE
Vps 114/standardize scene numbering

### DIFF
--- a/frontend/src/components/SideBar/SideBar.jsx
+++ b/frontend/src/components/SideBar/SideBar.jsx
@@ -40,7 +40,7 @@ export default function SideBar() {
     await usePost(
       `/api/scenario/${newScenario._id}/scene`,
       {
-        name: `Scene 0`,
+        name: `Scene 1`,
       },
       getUserIdToken
     );

--- a/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
+++ b/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
@@ -118,7 +118,7 @@ export function SceneSelectionPage() {
     const newScene = await usePost(
       `/api/scenario/${scenarioId}/scene`,
       {
-        name: `Scene ${scenes.length}`,
+        name: `Scene ${scenes.length + 1}`,
       },
       getUserIdToken
     );


### PR DESCRIPTION
## Describe the issue

The scene numbering would start off at 0 whenever a new Scenario is made

## Describe the solution

Made 2 changes - fixed the Scene to start at 1 instead of 0 during scene creation, and changed the scene navigator logic to use 1 based indexing.

## Risk

No risks found :D

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
