### PR TITLE
feat: upload indicator for images

### DIFF
--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -83,7 +83,7 @@ function Canvas() {
         onContextMenu={handleContextMenu}
       >
         <Overlay />
-        <LoadingOverlay />
+        {loading && <LoadingOverlay />}
 
         {/* scene outline */}
         <svg

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -16,6 +16,8 @@ import {
 } from "../handlers/pointer/pointer";
 import { handleContextGlobal } from "../handlers/pointer/context";
 import { handleGlobal } from "../handlers/keyboard/keyboard";
+import LoadingOverlay from "./LoadingOverlay.tsx";
+import useEditorStore from "../stores/editor.ts";
 
 const componentMap: Record<string, React.FC<any>> = {
   textbox: (props) => <TextBox {...props} editable={true} />,
@@ -70,16 +72,18 @@ function Canvas() {
     .sort((a, b) => a.zIndex - b.zIndex)
     .map(resolve);
 
+  const loading = useEditorStore((state) => state.loading);
   return (
     <CanvasContext.Provider value={{ toSVGSpace, canvasRef }}>
       <div
-        className="flex-grow relative"
+        className={`flex-grow relative ${loading ? "pointer-events-none" : ""}`}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseDown={handleMouseDown}
         onContextMenu={handleContextMenu}
       >
         <Overlay />
+        <LoadingOverlay />
 
         {/* scene outline */}
         <svg

--- a/frontend/src/features/authoring/canvas/LoadingOverlay.tsx
+++ b/frontend/src/features/authoring/canvas/LoadingOverlay.tsx
@@ -1,0 +1,21 @@
+import useEditorStore from "../stores/editor.ts";
+
+function LoadingOverlay() {
+  const loading = useEditorStore((state) => state.loading);
+
+  if (!loading) return null;
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center pointer-events-auto">
+      {/* Blur background */}
+      <div className="absolute inset-0 backdrop-blur-sm bg-black/20" />
+
+      {/* Spinner */}
+      <div className="relative z-10">
+        <div className="w-12 h-12 border-4 border-white border-t-transparent rounded-full animate-spin" />
+      </div>
+    </div>
+  );
+}
+
+export default LoadingOverlay;

--- a/frontend/src/features/authoring/canvas/LoadingOverlay.tsx
+++ b/frontend/src/features/authoring/canvas/LoadingOverlay.tsx
@@ -1,10 +1,4 @@
-import useEditorStore from "../stores/editor.ts";
-
 function LoadingOverlay() {
-  const loading = useEditorStore((state) => state.loading);
-
-  if (!loading) return null;
-
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center pointer-events-auto">
       {/* Blur background */}

--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -20,6 +20,7 @@ import { getDownloadURL, getStorage, ref, uploadBytes } from "firebase/storage";
 import { api, handleGeneric } from "../../util/api";
 import ModalDialog from "../../components/ModalDialogue";
 import useEditorStore from "./stores/editor.ts";
+import toast from "react-hot-toast";
 
 const storage = getStorage();
 const db = getFirestore();
@@ -88,6 +89,9 @@ async function addNewImage(fileObject: File) {
     newImage.href = downloadURL;
     newImage.bounds!.verts = await getImageDimensions(downloadURL);
     add(newImage);
+  } catch (e) {
+    console.error(e);
+    toast.error("Image upload failed");
   } finally {
     setLoading(false);
   }

--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -19,6 +19,7 @@ import type { ImageComponent } from "./types";
 import { getDownloadURL, getStorage, ref, uploadBytes } from "firebase/storage";
 import { api, handleGeneric } from "../../util/api";
 import ModalDialog from "../../components/ModalDialogue";
+import useEditorStore from "./stores/editor.ts";
 
 const storage = getStorage();
 const db = getFirestore();
@@ -46,42 +47,50 @@ async function addExistingImage(image: Image | null) {
 // NOTE: this should be handled in the backend instead, and asynchronously (uploaded on save)
 
 async function addNewImage(fileObject: File) {
-  const auth = getAuth();
-  const user = auth.currentUser;
+  const { setLoading } = useEditorStore.getState();
 
-  if (!user) return;
+  setLoading(true);
 
-  // Upload image to Firebase Storage
-  const storageRef = ref(storage, `uploads/${fileObject.name}_${Date.now()}`);
-  const snapshot = await uploadBytes(storageRef, fileObject);
-  const downloadURL = await getDownloadURL(snapshot.ref);
+  try {
+    const auth = getAuth();
+    const user = auth.currentUser;
 
-  // Save image URL and metadata in Firestore
-  const uploadedAt = new Date().toISOString();
-  const docRef = await addDoc(collection(db, "uploadedImages"), {
-    url: downloadURL,
-    uploadedAt,
-    fileName: fileObject.name,
-    uid: user.uid,
-  });
-  await setDoc(docRef, { id: docRef.id }, { merge: true });
+    if (!user) return;
 
-  // Notify your backend using centralized axios client (auth handled)
-  await api.post(user, "/api/image", {
-    images: [
-      {
-        id: docRef.id,
-        url: downloadURL,
-        fileName: fileObject.name,
-        uploadedAt,
-      },
-    ],
-  });
+    // Upload image to Firebase Storage
+    const storageRef = ref(storage, `uploads/${fileObject.name}_${Date.now()}`);
+    const snapshot = await uploadBytes(storageRef, fileObject);
+    const downloadURL = await getDownloadURL(snapshot.ref);
 
-  const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
-  newImage.href = downloadURL;
-  newImage.bounds!.verts = await getImageDimensions(downloadURL);
-  add(newImage);
+    // Save image URL and metadata in Firestore
+    const uploadedAt = new Date().toISOString();
+    const docRef = await addDoc(collection(db, "uploadedImages"), {
+      url: downloadURL,
+      uploadedAt,
+      fileName: fileObject.name,
+      uid: user.uid,
+    });
+    await setDoc(docRef, { id: docRef.id }, { merge: true });
+
+    // Notify your backend using centralized axios client (auth handled)
+    await api.post(user, "/api/image", {
+      images: [
+        {
+          id: docRef.id,
+          url: downloadURL,
+          fileName: fileObject.name,
+          uploadedAt,
+        },
+      ],
+    });
+
+    const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
+    newImage.href = downloadURL;
+    newImage.bounds!.verts = await getImageDimensions(downloadURL);
+    add(newImage);
+  } finally {
+    setLoading(false);
+  }
 }
 
 async function getImageDimensions(url: string, defaultHeight = 300) {

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -7,6 +7,7 @@ import { getStyleForSelection } from "../scene/operations/text";
 type Mode = "normal" | "resize" | "create" | "text" | "mutation";
 
 interface EditorState {
+  loading: boolean;
   selected: string | null;
   createType: string | null;
   mouseDown: boolean;
@@ -25,6 +26,7 @@ interface EditorState {
   desiredColumn: number | null;
   activeStyle: BaseTextStyle | null;
 
+  setLoading: (loading: boolean) => void;
   setSelection: (selection: ModelSelection) => void;
   setVisualSelection: Dynamic<VisualSelection>;
   setDesiredColumn: (column: number | null) => void;
@@ -52,12 +54,14 @@ function setter<K extends keyof EditorState>(set: Function, prop: K) {
 }
 
 const useEditorStore = create<EditorState>((set) => ({
+  loading: false,
   selected: null,
   createType: null,
   mouseDown: false,
   mutationBounds: { verts: [], rotation: 0 },
   offset: { x: 0, y: 0 },
 
+  setLoading: (value: boolean) => set({ loading: value }),
   setSelected: (id) => set({ selected: id }),
   setCreateType: (type: string) => set({ createType: type }),
   setMouseDown: (mouseDown) => set({ mouseDown }),


### PR DESCRIPTION
## Issue
To let the user know that an image is being uploaded, it needs a clear indication that something is happening.  This prevents users from being misled into thinking nothing is happening and from uploading duplicates.

## Solution
Introduced a `LoadingOverlay` function that blurs the canvas and displays a loading animation while the image is being uploaded. 

- Introduced `loading` states to represent that something is being uploaded. The default value is `false`, since it will only change to' true' when the user tries to upload. 
- When user is uploading an image, the `addNewImage` function is being called, and it will then set `loading=true`. Then the actual upload process begins. 
- After the upload process is finished, it will then set the `loading` state to `false`

## Risk

- The entire canvas is locked during upload, cannot continue editing and cannot cancel when the upload is too slow. 
- It could feel like it is frozen when the image is taking time to upload.


## Checklist:
- [ ] Acceptance criteria met 
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
