### PR TITLE
fix: move path prefix into libdoc settings

### DIFF
--- a/learn/package.json
+++ b/learn/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "build": "eleventy --pathprefix=/VPS/",
+    "build": "eleventy",
     "dev": "eleventy --serve"
   },
   "dependencies": {

--- a/learn/settings.json
+++ b/learn/settings.json
@@ -3,5 +3,6 @@
   "siteDescription": "Virtual Patient Simulator learning resources",
   "faviconUrl": "/assets/myfavicon.png",
   "productionUrl": "https://uoawdcc.github.io/VPS/",
-  "editThisPageRootUrl": "https://github.com/UoaWDCC/VPS/tree/master/learn"
+  "editThisPageRootUrl": "https://github.com/UoaWDCC/VPS/tree/master/learn",
+  "htmlBasePathPrefix": "/VPS/"
 }


### PR DESCRIPTION
## Issue

Asset files are not loading. This is because the path prefix of /VPS/, which is required since gh pages serves at that subpath, is defined for eleventy output but not for static assets. This means that the document is trying to fetch them using the wrong path.

## Solution

Moved the /VPS/ path prefix, which was defined in the eleventy build step, to the libdoc settings, which will append the prefix to the asset files as well.

## Risk

No risks.

## Checklist

- [ ] Acceptance criteria met
