### PR TITLE
docs: update deployment url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub contributors from allcontributors.org](https://img.shields.io/github/all-contributors/UoaWDCC/VPS?style=for-the-badge&color=orange)
 ![GitHub commit activity (branch)](https://img.shields.io/github/commit-activity/t/UoaWDCC/VPS/master?style=for-the-badge)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr-closed-raw/UoaWDCC/VPS?style=for-the-badge)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/UoaWDCC/VPS/deploy.staging.yml?style=for-the-badge)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/UoaWDCC/VPS/fly-deploy.yml?style=for-the-badge)
 
 This project aims to provide students and faculty at the University of Auckland with a tool that supports interactive and immersive education through scene based branching scenarios.
 
@@ -12,10 +12,9 @@ This project aims to provide students and faculty at the University of Auckland 
 
 This project was initally associated with The University of Auckland SOFTENG 761 in 2021, but since 2022, is being developed by WDCC project teams. The repo located here for this project is a bare clone of the original repo, which no longer exists. The project has grown immensely over that time, and the result you can see here is a culmination of the hard work of all of the many teams who put hundreds of collective hours into this each year.
 
-# Live deployments
+# Live deployment
 
--   Production: https://wdcc-vps.fly.dev/
--   Staging: https://wdcc-vps-staging.fly.dev/
+The deployment of this project is done using fly.io, you can access the latest at [vps.wdcc.co.nz](https://vps.wdcc.co.nz/).
 
 # Contributing
 

--- a/wiki/VPS Home.md
+++ b/wiki/VPS Home.md
@@ -8,8 +8,7 @@ Welcome to the documentation home for the Virtual Patient Simulator (VPS) projec
 ## Useful Links
 
 - [Github Repository](https://github.com/UoaWDCC/VPS)
-- [Live Staging Deployment](https://wdcc-vps-staging.fly.dev/)
-- [Production Deployment](https://wdcc-vps.fly.dev/)
+- [Live Deployment](https://vps.wdcc.co.nz/)
 
 ## Wiki Structure
 


### PR DESCRIPTION
## Issue

Deployment URLs are incorrect

## Solution

Updated them to vps.wdcc.co.nz

## Risk

None

## Checklist

- [x] Wiki documentation is written and up to date
