### PR TITLE
chore(actions): rename secrets

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Deploy Frontend to Fly.io
         run: >
           flyctl deploy --remote-only --config fly.toml
-          --build-arg VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }}
-          --build-arg VITE_FIREBASE_API_KEY=${{ secrets.VITE_REACT_APP_API_KEY }}
-          --build-arg VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_REACT_APP_AUTH_DOMAIN }}
-          --build-arg VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_REACT_APP_STORAGE_BUCKET }}
-          --build-arg VITE_FIREBASE_APP_ID=${{ secrets.VITE_REACT_APP_APP_ID }}
-          --build-arg VITE_SERVER_URL=${{ secrets.VITE_REACT_APP_SERVER_URL_PRODUCTION }}
+          --build-arg VITE_FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+          --build-arg VITE_FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}
+          --build-arg VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          --build-arg VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          --build-arg VITE_FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}
+          --build-arg VITE_SERVER_URL=${{ secrets.SERVER_URL }}
         working-directory: ./frontend
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_API_TOKEN }}


### PR DESCRIPTION
## Issue

The gh deployment action sends a bunch of secrets (from the repo environment) to fly, and the naming is inconsistent.

## Solution

Renamed the secrets in the gh environment and hence in the gh action.

## Risk

The deployment might fail if I've messed something up
