### PR TITLE
Prevent duplicate scene naming

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -14,7 +14,10 @@ import { withStyles } from "@material-ui/core/styles";
 import { useContext, useState, useEffect } from "react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
-import { isSceneNameDuplicate, generateUniqueSceneName } from '../../../utils/sceneUtils';
+import {
+  isSceneNameDuplicate,
+  generateUniqueSceneName,
+} from "../../../utils/sceneUtils";
 
 import styles from "./CanvasSideBar.module.scss";
 import CustomInputLabelStyles from "./CustomPropertyInputStyles/CustomInputLabelStyles";
@@ -41,10 +44,11 @@ const CustomTextField = withStyles({
  * @component
  */
 export default function SceneSettings() {
-  const { currentScene, setCurrentScene, scenes, reFetch } = useContext(SceneContext);
+  const { currentScene, setCurrentScene, scenes, reFetch } =
+    useContext(SceneContext);
   const { roleList } = useContext(ScenarioContext);
   const [selectedRoles, setSelectedRoles] = useState([]);
-  const [originalSceneName, setOriginalSceneName] = useState('');
+  const [originalSceneName, setOriginalSceneName] = useState("");
 
   const [checked, setChecked] = useState([]);
   const [allChecked, setAllChecked] = useState(false);
@@ -93,8 +97,8 @@ export default function SceneSettings() {
 
   const saveSceneName = async (newName) => {
     // Check for empty name first
-    if (!newName || newName.trim() === '') {
-      alert('Scene name cannot be empty.');
+    if (!newName || newName.trim() === "") {
+      alert("Scene name cannot be empty.");
       setCurrentScene({
         ...currentScene,
         name: originalSceneName,
@@ -104,15 +108,20 @@ export default function SceneSettings() {
 
     // Check for duplicates and auto-fix
     let finalName = newName.trim();
-    
-    console.log('Checking duplicate for:', finalName);
-    console.log('Current scene ID:', currentScene._id);
-    console.log('All scenes:', scenes.map(s => ({ id: s._id, name: s.name })));
-    
+
+    console.log("Checking duplicate for:", finalName);
+    console.log("Current scene ID:", currentScene._id);
+    console.log(
+      "All scenes:",
+      scenes.map((s) => ({ id: s._id, name: s.name }))
+    );
+
     if (isSceneNameDuplicate(finalName, scenes, currentScene._id)) {
-      console.log('Duplicate found, generating unique name...');
+      console.log("Duplicate found, generating unique name...");
       finalName = generateUniqueSceneName(scenes, finalName);
-      alert(`Scene name "${newName}" already exists. Changed to "${finalName}".`);
+      alert(
+        `Scene name "${newName}" already exists. Changed to "${finalName}".`
+      );
       // Update the local state with the corrected name
       setCurrentScene({
         ...currentScene,
@@ -132,7 +141,7 @@ export default function SceneSettings() {
       },
       getUserIdToken
     );
-    
+
     // Refresh the scenes data
     reFetch();
   };
@@ -187,9 +196,8 @@ export default function SceneSettings() {
             }}
             onBlur={(event) => {
               const currentValue = event.target.value.trim();
-  
+
               saveSceneName(currentValue);
-              
             }}
           />
           {/* input for scene roles */}

--- a/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
+++ b/frontend/src/features/sceneSelection/SceneSelectionPage.jsx
@@ -28,11 +28,11 @@ import {
 } from "../../hooks/crudHooks";
 import AuthoringToolPage from "../authoring/AuthoringToolPage";
 
-import { 
-  generateUniqueSceneName, 
-  isSceneNameDuplicate, 
-  generateDuplicateSceneName 
-} from '../../utils/sceneUtils';
+import {
+  generateUniqueSceneName,
+  isSceneNameDuplicate,
+  generateDuplicateSceneName,
+} from "../../utils/sceneUtils";
 
 // !! this should be handled by the backend instead
 function generateUID() {
@@ -122,7 +122,7 @@ export function SceneSelectionPage() {
   /** called when the Add card is clicked */
   async function createNewScene() {
     const uniqueName = generateUniqueSceneName(scenes, "Scene");
-    
+
     await usePost(
       `/api/scenario/${scenarioId}/scene`,
       {
@@ -158,7 +158,7 @@ export function SceneSelectionPage() {
   /** called when Duplicate button is clicked */
   async function duplicateScene() {
     const duplicateName = generateDuplicateSceneName(currentScene.name, scenes);
-    
+
     await usePost(
       `/api/scenario/${scenarioId}/scene/duplicate/${currentScene._id}`,
       { name: duplicateName },
@@ -188,25 +188,27 @@ export function SceneSelectionPage() {
   /** called when user unfocuses from a scene name */
   async function changeSceneName({ target }) {
     const newName = target.value.trim();
-    
+
     // check for empty name
     if (newName === "" || newName === null) {
       target.value = currentScene.name;
       setInvalidNameId(currentScene._id);
       return;
     }
-    
+
     // check for duplicate name and auto-generate unique name
     let finalName = newName;
     if (isSceneNameDuplicate(newName, scenes, currentScene._id)) {
       finalName = generateUniqueSceneName(scenes, newName);
       target.value = finalName;
-      alert(`Scene name "${newName}" already exists. Changed to "${finalName}".`);
+      alert(
+        `Scene name "${newName}" already exists. Changed to "${finalName}".`
+      );
     }
-    
+
     //  we get here the name is valid
     setInvalidNameId("");
-    
+
     await usePut(
       `/api/scenario/${scenarioId}/scene/${currentScene._id}`,
       {

--- a/frontend/src/utils/sceneUtils.js
+++ b/frontend/src/utils/sceneUtils.js
@@ -2,36 +2,33 @@
  * Utility functions for scene name management
  */
 
-
 /**
  * Generates a unique scene name by checking existing scene names
  * @param {Array} scenes - Array of existing scenes
  * @param {String} baseName - Base name to use (default: "Scene")
  * @returns {String} - Unique scene name
  */
-export function generateUniqueSceneName(scenes, baseName = "Scene"){
+export function generateUniqueSceneName(scenes, baseName = "Scene") {
+  // handle empty or non-eixting scenes array
+  if (!scenes || scenes.length === 0) {
+    return `${baseName} 1`;
+  }
 
-    // handle empty or non-eixting scenes array
-    if (!scenes || scenes.length === 0) {
-        return `${baseName} 1`;
-    }
-    
-    // get all existing names, filtering out invalid scenes
-    const existingNames = scenes
-        .filter(scene => scene && scene.name && typeof scene.name === 'string')
-        .map(scene => scene.name.toLowerCase().trim());
+  // get all existing names, filtering out invalid scenes
+  const existingNames = scenes
+    .filter((scene) => scene && scene.name && typeof scene.name === "string")
+    .map((scene) => scene.name.toLowerCase().trim());
 
+  let counter = 1;
+  let newName = `${baseName} ${counter}`;
 
-    let counter = 1;
-    let newName = `${baseName} ${counter}`;
-    
-    // keep adding until we get a unique name
-    while (existingNames.includes(newName.toLowerCase())) {
-        counter++;
-        newName = `${baseName} ${counter}`;
-    }
-    
-    return newName;
+  // keep adding until we get a unique name
+  while (existingNames.includes(newName.toLowerCase())) {
+    counter++;
+    newName = `${baseName} ${counter}`;
+  }
+
+  return newName;
 }
 
 /**
@@ -42,28 +39,28 @@ export function generateUniqueSceneName(scenes, baseName = "Scene"){
  * @returns {Boolean} - True if name already exists
  */
 export function isSceneNameDuplicate(name, scenes, excludeId = null) {
-    // handle empty or non-existing scenes array
-    if (!scenes || scenes.length === 0) {
-        console.log("Invalid scenes or name provided for duplicate checking");
-        return false;
-    }
-
-    // normalise the name to check
-    const normalisedName = name ? name.toLowerCase().trim() : '';
-
-    for (const scene of scenes) {
-        // skip the scene if its ID matches the excludeId
-        if (scene._id === excludeId) {
-            continue;
-        }
-
-        // check if the scene name matches the normalised name
-        if (scene.name && scene.name.toLowerCase().trim() === normalisedName) {
-            return true;
-        }
-    }
-
+  // handle empty or non-existing scenes array
+  if (!scenes || scenes.length === 0) {
+    console.log("Invalid scenes or name provided for duplicate checking");
     return false;
+  }
+
+  // normalise the name to check
+  const normalisedName = name ? name.toLowerCase().trim() : "";
+
+  for (const scene of scenes) {
+    // skip the scene if its ID matches the excludeId
+    if (scene._id === excludeId) {
+      continue;
+    }
+
+    // check if the scene name matches the normalised name
+    if (scene.name && scene.name.toLowerCase().trim() === normalisedName) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -73,32 +70,28 @@ export function isSceneNameDuplicate(name, scenes, excludeId = null) {
  * @returns {String} - Unique name for the duplicate
  */
 export function generateDuplicateSceneName(originalName, scenes) {
-    // Validate original name
-    if (!originalName || typeof originalName !== 'string') {
-        return 'Untitled Copy';
-    }
-    
-    // Handle empty scenes array
-    if (!scenes || scenes.length === 0) {
-        return `${originalName} Copy`;
-    }
-    
- 
-    const existingNames = scenes
-        .filter(scene => scene && scene.name && typeof scene.name === 'string')
-        .map(scene => scene.name.toLowerCase().trim());
-    
-    let counter = 1;
-    let newName = `${originalName} Copy`;
-    
-    // if copy is taken add numberss
-    while (existingNames.includes(newName.toLowerCase())) {
-        counter++;
-        newName = `${originalName} Copy ${counter}`;
-    }
-    
-    return newName;
+  // Validate original name
+  if (!originalName || typeof originalName !== "string") {
+    return "Untitled Copy";
+  }
+
+  // Handle empty scenes array
+  if (!scenes || scenes.length === 0) {
+    return `${originalName} Copy`;
+  }
+
+  const existingNames = scenes
+    .filter((scene) => scene && scene.name && typeof scene.name === "string")
+    .map((scene) => scene.name.toLowerCase().trim());
+
+  let counter = 1;
+  let newName = `${originalName} Copy`;
+
+  // if copy is taken add numberss
+  while (existingNames.includes(newName.toLowerCase())) {
+    counter++;
+    newName = `${originalName} Copy ${counter}`;
+  }
+
+  return newName;
 }
-
-
-

--- a/frontend/src/utils/sceneUtils.js
+++ b/frontend/src/utils/sceneUtils.js
@@ -1,0 +1,104 @@
+/**
+ * Utility functions for scene name management
+ */
+
+
+/**
+ * Generates a unique scene name by checking existing scene names
+ * @param {Array} scenes - Array of existing scenes
+ * @param {String} baseName - Base name to use (default: "Scene")
+ * @returns {String} - Unique scene name
+ */
+export function generateUniqueSceneName(scenes, baseName = "Scene"){
+
+    // handle empty or non-eixting scenes array
+    if (!scenes || scenes.length === 0) {
+        return `${baseName} 1`;
+    }
+    
+    // get all existing names, filtering out invalid scenes
+    const existingNames = scenes
+        .filter(scene => scene && scene.name && typeof scene.name === 'string')
+        .map(scene => scene.name.toLowerCase().trim());
+
+
+    let counter = 1;
+    let newName = `${baseName} ${counter}`;
+    
+    // keep adding until we get a unique name
+    while (existingNames.includes(newName.toLowerCase())) {
+        counter++;
+        newName = `${baseName} ${counter}`;
+    }
+    
+    return newName;
+}
+
+/**
+ * Checks if a scene name already exists (case-insensitive)
+ * @param {String} name - Name to check
+ * @param {Array} scenes - Array of existing scenes
+ * @param {String} excludeId - Scene ID to exclude from check (for editing)
+ * @returns {Boolean} - True if name already exists
+ */
+export function isSceneNameDuplicate(name, scenes, excludeId = null) {
+    // handle empty or non-existing scenes array
+    if (!scenes || scenes.length === 0) {
+        console.log("Invalid scenes or name provided for duplicate checking");
+        return false;
+    }
+
+    // normalise the name to check
+    const normalisedName = name ? name.toLowerCase().trim() : '';
+
+    for (const scene of scenes) {
+        // skip the scene if its ID matches the excludeId
+        if (scene._id === excludeId) {
+            continue;
+        }
+
+        // check if the scene name matches the normalised name
+        if (scene.name && scene.name.toLowerCase().trim() === normalisedName) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Generates a unique name for a duplicated scene
+ * @param {String} originalName - Original scene name
+ * @param {Array} scenes - Array of existing scenes
+ * @returns {String} - Unique name for the duplicate
+ */
+export function generateDuplicateSceneName(originalName, scenes) {
+    // Validate original name
+    if (!originalName || typeof originalName !== 'string') {
+        return 'Untitled Copy';
+    }
+    
+    // Handle empty scenes array
+    if (!scenes || scenes.length === 0) {
+        return `${originalName} Copy`;
+    }
+    
+ 
+    const existingNames = scenes
+        .filter(scene => scene && scene.name && typeof scene.name === 'string')
+        .map(scene => scene.name.toLowerCase().trim());
+    
+    let counter = 1;
+    let newName = `${originalName} Copy`;
+    
+    // if copy is taken add numberss
+    while (existingNames.includes(newName.toLowerCase())) {
+        counter++;
+        newName = `${originalName} Copy ${counter}`;
+    }
+    
+    return newName;
+}
+
+
+


### PR DESCRIPTION
## Describe the issue

Scene names were not checked properly, leading to some names being duplicated. 

## Describe the solution

Created a utils file that checks to see the uniqueness/duplicates for each name, make it so that work for every type of scene naming/changing.

## Risk

It may mess with the the naming conventions, but otherwise it should work.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
