### PR TITLE
fix: deselect component after delete via context

### DIFF
--- a/frontend/src/features/authoring/handlers/pointer/ComponentContext.tsx
+++ b/frontend/src/features/authoring/handlers/pointer/ComponentContext.tsx
@@ -13,8 +13,14 @@ import {
   sendBackward,
   sendToBack,
 } from "../../scene/operations/component";
+import useEditorStore from "../../stores/editor";
 
 const ComponentMenu = ({ id }: { id: string }) => {
+  function removeAndDeselect(id: string) {
+    remove(id);
+    useEditorStore.getState().setSelected(null);
+  }
+
   return (
     <ul className="menu bg-base-200 rounded-box w-fit">
       <li>
@@ -24,7 +30,7 @@ const ComponentMenu = ({ id }: { id: string }) => {
         </a>
       </li>
       <li>
-        <a onClick={handle(remove, id)}>
+        <a onClick={handle(removeAndDeselect, id)}>
           <Trash2Icon size={16} />
           Delete
         </a>


### PR DESCRIPTION
## Issue

After deleting a component using the context menu, the selection stays on the deleted element, causing a crash shortly after.

## Solution

Deselected the element in the editor state store directly after the delete.

## Risk

No risks.

## Checklist

- [x] Acceptance criteria met
- [ ] Continuous integration build passing
