### PR TITLE
PDF rendering for resources

### DIFF
--- a/frontend/src/features/playScenario/components/ResourcePreview.jsx
+++ b/frontend/src/features/playScenario/components/ResourcePreview.jsx
@@ -63,6 +63,7 @@ export default function ResourcePreview({ file, getDownloadUrl }) {
   }
 
   const isImage = file.type?.startsWith("image/");
+  const isPDF = file.type === "application/pdf";
   const isText =
     file.type?.startsWith("text/") || /json|xml|csv/.test(file.type || "");
 
@@ -95,6 +96,14 @@ export default function ResourcePreview({ file, getDownloadUrl }) {
               src={url}
               alt={file.name}
               className="rounded-xl max-h-[60vh] object-contain mx-auto"
+            />
+          </div>
+        ) : isPDF && url ? (
+          <div className="w-full h-full">
+            <iframe
+              src={url}
+              title={file.name}
+              className="w-full h-full min-h-[60vh] rounded-xl border"
             />
           </div>
         ) : isText && url ? (


### PR DESCRIPTION
## Describe the issue
The current ResourcePreview component does not support previewing PDF files, which limits the user's ability to view common document types directly within the interface.

## Describe the solution
This pull request adds support for detecting and previewing PDF files within the ResourcePreview component. If the file type is identified as "application/pdf", the component now renders the file using an embedded <iframe>, enabling inline PDF viewing without downloading.

## Risk
- Embedding PDFs via <iframe> may have inconsistent behavior across browsers or devices.
- Potential for increased load times or rendering issues with large PDF files.
- Security risks if the PDF source URL is not properly sanitized or validated.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
