### PR TITLE
Create and Edit State Operations

### DIFF
--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -12,21 +12,17 @@ import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import StateOperationForm from "./StateOperationForm";
 
-const CreateStateOperation = ({
-  componentIndex,
-  stateOperations,
-  setStateOperations,
-}) => {
+const CreateStateOperation = ({ component, componentIndex }) => {
   const { stateVariables } = useContext(ScenarioContext);
   const { updateComponentProperty } = useContext(SceneContext);
 
-  const [selectedState, setSelectedState] = useState("");
+  const [selectedState, setSelectedState] = useState();
   const [operation, setOperation] = useState();
   const [value, setValue] = useState();
 
   const handleSubmit = () => {
     const newStateOperations = [
-      ...stateOperations,
+      ...(component.stateOperations || []),
       {
         name: selectedState.name,
         operation,
@@ -38,7 +34,10 @@ const CreateStateOperation = ({
       "stateOperations",
       newStateOperations
     );
-    setStateOperations(newStateOperations);
+
+    setSelectedState();
+    setOperation();
+    setValue();
   };
 
   if (stateVariables && stateVariables.length == 0) {
@@ -63,13 +62,15 @@ const CreateStateOperation = ({
     >
       <FormControl>
         <InputLabel>Name</InputLabel>
-        <Select>
+        <Select
+          value={selectedState && selectedState.name}
+          onChange={(e) => {
+            setSelectedState(e.target.value);
+          }}
+          required
+        >
           {stateVariables.map((stateVariable) => (
-            <MenuItem
-              key={stateVariable.name}
-              value={stateVariable.name}
-              onClick={() => setSelectedState(stateVariable)}
-            >
+            <MenuItem key={stateVariable.name} value={stateVariable}>
               {stateVariable.name}
             </MenuItem>
           ))}

--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -11,14 +11,15 @@ import { useContext, useState } from "react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import StateOperationForm from "./StateOperationForm";
+import { getDefaultValue } from "./StateTypes";
 
 const CreateStateOperation = ({ component, componentIndex }) => {
   const { stateVariables } = useContext(ScenarioContext);
   const { updateComponentProperty } = useContext(SceneContext);
 
-  const [selectedState, setSelectedState] = useState();
-  const [operation, setOperation] = useState();
-  const [value, setValue] = useState();
+  const [selectedState, setSelectedState] = useState("");
+  const [operation, setOperation] = useState("");
+  const [value, setValue] = useState("");
 
   const handleSubmit = () => {
     const newStateOperations = [
@@ -63,9 +64,12 @@ const CreateStateOperation = ({ component, componentIndex }) => {
       <FormControl>
         <InputLabel>Name</InputLabel>
         <Select
-          value={selectedState && selectedState.name}
+          value={selectedState}
           onChange={(e) => {
-            setSelectedState(e.target.value);
+            const newSelectedState = e.target.value;
+            setSelectedState(newSelectedState);
+            setOperation("");
+            setValue(getDefaultValue(newSelectedState.type));
           }}
           required
         >

--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -9,22 +9,36 @@ import {
 } from "@material-ui/core";
 import { useContext, useState } from "react";
 import ScenarioContext from "context/ScenarioContext";
+import SceneContext from "context/SceneContext";
 import StateOperationForm from "./StateOperationForm";
 
-const CreateStateOperation = ({ stateOperations, setStateOperations }) => {
+const CreateStateOperation = ({
+  componentIndex,
+  stateOperations,
+  setStateOperations,
+}) => {
   const { stateVariables } = useContext(ScenarioContext);
+  const { updateComponentProperty } = useContext(SceneContext);
 
   const [selectedState, setSelectedState] = useState("");
   const [operation, setOperation] = useState();
   const [value, setValue] = useState();
 
   const handleSubmit = () => {
-    const newStateOperation = {
-      name: selectedState.name,
-      operation,
-      value,
-    };
-    setStateOperations([ ...stateOperations, newStateOperation ]);
+    const newStateOperations = [
+      ...stateOperations,
+      {
+        name: selectedState.name,
+        operation,
+        value,
+      },
+    ];
+    updateComponentProperty(
+      componentIndex,
+      "stateOperations",
+      newStateOperations
+    );
+    setStateOperations(newStateOperations);
   };
 
   if (stateVariables && stateVariables.length == 0) {

--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -1,0 +1,77 @@
+import {
+  Button,
+  FormControl,
+  FormGroup,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@material-ui/core";
+import { useContext, useState } from "react";
+import ScenarioContext from "context/ScenarioContext";
+import StateOperationForm from "./StateOperationForm";
+
+const CreateStateOperation = () => {
+  const { stateVariables } = useContext(ScenarioContext);
+
+  const [selectedState, setSelectedState] = useState("");
+  const [operation, setOperation] = useState();
+  const [value, setValue] = useState();
+
+  const handleSubmit = () => {
+    console.log("submit")
+  }
+
+  if (stateVariables && stateVariables.length == 0) {
+    return (
+      <Typography variant="body2">
+        No state variables found, create some in the state variable menu.
+      </Typography>
+    );
+  }
+
+  return (
+    <FormGroup
+      style={{
+        marginBottom: "30px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+        background: "#f9f9f9",
+        padding: "16px",
+        borderRadius: "8px",
+      }}
+    >
+      <FormControl>
+        <InputLabel>Name</InputLabel>
+        <Select>
+          {stateVariables.map((stateVariable) => (
+            <MenuItem
+              key={stateVariable.name}
+              value={stateVariable.name}
+              onClick={() => setSelectedState(stateVariable)}
+            >
+              {stateVariable.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <StateOperationForm
+        selectedState={selectedState}
+        setOperation={setOperation}
+        value={value}
+        setValue={setValue}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        onClick={handleSubmit}
+      >
+        Create
+      </Button>
+    </FormGroup>
+  );
+};
+
+export default CreateStateOperation;

--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -13,6 +13,12 @@ import SceneContext from "context/SceneContext";
 import StateOperationForm from "./StateOperationForm";
 import { getDefaultValue } from "./StateTypes";
 
+/**
+ * Component used for creating state operations
+ * State operations are used to manipulate state variables while playing through a scenario
+ *
+ * @component
+ */
 const CreateStateOperation = ({ component, componentIndex }) => {
   const { stateVariables } = useContext(ScenarioContext);
   const { updateComponentProperty } = useContext(SceneContext);

--- a/frontend/src/components/StateVariables/CreateStateOperation.jsx
+++ b/frontend/src/components/StateVariables/CreateStateOperation.jsx
@@ -11,7 +11,7 @@ import { useContext, useState } from "react";
 import ScenarioContext from "context/ScenarioContext";
 import StateOperationForm from "./StateOperationForm";
 
-const CreateStateOperation = () => {
+const CreateStateOperation = ({ stateOperations, setStateOperations }) => {
   const { stateVariables } = useContext(ScenarioContext);
 
   const [selectedState, setSelectedState] = useState("");
@@ -19,13 +19,18 @@ const CreateStateOperation = () => {
   const [value, setValue] = useState();
 
   const handleSubmit = () => {
-    console.log("submit")
-  }
+    const newStateOperation = {
+      name: selectedState.name,
+      operation,
+      value,
+    };
+    setStateOperations([ ...stateOperations, newStateOperation ]);
+  };
 
   if (stateVariables && stateVariables.length == 0) {
     return (
       <Typography variant="body2">
-        No state variables found, create some in the state variable menu.
+        No state variables found, create some in the state variable menu
       </Typography>
     );
   }
@@ -58,6 +63,7 @@ const CreateStateOperation = () => {
       </FormControl>
       <StateOperationForm
         selectedState={selectedState}
+        operation={operation}
         setOperation={setOperation}
         value={value}
         setValue={setValue}

--- a/frontend/src/components/StateVariables/EditStateOperation.jsx
+++ b/frontend/src/components/StateVariables/EditStateOperation.jsx
@@ -3,9 +3,16 @@ import { useContext, useState } from "react";
 import EditingTooltips from "./EditingTooltips";
 import StateOperationForm from "./StateOperationForm";
 import ScenarioContext from "../../context/ScenarioContext";
+import SceneContext from "../../context/SceneContext";
 
-const EditStateOperation = ({ stateOperation }) => {
+const EditStateOperation = ({
+  componentIndex,
+  component,
+  operationIndex,
+  stateOperation,
+}) => {
   const { stateVariables } = useContext(ScenarioContext);
+  const { updateComponentProperty } = useContext(SceneContext);
 
   const stateVariable = stateVariables.find(
     (variable) => variable.name === stateOperation.name
@@ -14,16 +21,49 @@ const EditStateOperation = ({ stateOperation }) => {
   const [newOperation, setNewOperation] = useState(stateOperation.operation);
   const [newValue, setNewValue] = useState(stateOperation.value);
 
+  const editing = newOperation !== stateOperation.operation || newValue !== stateOperation.value;
+
+  const resetStateOperation = () => {
+    setNewOperation(stateOperation.operation);
+    setNewValue(stateOperation.value);
+  };
+
+  const editStateOperation = () => {
+    const newStateOperations = component.stateOperations.map((operation, index) =>
+      index === operationIndex
+        ? { ...operation, operation: newOperation, value: newValue }
+        : operation
+    );
+    updateComponentProperty(
+      componentIndex,
+      "stateOperations",
+      newStateOperations
+    );
+  };
+
+  const deleteStateOperation = () => {
+    const newStateOperations = component.stateOperations.filter(
+      (_, index) => index !== operationIndex
+    );
+    updateComponentProperty(
+      componentIndex,
+      "stateOperations",
+      newStateOperations
+    );
+  };
+
   return (
     <FormGroup
       style={{
-        marginBottom: "60px",
+        marginBottom: "30px",
         display: "flex",
         flexDirection: "column",
         gap: "10px",
         background: "#f9f9f9",
         padding: "16px",
         borderRadius: "8px",
+        border: "2px solid",
+        borderColor: editing ? "#ffa600" : "transparent",
       }}
     >
       <Typography variant="subtitle1" fontWeight="bold">
@@ -37,7 +77,7 @@ const EditStateOperation = ({ stateOperation }) => {
         setValue={setNewValue}
       />
       <Box width="100%" display="flex" justifyContent="space-between">
-        <EditingTooltips />
+        <EditingTooltips onReset={resetStateOperation} onSave={editStateOperation} onDelete={deleteStateOperation} />
       </Box>
     </FormGroup>
   );

--- a/frontend/src/components/StateVariables/EditStateOperation.jsx
+++ b/frontend/src/components/StateVariables/EditStateOperation.jsx
@@ -5,6 +5,12 @@ import StateOperationForm from "./StateOperationForm";
 import ScenarioContext from "../../context/ScenarioContext";
 import SceneContext from "../../context/SceneContext";
 
+/**
+ * Component used for editing state operations
+ * State operations are used to manipulate state variables while playing through a scenario
+ *
+ * @component
+ */
 const EditStateOperation = ({
   componentIndex,
   component,

--- a/frontend/src/components/StateVariables/EditStateOperation.jsx
+++ b/frontend/src/components/StateVariables/EditStateOperation.jsx
@@ -1,0 +1,46 @@
+import { Box, FormGroup, Typography } from "@material-ui/core";
+import { useContext, useState } from "react";
+import EditingTooltips from "./EditingTooltips";
+import StateOperationForm from "./StateOperationForm";
+import ScenarioContext from "../../context/ScenarioContext";
+
+const EditStateOperation = ({ stateOperation }) => {
+  const { stateVariables } = useContext(ScenarioContext);
+
+  const stateVariable = stateVariables.find(
+    (variable) => variable.name === stateOperation.name
+  );
+
+  const [newOperation, setNewOperation] = useState(stateOperation.operation);
+  const [newValue, setNewValue] = useState(stateOperation.value);
+
+  return (
+    <FormGroup
+      style={{
+        marginBottom: "60px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+        background: "#f9f9f9",
+        padding: "16px",
+        borderRadius: "8px",
+      }}
+    >
+      <Typography variant="subtitle1" fontWeight="bold">
+        {stateOperation.name}
+      </Typography>
+      <StateOperationForm
+        selectedState={stateVariable}
+        operation={newOperation}
+        setOperation={setNewOperation}
+        value={newValue}
+        setValue={setNewValue}
+      />
+      <Box width="100%" display="flex" justifyContent="space-between">
+        <EditingTooltips />
+      </Box>
+    </FormGroup>
+  );
+};
+
+export default EditStateOperation;

--- a/frontend/src/components/StateVariables/EditStateOperation.jsx
+++ b/frontend/src/components/StateVariables/EditStateOperation.jsx
@@ -21,7 +21,9 @@ const EditStateOperation = ({
   const [newOperation, setNewOperation] = useState(stateOperation.operation);
   const [newValue, setNewValue] = useState(stateOperation.value);
 
-  const editing = newOperation !== stateOperation.operation || newValue !== stateOperation.value;
+  const editing =
+    newOperation !== stateOperation.operation ||
+    newValue !== stateOperation.value;
 
   const resetStateOperation = () => {
     setNewOperation(stateOperation.operation);
@@ -29,10 +31,11 @@ const EditStateOperation = ({
   };
 
   const editStateOperation = () => {
-    const newStateOperations = component.stateOperations.map((operation, index) =>
-      index === operationIndex
-        ? { ...operation, operation: newOperation, value: newValue }
-        : operation
+    const newStateOperations = component.stateOperations.map(
+      (operation, index) =>
+        index === operationIndex
+          ? { ...operation, operation: newOperation, value: newValue }
+          : operation
     );
     updateComponentProperty(
       componentIndex,
@@ -77,7 +80,11 @@ const EditStateOperation = ({
         setValue={setNewValue}
       />
       <Box width="100%" display="flex" justifyContent="space-between">
-        <EditingTooltips onReset={resetStateOperation} onSave={editStateOperation} onDelete={deleteStateOperation} />
+        <EditingTooltips
+          onReset={resetStateOperation}
+          onSave={editStateOperation}
+          onDelete={deleteStateOperation}
+        />
       </Box>
     </FormGroup>
   );

--- a/frontend/src/components/StateVariables/EditStateVariable.jsx
+++ b/frontend/src/components/StateVariables/EditStateVariable.jsx
@@ -1,13 +1,11 @@
-import { Box, Grid, IconButton, Tooltip, Card } from "@material-ui/core";
-import ReplayIcon from "@mui/icons-material/Replay";
-import SaveIcon from "@material-ui/icons/Save";
-import DeleteIcon from "@material-ui/icons/Delete";
+import { Box, Grid, Card } from "@material-ui/core";
 import { api } from "../../util/api";
 import { useContext, useState } from "react";
 import AuthenticationContext from "../../context/AuthenticationContext";
 import toast from "react-hot-toast";
 import StateVariableForm from "./StateVariableForm";
 import ScenarioContext from "../../context/ScenarioContext";
+import EditingTooltips from "./EditingTooltips";
 
 const EditStateVariable = ({ stateVariable, scenarioId }) => {
   const { user } = useContext(AuthenticationContext);
@@ -80,21 +78,11 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
           setValue={setNewValue}
         />
         <Box ml="auto" display="flex" alignItems="center">
-          <Tooltip title="Reset">
-            <IconButton color="default" onClick={resetFields}>
-              <ReplayIcon />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Save">
-            <IconButton color="primary" onClick={editStateVariable}>
-              <SaveIcon />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Delete">
-            <IconButton color="secondary" onClick={deleteStateVariable}>
-              <DeleteIcon />
-            </IconButton>
-          </Tooltip>
+          <EditingTooltips
+            onReset={resetFields}
+            onSave={editStateVariable}
+            onDelete={deleteStateVariable}
+          />
         </Box>
       </Grid>
     </Card>

--- a/frontend/src/components/StateVariables/EditingTooltips.jsx
+++ b/frontend/src/components/StateVariables/EditingTooltips.jsx
@@ -1,0 +1,28 @@
+import { IconButton, Tooltip } from "@material-ui/core";
+import ReplayIcon from "@mui/icons-material/Replay";
+import SaveIcon from "@material-ui/icons/Save";
+import DeleteIcon from "@material-ui/icons/Delete";
+
+const EditingTooltips = ({ onReset, onSave, onDelete }) => {
+  return (
+    <>
+      <Tooltip title="Reset">
+        <IconButton color="default" onClick={onReset}>
+          <ReplayIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Save">
+        <IconButton color="primary" onClick={onSave}>
+          <SaveIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete">
+        <IconButton color="secondary" onClick={onDelete}>
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+};
+
+export default EditingTooltips;

--- a/frontend/src/components/StateVariables/EditingTooltips.jsx
+++ b/frontend/src/components/StateVariables/EditingTooltips.jsx
@@ -3,6 +3,11 @@ import ReplayIcon from "@mui/icons-material/Replay";
 import SaveIcon from "@material-ui/icons/Save";
 import DeleteIcon from "@material-ui/icons/Delete";
 
+/**
+ * Tooltips used when editing state variables or state operations
+ *
+ * @component
+ */
 const EditingTooltips = ({ onReset, onSave, onDelete }) => {
   return (
     <>

--- a/frontend/src/components/StateVariables/Operations.js
+++ b/frontend/src/components/StateVariables/Operations.js
@@ -1,0 +1,12 @@
+import { StateTypes } from "./StateTypes";
+
+export const operations = {
+  SET: "set",
+  ADD: "add",
+};
+
+export const validOperations = {
+  [StateTypes.STRING]: [operations.SET],
+  [StateTypes.NUMBER]: [operations.SET, operations.ADD],
+  [StateTypes.BOOLEAN]: [operations.SET],
+};

--- a/frontend/src/components/StateVariables/StateOperationForm.jsx
+++ b/frontend/src/components/StateVariables/StateOperationForm.jsx
@@ -1,0 +1,111 @@
+import {
+  FormControl,
+  FormGroup,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { useContext, useState } from "react";
+import ScenarioContext from "context/ScenarioContext";
+import { validOperations } from "./Operations";
+import { StateTypes } from "./StateTypes";
+
+const StateOperationForm = () => {
+  const { stateVariables } = useContext(ScenarioContext);
+
+  const [selectedState, setSelectedState] = useState("");
+  const [newValue, setNewValue] = useState();
+
+  return (
+    <FormGroup
+      style={{
+        marginBottom: "60px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+        background: "#f9f9f9",
+        padding: "16px",
+        borderRadius: "8px",
+      }}
+    >
+      {stateVariables && stateVariables.length > 0 ? (
+        <>
+          <FormControl>
+            <InputLabel>Name</InputLabel>
+            <Select>
+              {stateVariables.map((stateVariable) => (
+                <MenuItem
+                  key={stateVariable.name}
+                  value={stateVariable.name}
+                  onClick={() => setSelectedState(stateVariable)}
+                >
+                  {stateVariable.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {selectedState && (
+            <>
+              <Typography variant="body2">
+                Type:{" "}
+                {selectedState.type.charAt(0).toUpperCase() +
+                  selectedState.type.slice(1)}
+              </Typography>
+              <FormControl>
+                <InputLabel>Operation</InputLabel>
+                <Select>
+                  {validOperations[selectedState.type].map((operation) => (
+                    <MenuItem key={operation} value={operation}>
+                      {operation.charAt(0).toUpperCase() + operation.slice(1)}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl>
+                {selectedState.type === StateTypes.BOOLEAN ? (
+                  <>
+                    <InputLabel>Value</InputLabel>
+                    <Select
+                      value={newValue}
+                      onChange={(e) => setNewValue(e.target.value)}
+                      required
+                    >
+                      <MenuItem value={true}>True</MenuItem>
+                      <MenuItem value={false}>False</MenuItem>
+                    </Select>
+                  </>
+                ) : (
+                  <TextField
+                    value={newValue}
+                    label={`Value`}
+                    onChange={(e) =>
+                      setNewValue(
+                        selectedState.type === StateTypes.NUMBER
+                          ? Number(e.target.value)
+                          : e.target.value
+                      )
+                    }
+                    required
+                    type={
+                      selectedState.type === StateTypes.NUMBER
+                        ? "number"
+                        : "text"
+                    }
+                  />
+                )}
+              </FormControl>
+            </>
+          )}
+        </>
+      ) : (
+        <Typography variant="body2">
+          No state variables found, create some in the state variable menu.
+        </Typography>
+      )}
+    </FormGroup>
+  );
+};
+
+export default StateOperationForm;

--- a/frontend/src/components/StateVariables/StateOperationForm.jsx
+++ b/frontend/src/components/StateVariables/StateOperationForm.jsx
@@ -9,6 +9,11 @@ import {
 import { validOperations } from "./Operations";
 import { StateTypes } from "./StateTypes";
 
+/**
+ * Component with fields shared in both creating and editing state operations
+ *
+ * @component
+ */
 const StateOperationForm = ({
   selectedState,
   operation,

--- a/frontend/src/components/StateVariables/StateOperationForm.jsx
+++ b/frontend/src/components/StateVariables/StateOperationForm.jsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   FormControl,
   FormGroup,
   InputLabel,
@@ -11,6 +12,7 @@ import { useContext, useState } from "react";
 import ScenarioContext from "context/ScenarioContext";
 import { validOperations } from "./Operations";
 import { StateTypes } from "./StateTypes";
+import EditingTooltips from "./EditingTooltips";
 
 const StateOperationForm = () => {
   const { stateVariables } = useContext(ScenarioContext);
@@ -98,6 +100,9 @@ const StateOperationForm = () => {
               </FormControl>
             </>
           )}
+          <Box width="100%" display="flex" justifyContent="space-between">
+            <EditingTooltips />
+          </Box>
         </>
       ) : (
         <Typography variant="body2">

--- a/frontend/src/components/StateVariables/StateOperationForm.jsx
+++ b/frontend/src/components/StateVariables/StateOperationForm.jsx
@@ -1,115 +1,75 @@
 import {
-  Box,
   FormControl,
-  FormGroup,
   InputLabel,
   MenuItem,
   Select,
   TextField,
   Typography,
 } from "@material-ui/core";
-import { useContext, useState } from "react";
-import ScenarioContext from "context/ScenarioContext";
 import { validOperations } from "./Operations";
 import { StateTypes } from "./StateTypes";
-import EditingTooltips from "./EditingTooltips";
 
-const StateOperationForm = () => {
-  const { stateVariables } = useContext(ScenarioContext);
-
-  const [selectedState, setSelectedState] = useState("");
-  const [newValue, setNewValue] = useState();
+const StateOperationForm = ({
+  selectedState,
+  setOperation,
+  value,
+  setValue,
+}) => {
+  if (!selectedState) {
+    return null;
+  }
 
   return (
-    <FormGroup
-      style={{
-        marginBottom: "60px",
-        display: "flex",
-        flexDirection: "column",
-        gap: "10px",
-        background: "#f9f9f9",
-        padding: "16px",
-        borderRadius: "8px",
-      }}
-    >
-      {stateVariables && stateVariables.length > 0 ? (
-        <>
-          <FormControl>
-            <InputLabel>Name</InputLabel>
-            <Select>
-              {stateVariables.map((stateVariable) => (
-                <MenuItem
-                  key={stateVariable.name}
-                  value={stateVariable.name}
-                  onClick={() => setSelectedState(stateVariable)}
-                >
-                  {stateVariable.name}
-                </MenuItem>
-              ))}
+    <>
+      <Typography variant="body2">
+        Type:{" "}
+        {selectedState.type.charAt(0).toUpperCase() +
+          selectedState.type.slice(1)}
+      </Typography>
+      <FormControl>
+        <InputLabel>Operation</InputLabel>
+        <Select>
+          {validOperations[selectedState.type].map((operation) => (
+            <MenuItem
+              key={operation}
+              value={operation}
+              onClick={() => setOperation(operation)}
+            >
+              {operation.charAt(0).toUpperCase() + operation.slice(1)}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl>
+        {selectedState.type === StateTypes.BOOLEAN ? (
+          <>
+            <InputLabel>Value</InputLabel>
+            <Select
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              required
+            >
+              <MenuItem value={true}>True</MenuItem>
+              <MenuItem value={false}>False</MenuItem>
             </Select>
-          </FormControl>
-          {selectedState && (
-            <>
-              <Typography variant="body2">
-                Type:{" "}
-                {selectedState.type.charAt(0).toUpperCase() +
-                  selectedState.type.slice(1)}
-              </Typography>
-              <FormControl>
-                <InputLabel>Operation</InputLabel>
-                <Select>
-                  {validOperations[selectedState.type].map((operation) => (
-                    <MenuItem key={operation} value={operation}>
-                      {operation.charAt(0).toUpperCase() + operation.slice(1)}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-              <FormControl>
-                {selectedState.type === StateTypes.BOOLEAN ? (
-                  <>
-                    <InputLabel>Value</InputLabel>
-                    <Select
-                      value={newValue}
-                      onChange={(e) => setNewValue(e.target.value)}
-                      required
-                    >
-                      <MenuItem value={true}>True</MenuItem>
-                      <MenuItem value={false}>False</MenuItem>
-                    </Select>
-                  </>
-                ) : (
-                  <TextField
-                    value={newValue}
-                    label={`Value`}
-                    onChange={(e) =>
-                      setNewValue(
-                        selectedState.type === StateTypes.NUMBER
-                          ? Number(e.target.value)
-                          : e.target.value
-                      )
-                    }
-                    required
-                    type={
-                      selectedState.type === StateTypes.NUMBER
-                        ? "number"
-                        : "text"
-                    }
-                  />
-                )}
-              </FormControl>
-            </>
-          )}
-          <Box width="100%" display="flex" justifyContent="space-between">
-            <EditingTooltips />
-          </Box>
-        </>
-      ) : (
-        <Typography variant="body2">
-          No state variables found, create some in the state variable menu.
-        </Typography>
-      )}
-    </FormGroup>
+          </>
+        ) : (
+          <TextField
+            value={value}
+            label={`Value`}
+            onChange={(e) =>
+              setValue(
+                selectedState.type === StateTypes.NUMBER
+                  ? Number(e.target.value)
+                  : e.target.value
+              )
+            }
+            required
+            type={selectedState.type === StateTypes.NUMBER ? "number" : "text"}
+          />
+        )}
+      </FormControl>
+    </>
   );
 };
 

--- a/frontend/src/components/StateVariables/StateOperationForm.jsx
+++ b/frontend/src/components/StateVariables/StateOperationForm.jsx
@@ -11,6 +11,7 @@ import { StateTypes } from "./StateTypes";
 
 const StateOperationForm = ({
   selectedState,
+  operation,
   setOperation,
   value,
   setValue,
@@ -28,14 +29,16 @@ const StateOperationForm = ({
       </Typography>
       <FormControl>
         <InputLabel>Operation</InputLabel>
-        <Select>
-          {validOperations[selectedState.type].map((operation) => (
-            <MenuItem
-              key={operation}
-              value={operation}
-              onClick={() => setOperation(operation)}
-            >
-              {operation.charAt(0).toUpperCase() + operation.slice(1)}
+        <Select
+          value={operation}
+          onChange={(e) => {
+            setOperation(e.target.value);
+          }}
+          required
+        >
+          {validOperations[selectedState.type].map((validOperation) => (
+            <MenuItem key={validOperation} value={validOperation}>
+              {validOperation.charAt(0).toUpperCase() + validOperation.slice(1)}
             </MenuItem>
           ))}
         </Select>

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -1,10 +1,8 @@
 import { Typography } from "@material-ui/core";
-import { useState } from "react";
 import CreateStateOperation from "./CreateStateOperation";
 import EditStateOperation from "./EditStateOperation";
 
 const StateOperationMenu = ({ component, componentIndex }) => {
-  const [stateOperations, setStateOperations] = useState(component.stateOperations || []);
 
   return (
     <div>
@@ -15,14 +13,16 @@ const StateOperationMenu = ({ component, componentIndex }) => {
         State Variables
       </Typography>
       <CreateStateOperation
+        component={component}
         componentIndex={componentIndex}
-        stateOperations={stateOperations}
-        setStateOperations={setStateOperations}
       />
-      {stateOperations.map((stateOperation) => (
+      {component.stateOperations && component.stateOperations.map((stateOperation, operationIndex) => (
         <EditStateOperation
+          componentIndex={componentIndex}
+          component={component}
+          operationIndex={operationIndex}
           stateOperation={stateOperation}
-          key={stateOperation}
+          key={operationIndex}
         />
       ))}
     </div>

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -1,16 +1,26 @@
 import { Typography } from "@material-ui/core";
 import { useState } from "react";
 import CreateStateOperation from "./CreateStateOperation";
+import EditStateOperation from "./EditStateOperation"
 
 const StateOperationMenu = () => {
   const [stateOperations, setStateOperations] = useState([]);
 
   return (
     <div>
-      <Typography variant="subtitle1" style={{ marginTop: "30px", marginBottom: "20px" }}>
+      <Typography
+        variant="subtitle1"
+        style={{ marginTop: "30px", marginBottom: "20px" }}
+      >
         State Variables
       </Typography>
-      <CreateStateOperation />
+      <CreateStateOperation
+        stateOperations={stateOperations}
+        setStateOperations={setStateOperations}
+      />
+      {stateOperations.map((stateOperation) => (
+        <EditStateOperation stateOperation={stateOperation} key={stateOperation} />
+      ))}
     </div>
   );
 };

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -1,0 +1,27 @@
+import { Button, Typography } from "@material-ui/core";
+import { useState } from "react";
+import StateOperationForm from "./StateOperationForm";
+
+const StateOperationMenu = () => {
+  const [stateOperations, setStateOperations] = useState([]);
+
+  const addOperation = () => {
+    setStateOperations([...stateOperations, {}]);
+  };
+
+  return (
+    <div>
+      <Typography variant="subtitle1" style={{ marginTop: "30px" }}>
+        State Variables
+      </Typography>
+      <Button onClick={addOperation}>New Operation</Button>
+      <div style={{ marginTop: "16px" }}>
+        {stateOperations.map((stateOperator, index) => (
+          <StateOperationForm key={index} stateOperator={stateOperator} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default StateOperationMenu;

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -2,6 +2,11 @@ import { Typography } from "@material-ui/core";
 import CreateStateOperation from "./CreateStateOperation";
 import EditStateOperation from "./EditStateOperation";
 
+/**
+ * Component that houses state operation interface (methods for creating and editing)
+ *
+ * @component
+ */
 const StateOperationMenu = ({ component, componentIndex }) => {
   return (
     <div>
@@ -9,7 +14,7 @@ const StateOperationMenu = ({ component, componentIndex }) => {
         variant="subtitle1"
         style={{ marginTop: "30px", marginBottom: "20px" }}
       >
-        State Variables
+        State Operations
       </Typography>
       <CreateStateOperation
         component={component}

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -3,7 +3,6 @@ import CreateStateOperation from "./CreateStateOperation";
 import EditStateOperation from "./EditStateOperation";
 
 const StateOperationMenu = ({ component, componentIndex }) => {
-
   return (
     <div>
       <Typography
@@ -16,15 +15,16 @@ const StateOperationMenu = ({ component, componentIndex }) => {
         component={component}
         componentIndex={componentIndex}
       />
-      {component.stateOperations && component.stateOperations.map((stateOperation, operationIndex) => (
-        <EditStateOperation
-          componentIndex={componentIndex}
-          component={component}
-          operationIndex={operationIndex}
-          stateOperation={stateOperation}
-          key={operationIndex}
-        />
-      ))}
+      {component.stateOperations &&
+        component.stateOperations.map((stateOperation, operationIndex) => (
+          <EditStateOperation
+            componentIndex={componentIndex}
+            component={component}
+            operationIndex={operationIndex}
+            stateOperation={stateOperation}
+            key={operationIndex}
+          />
+        ))}
     </div>
   );
 };

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -1,25 +1,16 @@
-import { Button, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import { useState } from "react";
-import StateOperationForm from "./StateOperationForm";
+import CreateStateOperation from "./CreateStateOperation";
 
 const StateOperationMenu = () => {
   const [stateOperations, setStateOperations] = useState([]);
 
-  const addOperation = () => {
-    setStateOperations([...stateOperations, {}]);
-  };
-
   return (
     <div>
-      <Typography variant="subtitle1" style={{ marginTop: "30px" }}>
+      <Typography variant="subtitle1" style={{ marginTop: "30px", marginBottom: "20px" }}>
         State Variables
       </Typography>
-      <Button onClick={addOperation}>New Operation</Button>
-      <div style={{ marginTop: "16px" }}>
-        {stateOperations.map((stateOperator, index) => (
-          <StateOperationForm key={index} stateOperator={stateOperator} />
-        ))}
-      </div>
+      <CreateStateOperation />
     </div>
   );
 };

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -1,10 +1,10 @@
 import { Typography } from "@material-ui/core";
 import { useState } from "react";
 import CreateStateOperation from "./CreateStateOperation";
-import EditStateOperation from "./EditStateOperation"
+import EditStateOperation from "./EditStateOperation";
 
-const StateOperationMenu = () => {
-  const [stateOperations, setStateOperations] = useState([]);
+const StateOperationMenu = ({ component, componentIndex }) => {
+  const [stateOperations, setStateOperations] = useState(component.stateOperations || []);
 
   return (
     <div>
@@ -15,11 +15,15 @@ const StateOperationMenu = () => {
         State Variables
       </Typography>
       <CreateStateOperation
+        componentIndex={componentIndex}
         stateOperations={stateOperations}
         setStateOperations={setStateOperations}
       />
       {stateOperations.map((stateOperation) => (
-        <EditStateOperation stateOperation={stateOperation} key={stateOperation} />
+        <EditStateOperation
+          stateOperation={stateOperation}
+          key={stateOperation}
+        />
       ))}
     </div>
   );

--- a/frontend/src/features/authoring/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -262,7 +262,10 @@ export default function ButtonPropertiesComponent({
           }}
         />
       </FormControl>
-      <StateOperationMenu />
+      <StateOperationMenu
+        component={component}
+        componentIndex={componentIndex}
+      />
     </>
   );
 }

--- a/frontend/src/features/authoring/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/ComponentProperties/ButtonPropertiesComponent.jsx
@@ -19,6 +19,7 @@ import ColourPickerComponent from "../../components/ColourPickerComponent";
 import { ensureRgbObject } from "../../../../utils/colourUtils";
 
 import styles from "../CanvasSideBar.module.scss";
+import StateOperationMenu from "../../../../components/StateVariables/StateOperationMenu";
 
 const CustomTextField = CustomTextFieldStyles()(TextField);
 const CustomInputLabel = CustomInputLabelStyles()(InputLabel);
@@ -261,6 +262,7 @@ export default function ButtonPropertiesComponent({
           }}
         />
       </FormControl>
+      <StateOperationMenu />
     </>
   );
 }


### PR DESCRIPTION
## Describe the issue
We want to be able to create "state operations", these are objects that manipulate state variables when scenarios are played

## Describe the solution
This implements a basic solution by adding the state operation menu to button properties. Similar to the state variable menu, authors are able to create state variables and edit them at a later point.

State Operation Menu
<img width="300" height="1092" alt="image" src="https://github.com/user-attachments/assets/61899548-e8b1-467b-b7f6-d17a4c9ca08a" />

Creating State Operations
<img width="200" height="525" alt="image" src="https://github.com/user-attachments/assets/a0c46d3a-b069-4e53-bd35-191e5dab7e6d" />

Editing State Operations
<img width="200" height="519" alt="image" src="https://github.com/user-attachments/assets/70f68256-e55f-485c-9dc9-e3137bc1fee7" />

How it exists in MongoDB
<img width="500" height="868" alt="image" src="https://github.com/user-attachments/assets/9593cfda-f764-4fdc-85a4-3c81f369ece6" />

Here's an outline of the current component tree (green are the components added in this commit). I ended up trying to imitate the structure of state variable creation/editing since that seemed to work relatively effectively.
<img width="1761" height="827" alt="image" src="https://github.com/user-attachments/assets/ba2978ee-bc20-4129-a0e9-cb9487e1cbb0" />

Quick summary of new files
``StateOperationMenu.jsx`` - Houses the components for creating and editing state operations
``CreateStateOperation.jsx`` - Allows users to create state operations
``EditStateOperation.jsx`` - Allows users to edit state operations
``StateOperationForm.jsx`` - Contains form fields that used by both ``CreateStateOperation.jsx`` and ``EditStateOperation.jsx``
``Operations.jsx`` - Contains an array of valid state operations for each state type
``EditingTooltips.jsx`` - Contains reset, save, and delete tooltips used by both ``EditStateOperation.jsx`` and ``EditStateVariables.jsx``

Summary of changed files
``ButtonPropertiesComponent.jsx`` - Added ``StateOperationMenu.jsx`` component for authors to see and use
``EditStateVariables.jsx`` - Moved code out and into ``EditingTooltips.jsx``

Please note that in the first commit, I had intended to create the feature using a slightly different method, so some of the design choices should be ignored since they get changed later.

## Risk
This PR is already really big, so I think it's good to make a checkpoint here. That being said, there's a lot of issues associated with editing and deleting state variables that should probably be solved before we start adding more state types
* If a state variable name is changed then there will be a desync between it and the names of its operations (maybe we should use a UUID instead to store and track state variables?)
* If a state variable type is changed then existing operations may no longer be able to perform the associated operation type on the state variable (e.g. if a state variable of type Number gets changed to a state variable of type String, an associated state operation that tries to add to the state variable will likely cause an error since you can't add to a String)
* If a state variable is deleted, its operations will continue to exist when they should be deleted as well
* Also, the save button when editing state operations may be a little misleading since it only saves the operation for the button locally (so that clicking off and back on will persist the changed state). Syncing with backend only happens when the scene is saved (either by pressing one of the save buttons or navigating to a different scene.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
