### PR TITLE
feat: add path navigator & table for state variable

### DIFF
--- a/frontend/src/features/dashboard/Dashboard.jsx
+++ b/frontend/src/features/dashboard/Dashboard.jsx
@@ -37,7 +37,7 @@ export default function Dashboard() {
     // Placeholder here, needs an update for when the group completes a scenario it sets a var in the database, probs alr exist but will implement this later
     const groupsCompleted = 0;
     return (
-      <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <div className="bg-white col-auto border rounded-xl p-2 text-center">
           <h3 className="text-xl font-mona font-bold">Groups</h3>
           <p className="text-lg">{totalGroups}</p>
@@ -50,14 +50,9 @@ export default function Dashboard() {
           <h3 className="text-xl font-mona font-bold ">Started</h3>
           <p className="text-lg">{groupsStarted}</p>
         </div>
-        <div className="bg-green-300 col-auto border rounded-xl p-2 text-center">
-          <h3 className="text-xl font-mona font-bold">Completed</h3>
-          <p className="text-lg">{groupsCompleted}</p>
-        </div>
       </div>
     );
   };
-  // Is it better to just show a loading screen instead of conditionally rendering the content to stop it flashing?
   /**
    * Is it better to just show a loading screen instead of conditionally rendering the content to stop it
    * flashing?

--- a/frontend/src/features/dashboard/Dashboard.jsx
+++ b/frontend/src/features/dashboard/Dashboard.jsx
@@ -35,7 +35,6 @@ export default function Dashboard() {
       (group) => group.path.length != 0
     ).length;
     // Placeholder here, needs an update for when the group completes a scenario it sets a var in the database, probs alr exist but will implement this later
-    const groupsCompleted = 0;
     return (
       <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <div className="bg-white col-auto border rounded-xl p-2 text-center">

--- a/frontend/src/features/dashboard/ViewGroup.jsx
+++ b/frontend/src/features/dashboard/ViewGroup.jsx
@@ -10,6 +10,20 @@ import { MarkerType, ReactFlowProvider } from "@xyflow/react";
 import ScenarioGraph from "./components/Graph";
 import TestTable from "./components/Table";
 import { Skeleton } from "@mui/material";
+
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TableFooter from "@mui/material/TableFooter";
+import TablePagination from "@mui/material/TablePagination";
+import { Paper, Typography } from "@material-ui/core";
+import TablePaginationActions from "./components/TablePaginationAction";
+import useStyles from "./components/TableStyle";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import getComparator from "./components/TableHelper";
 /**
  * Might move this logic to it's own file, this way we can render a basic path on the dasboard as well
  * as the viewgroup page.
@@ -28,7 +42,7 @@ export default function ViewGroupPage() {
     height: 15,
   };
 
-  const { nodes, edges, groupEdges } = useMemo(() => {
+  const { nodes, edges, groupEdges, groupPath, sceneMap } = useMemo(() => {
     var sceneMap = [];
     var groupPath = [];
     const nodes = [];
@@ -58,6 +72,7 @@ export default function ViewGroupPage() {
             components: scene.components,
             visited: visitCounter.get(scene._id) != undefined,
             visitCounter: visitCounter.get(scene._id),
+            isHighlighted: false,
           },
         });
       });
@@ -116,8 +131,9 @@ export default function ViewGroupPage() {
       edge.data = { label: edgeCounter.get(edge.id) };
     });
 
-    return { nodes, edges, groupEdges };
+    return { nodes, edges, groupEdges, groupPath, sceneMap };
   }, [scenes, groupInfo]);
+
   return (
     <ScreenContainer vertical>
       <DashTopBar back={`/dashboard/${scenarioId}`}>
@@ -129,7 +145,9 @@ export default function ViewGroupPage() {
             <h1 className="text-3xl font-mona font-bold my-3">
               Viewing Group {groupInfo.users[0].group}
             </h1>
+
             <TestTable groupInfo={groupInfo} />
+            <StateVarTable data={groupInfo.stateVariables} />
           </div>
           <div className="w-full h-full">
             <h1 className="text-3xl font-mona font-bold px-10 my-3">
@@ -161,6 +179,8 @@ export default function ViewGroupPage() {
                         inNodes={nodes}
                         inEdges={edges}
                         inGPathEdges={groupEdges}
+                        inGPath={groupPath}
+                        inSceneMap={sceneMap}
                         onLoaded={() => {
                           setGraphLoading(false);
                         }}
@@ -175,3 +195,142 @@ export default function ViewGroupPage() {
     </ScreenContainer>
   );
 }
+
+const StateVarTable = ({ data }) => {
+  const classes = useStyles();
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const emptyRows =
+    page > 0 ? Math.max(0, (1 + page) * rowsPerPage - data.length) : 0;
+  const [order, setOrder] = useState("asc");
+  const [orderBy, setOrderBy] = useState("name");
+
+  const handleRequestSort = (property) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const visibleRows = useMemo(
+    () =>
+      [...data]
+        .sort(getComparator(order, orderBy))
+        .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [order, orderBy, page, rowsPerPage]
+  );
+
+  const PaperContainer = ({ children }) => (
+    <div className={classes.root}>
+      <Paper>
+        <Typography variant="h5" component="h1" className={classes.heading}>
+          State Variables
+        </Typography>
+        {children}
+      </Paper>
+    </div>
+  );
+  if (data.length == 0) {
+    return (
+      <PaperContainer>
+        <div>
+          State variables will show up once the group has scdtarted the
+          scenario.
+        </div>
+      </PaperContainer>
+    );
+  } else {
+    return (
+      <PaperContainer>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <TableSortLabel
+                    active={orderBy === "name"}
+                    direction={orderBy === "name" ? order : "asc"}
+                    onClick={() => handleRequestSort("name")}
+                  >
+                    Name
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={orderBy === "type"}
+                    direction={orderBy === "type" ? order : "asc"}
+                    onClick={() => handleRequestSort("type")}
+                  >
+                    Type
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={orderBy === "value"}
+                    direction={orderBy === "value" ? order : "asc"}
+                    onClick={() => handleRequestSort("value")}
+                  >
+                    Value
+                  </TableSortLabel>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {visibleRows.map((stateVar) => (
+                <TableRow key={stateVar.id}>
+                  <TableCell>{stateVar.name}</TableCell>
+                  <TableCell>{stateVar.type}</TableCell>
+                  <TableCell>
+                    {stateVar.type === "boolean"
+                      ? stateVar.value
+                        ? "True"
+                        : "False"
+                      : stateVar.value}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {emptyRows > 0 && (
+                <TableRow style={{ height: 53 * emptyRows }}>
+                  <TableCell colSpan={3} />
+                </TableRow>
+              )}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TablePagination
+                  rowsPerPageOptions={[
+                    5,
+                    10,
+                    25,
+                    { label: "All", value: data.length },
+                  ]}
+                  colSpan={3}
+                  count={data.length}
+                  rowsPerPage={rowsPerPage}
+                  page={page}
+                  slotProps={{
+                    select: {
+                      inputProps: {
+                        "aria-label": "rows per page",
+                      },
+                      native: true,
+                    },
+                  }}
+                  onPageChange={handleChangePage}
+                  onRowsPerPageChange={handleChangeRowsPerPage}
+                  ActionsComponent={TablePaginationActions}
+                />
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </TableContainer>
+      </PaperContainer>
+    );
+  }
+};

--- a/frontend/src/features/dashboard/ViewGroup.jsx
+++ b/frontend/src/features/dashboard/ViewGroup.jsx
@@ -10,7 +10,6 @@ import { MarkerType, ReactFlowProvider } from "@xyflow/react";
 import ScenarioGraph from "./components/Graph";
 import TestTable from "./components/Table";
 import { Skeleton } from "@mui/material";
-
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";

--- a/frontend/src/features/dashboard/components/CustomTypes.jsx
+++ b/frontend/src/features/dashboard/components/CustomTypes.jsx
@@ -6,7 +6,7 @@ import { Badge } from "@material-ui/core";
 
 const NodeBase = ({ data }) => (
   <div
-    className={`bg-black w-40 text-center ${data.visited ? "" : "brightness-60"}`}
+    className={`bg-black w-40 text-center ${data.visited ? "" : "brightness-60"} ${data.isHighlighted ? "border-red-500 border-4" : ""}`}
   >
     <div>
       <Thumbnail components={data.components} />

--- a/frontend/src/features/dashboard/components/DashTopBar.jsx
+++ b/frontend/src/features/dashboard/components/DashTopBar.jsx
@@ -26,7 +26,6 @@ export default function DashTopBar({ back = "/", children = [] }) {
       <div className={styles.topBar}>
         <ul className={styles.leftTopBarList}>
           <li className={styles.listItem}>
-            (
             <button
               className="btn vps w-[100px]"
               onClick={() => {
@@ -35,7 +34,6 @@ export default function DashTopBar({ back = "/", children = [] }) {
             >
               Back
             </button>
-            )
           </li>
         </ul>
         <div className={styles.rightTopBarList}>{children}</div>

--- a/frontend/src/features/dashboard/components/TableHelper.js
+++ b/frontend/src/features/dashboard/components/TableHelper.js
@@ -1,0 +1,65 @@
+function descendingComparator(a, b, orderBy) {
+  // Groups
+  if (orderBy === "groupNum") {
+    if (b.users[0].group < a.users[0].group) return -1;
+    if (b.users[0].group > a.users[0].group) return 1;
+    return 0;
+  }
+
+  if (orderBy === "groupSize") {
+    if (b.users.length < a.users.length) return -1;
+    if (b.users.length > a.users.length) return 1;
+    return 0;
+  }
+  if (orderBy === "groupStarted") {
+    const aStarted = a.path.length > 0;
+    const bStarted = b.path.length > 0;
+    if (bStarted < aStarted) return -1;
+    if (bStarted > aStarted) return 1;
+    return 0;
+  }
+
+  // Members (except name which is also for state variables)
+  if (orderBy === "name") {
+    if (b.name < a.name) return -1;
+    if (b.name > a.name) return 1;
+    return 0;
+  }
+  if (orderBy === "email") {
+    if (b.email < a.email) return -1;
+    if (b.email > a.email) return 1;
+    return 0;
+  }
+  if (orderBy === "role") {
+    if (b.role < a.role) return -1;
+    if (b.role > a.role) return 1;
+    return 0;
+  }
+
+  // State Variables
+  if (orderBy === "type") {
+    if (b.type < a.type) return -1;
+    if (b.type > a.type) return 1;
+    return 0;
+  }
+  if (orderBy === "value") {
+    /**
+     * Could be uncommented for number grouping when sorting?
+     * Could also add in bool? to group them?
+     */
+    // const aIsNumber = typeof a.value === "number";
+    // const bIsNumber = typeof b.value === "number";
+    // if(aIsNumber && !bIsNumber) return -1;
+    // if(!aIsNumber && bIsNumber) return 1;
+    if (b.value < a.value) return -1;
+    if (b.value > a.value) return 1;
+    return 0;
+  }
+  return 0;
+}
+
+export default function getComparator(order, orderBy) {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}

--- a/frontend/src/features/dashboard/components/TablePaginationAction.jsx
+++ b/frontend/src/features/dashboard/components/TablePaginationAction.jsx
@@ -1,0 +1,63 @@
+/**
+ * https://mui.com/material-ui/react-table/#custom-pagination-actions
+ */
+
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import FirstPageIcon from "@mui/icons-material/FirstPage";
+import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
+import LastPageIcon from "@mui/icons-material/LastPage";
+
+export default function TablePaginationActions(props) {
+  const { count, page, rowsPerPage, onPageChange } = props;
+
+  const handleFirstPageButtonClick = (event) => {
+    onPageChange(event, 0);
+  };
+
+  const handleBackButtonClick = (event) => {
+    onPageChange(event, page - 1);
+  };
+
+  const handleNextButtonClick = (event) => {
+    onPageChange(event, page + 1);
+  };
+
+  const handleLastPageButtonClick = (event) => {
+    onPageChange(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
+  };
+
+  return (
+    <Box sx={{ flexShrink: 0, ml: 2.5 }}>
+      <IconButton
+        onClick={handleFirstPageButtonClick}
+        disabled={page === 0}
+        aria-label="first page"
+      >
+        <FirstPageIcon />
+      </IconButton>
+      <IconButton
+        onClick={handleBackButtonClick}
+        disabled={page === 0}
+        aria-label="previous page"
+      >
+        <KeyboardArrowLeft />
+      </IconButton>
+      <IconButton
+        onClick={handleNextButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        aria-label="next page"
+      >
+        <KeyboardArrowRight />
+      </IconButton>
+      <IconButton
+        onClick={handleLastPageButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        aria-label="last page"
+      >
+        <LastPageIcon />
+      </IconButton>
+    </Box>
+  );
+}

--- a/frontend/src/features/dashboard/components/TableStyle.js
+++ b/frontend/src/features/dashboard/components/TableStyle.js
@@ -1,0 +1,17 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: "5vh",
+    display: "flex",
+    justifyContent: "center",
+    overflowX: "auto",
+    width: "100%",
+  },
+  heading: {
+    fontWeight: "bold",
+    marginBottom: "1rem",
+    textAlign: "center",
+  },
+});
+export default useStyles;


### PR DESCRIPTION
## Describe the issue

The author has no way to tell the exact path students took if the students backtracked. They also don't have a way to view the state variables of the group.

## Describe the solution
- Added a path navigator to the graph, which allows the user to step through the path of the group, highlighting the node (could maybe add play pause for auto step-through in future)
- Added a table under the group member table that displays the state variables of the group.

## Risk

Potential risks that this PR might brings

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
