### PR TITLE
Vps 37/text box ctrl a and cmd a to select all

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,5 +78,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5001"
+  "proxy": "http://localhost:5002"
 }

--- a/frontend/src/components/ContextMenu/portal.jsx
+++ b/frontend/src/components/ContextMenu/portal.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 
-const OFFSET = 5;
+const OFFSET = -5;
 
 let listener;
 

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -48,14 +48,17 @@ function Canvas() {
   }
 
   function handleMouseMove(e: React.MouseEvent) {
+    if (e.button === 2) return;
     handleMouseMoveGlobal(e, toSVGSpace(e.clientX, e.clientY));
   }
 
-  function handleMouseUp() {
+  function handleMouseUp(e: React.MouseEvent) {
+    if (e.button === 2) return;
     handleMouseUpGlobal();
   }
 
   function handleMouseDown(e: React.MouseEvent) {
+    if (e.button === 2) return;
     handleMouseDownGlobal(e, toSVGSpace(e.clientX, e.clientY));
   }
 

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -48,7 +48,6 @@ function Canvas() {
   }
 
   function handleMouseMove(e: React.MouseEvent) {
-    if (e.button === 2) return;
     handleMouseMoveGlobal(e, toSVGSpace(e.clientX, e.clientY));
   }
 

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import CanvasContext from "./CanvasContext";
 import Overlay from "./Overlay";
 import type { Component } from "../types";
@@ -15,6 +15,7 @@ import {
   handleMouseUpGlobal,
 } from "../handlers/pointer/pointer";
 import { handleContextGlobal } from "../handlers/pointer/context";
+import { handleGlobal } from "../handlers/keyboard/keyboard";
 
 const componentMap: Record<string, React.FC<any>> = {
   textbox: (props) => <TextBox {...props} editable={true} />,
@@ -64,6 +65,20 @@ function Canvas() {
   function handleContextMenu(e: React.MouseEvent) {
     handleContextGlobal(e, toSVGSpace(e.clientX, e.clientY));
   }
+
+  useEffect(() => {
+    const handleCanvasKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      handleGlobal(e);
+    };
+
+    window.addEventListener("keydown", handleCanvasKeyDown);
+
+    // Cleanup function
+    return () => {
+      window.removeEventListener("keydown", handleCanvasKeyDown);
+    };
+  }, []);
 
   const components = Object.values(scene)
     .sort((a, b) => a.zIndex - b.zIndex)

--- a/frontend/src/features/authoring/elements/Box.tsx
+++ b/frontend/src/features/authoring/elements/Box.tsx
@@ -16,7 +16,6 @@ function Box(component: BoxComponent) {
     bounds.rotation
   );
   const path = constructPath(verts);
-
   return <path d={path} {...filterComponent(component)} />;
 }
 

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -21,14 +21,15 @@ export function handleGlobal(e: KeyboardEvent) {
   const target = e.target as HTMLElement;
   if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
 
-  if (e.ctrlKey) handleCtrlOperations(e);
-  else if (mode.includes("text")) handleTextMode(e);
+  if (mode.includes("text")) handleTextMode(e);
+  else if (e.ctrlKey || e.metaKey) handleCtrlOperations(e);
   else if (selected) handleComponentOperations(e, selected);
 }
 
 function handleCtrlOperations(e: KeyboardEvent) {
   const { selected, setSelected } = useEditorStore.getState();
 
+  // TODO ADD e.key === "a" for all components or create new function for cmd
   if (e.key === "z") undo();
   else if (e.key === "y") redo();
   else if (e.key === "d" && selected) {

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -23,11 +23,45 @@ export function handleTextMode(e: KeyboardEvent) {
   const { selected } = useEditorStore.getState();
   if (!selected) return;
 
-  if (e.key.startsWith("Arrow") || ["Home", "End"].includes(e.key)) {
+  if ((e.metaKey || e.ctrlKey) && e.key == "a") {
+    handleSelectAll(selected);
+  } else if (e.key.startsWith("Arrow") || ["Home", "End"].includes(e.key)) {
     handleNavigation(e, selected);
   } else {
     handleEditing(e, selected);
   }
+}
+
+export function handleSelectAll(selected: string) {
+  const { setVisualSelection } = useEditorStore.getState();
+  const scene = useVisualScene.getState().components;
+  const component = scene[selected];
+
+  const blocks = component.document.blocks;
+
+  if (!blocks || blocks.length === 0) return;
+
+  // Find the position of first character in textbox
+  const startCursor = {
+    blockI: 0,
+    lineI: 0,
+    spanI: 0,
+    charI: 0,
+  };
+
+  // Find the position of last character in textbox
+  const endCursor = {
+    blockI: blocks.length - 1,
+    lineI: blocks.at(-1).lines.length - 1,
+    spanI: blocks.at(-1).lines.at(-1).spans.length - 1,
+    charI: blocks.at(-1).lines.at(-1).spans.at(-1).text.length,
+  };
+
+  // Change visually
+  setVisualSelection({ start: startCursor, end: endCursor });
+
+  // Sync Highlight
+  syncModelSelection();
 }
 
 function handleEditing(e: KeyboardEvent, selected: string) {

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -146,11 +146,15 @@ export function modifyComponentBounds(id: string, bounds: Partial<Bounds>) {
 export function bringForward(id: string) {
   const currentZIndex = getComponentProp(id, "zIndex") as number;
   const components = Object.values(getScene().components) as Component[];
+  // 1. Find all z-indices that are strictly greater than the current one
   const higherZIndices = components
     .map((c) => c.zIndex)
     .filter((z) => z >= currentZIndex);
 
+  if (higherZIndices.length === 0) return;
+
   const immediatelyAbove = Math.min(...higherZIndices);
+  console.log(higherZIndices);
 
   if (currentZIndex === immediatelyAbove) {
     return modifyComponentProp(id, "zIndex", immediatelyAbove + 1);
@@ -165,6 +169,8 @@ export function sendBackward(id: string) {
   const lowerZIndices = components
     .map((c) => c.zIndex)
     .filter((z) => z <= currentZIndex);
+
+  if (lowerZIndices.length === 0) return;
 
   const immediatelyBelow = Math.max(...lowerZIndices);
 

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -146,38 +146,47 @@ export function modifyComponentBounds(id: string, bounds: Partial<Bounds>) {
 export function bringForward(id: string) {
   const currentZIndex = getComponentProp(id, "zIndex") as number;
   const components = Object.values(getScene().components) as Component[];
-  // 1. Find all z-indices that are strictly greater than the current one
-  const higherZIndices = components
-    .map((c) => c.zIndex)
-    .filter((z) => z >= currentZIndex);
 
-  if (higherZIndices.length === 0) return;
+  // 1. Find the highest zIndex that is strictly greater than the current one
 
-  const immediatelyAbove = Math.min(...higherZIndices);
-  console.log(higherZIndices);
+  const targetComponent = components
+    .filter((curr) => curr.zIndex > currentZIndex)
+    .reduce(
+      (prev, curr) => {
+        return prev == null || prev.zIndex > curr.zIndex ? curr : prev;
+      },
+      null as Component | null
+    );
 
-  if (currentZIndex === immediatelyAbove) {
-    return modifyComponentProp(id, "zIndex", immediatelyAbove + 1);
-  }
-  modifyComponentProp(id, "zIndex", immediatelyAbove);
+  // Return if component is at the top already
+  if (!targetComponent) return;
+
+  const aboveZIndex = targetComponent.zIndex;
+
+  // Swap Zindexs
+  modifyComponentProp(id, "zIndex", aboveZIndex);
+  modifyComponentProp(targetComponent.id, "zIndex", currentZIndex);
 }
 
 export function sendBackward(id: string) {
   const currentZIndex = getComponentProp(id, "zIndex") as number;
   const components = Object.values(getScene().components) as Component[];
 
-  const lowerZIndices = components
-    .map((c) => c.zIndex)
-    .filter((z) => z <= currentZIndex);
+  // 1. Find the highest zIndex that is strictly less than the current one
+  const targetComponent = components
+    .filter((curr) => curr.zIndex < currentZIndex)
+    .reduce(
+      (prev, curr) => {
+        return prev == null || prev.zIndex < curr.zIndex ? curr : prev;
+      },
+      null as Component | null
+    );
 
-  if (lowerZIndices.length === 0) return;
+  if (!targetComponent) return;
 
-  const immediatelyBelow = Math.max(...lowerZIndices);
-
-  if (currentZIndex === immediatelyBelow) {
-    return modifyComponentProp(id, "zIndex", immediatelyBelow - 1);
-  }
-  modifyComponentProp(id, "zIndex", immediatelyBelow);
+  const belowZIndex = targetComponent.zIndex;
+  modifyComponentProp(id, "zIndex", belowZIndex);
+  modifyComponentProp(targetComponent.id, "zIndex", currentZIndex);
 }
 
 export function bringToFront(id: string) {

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -3,6 +3,7 @@ import { getComponent, getComponentProp, getScene } from "../scene";
 import { mutate, subtract, translate } from "../../util";
 import { getObject, merge } from "../util";
 import { add, modify } from "./modifiers";
+import zIndex from "@material-ui/core/styles/zIndex";
 
 export const defaults = {
   textbox: {
@@ -32,6 +33,7 @@ export const defaults = {
         },
       ],
     },
+    zIndex: 0,
   },
   line: {
     type: "line",
@@ -43,6 +45,7 @@ export const defaults = {
         { x: 100, y: 100 },
       ],
     },
+    zIndex: 0,
   },
   speech: {
     type: "speech",
@@ -56,6 +59,7 @@ export const defaults = {
       ],
       rotation: 0,
     },
+    zIndex: 0,
   },
   box: {
     type: "box",
@@ -69,6 +73,7 @@ export const defaults = {
       ],
       rotation: 0,
     },
+    zIndex: 0,
   },
   ellipse: {
     type: "ellipse",
@@ -82,6 +87,7 @@ export const defaults = {
       ],
       rotation: 0,
     },
+    zIndex: 0,
   },
   image: {
     type: "image",
@@ -94,6 +100,7 @@ export const defaults = {
       ],
       rotation: 0,
     },
+    zIndex: 0,
   },
 };
 
@@ -123,6 +130,10 @@ export function createComponentFromBounds(
   const component = structuredClone(defaults[type]);
   const dims = mutate(subtract(bounds.verts[1], bounds.verts[0]), Math.abs);
   if (dims.x > 50 && dims.y > 50) component.bounds = bounds;
+
+  // Set zIndex to the current number of components on the canvas
+  const componentsCount = Object.keys(getScene().components).length;
+  component.zIndex = componentsCount;
   return add(component);
 }
 
@@ -183,7 +194,6 @@ export function sendBackward(id: string) {
     );
 
   if (!targetComponent) return;
-
   const belowZIndex = targetComponent.zIndex;
   modifyComponentProp(id, "zIndex", belowZIndex);
   modifyComponentProp(targetComponent.id, "zIndex", currentZIndex);
@@ -195,7 +205,7 @@ export function bringToFront(id: string) {
     (p, c) => (c.zIndex >= p ? c.zIndex : p),
     -Infinity
   );
-
+  if (max == -Infinity) return;
   modifyComponentProp(id, "zIndex", max + 1);
 }
 
@@ -205,5 +215,6 @@ export function sendToBack(id: string) {
     (p, c) => (c.zIndex <= p ? c.zIndex : p),
     Infinity
   );
+  if (min == Infinity) return;
   modifyComponentProp(id, "zIndex", min - 1);
 }

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -192,16 +192,17 @@ export function sendBackward(id: string) {
 export function bringToFront(id: string) {
   const components = Object.values(getScene().components) as Component[];
   const max = components.reduce(
-    (p, c) => (c.zIndex > p ? c.zIndex : p),
+    (p, c) => (c.zIndex >= p ? c.zIndex : p),
     -Infinity
   );
+
   modifyComponentProp(id, "zIndex", max + 1);
 }
 
 export function sendToBack(id: string) {
   const components = Object.values(getScene().components) as Component[];
   const min = components.reduce(
-    (p, c) => (c.zIndex < p ? c.zIndex : p),
+    (p, c) => (c.zIndex <= p ? c.zIndex : p),
     Infinity
   );
   modifyComponentProp(id, "zIndex", min - 1);

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -3,7 +3,6 @@ import { getComponent, getComponentProp, getScene } from "../scene";
 import { mutate, subtract, translate } from "../../util";
 import { getObject, merge } from "../util";
 import { add, modify } from "./modifiers";
-import zIndex from "@material-ui/core/styles/zIndex";
 
 export const defaults = {
   textbox: {

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -144,11 +144,34 @@ export function modifyComponentBounds(id: string, bounds: Partial<Bounds>) {
 }
 
 export function bringForward(id: string) {
-  modifyComponentProp(id, "zIndex", (val: number) => val + 1);
+  const currentZIndex = getComponentProp(id, "zIndex") as number;
+  const components = Object.values(getScene().components) as Component[];
+  const higherZIndices = components
+    .map((c) => c.zIndex)
+    .filter((z) => z >= currentZIndex);
+
+  const immediatelyAbove = Math.min(...higherZIndices);
+
+  if (currentZIndex === immediatelyAbove) {
+    return modifyComponentProp(id, "zIndex", immediatelyAbove + 1);
+  }
+  modifyComponentProp(id, "zIndex", immediatelyAbove);
 }
 
 export function sendBackward(id: string) {
-  modifyComponentProp(id, "zIndex", (val: number) => val - 1);
+  const currentZIndex = getComponentProp(id, "zIndex") as number;
+  const components = Object.values(getScene().components) as Component[];
+
+  const lowerZIndices = components
+    .map((c) => c.zIndex)
+    .filter((z) => z <= currentZIndex);
+
+  const immediatelyBelow = Math.max(...lowerZIndices);
+
+  if (currentZIndex === immediatelyBelow) {
+    return modifyComponentProp(id, "zIndex", immediatelyBelow - 1);
+  }
+  modifyComponentProp(id, "zIndex", immediatelyBelow);
 }
 
 export function bringToFront(id: string) {
@@ -157,7 +180,6 @@ export function bringToFront(id: string) {
     (p, c) => (c.zIndex > p ? c.zIndex : p),
     -Infinity
   );
-  if (getComponentProp(id, "zIndex") === max) return;
   modifyComponentProp(id, "zIndex", max + 1);
 }
 
@@ -167,6 +189,5 @@ export function sendToBack(id: string) {
     (p, c) => (c.zIndex < p ? c.zIndex : p),
     Infinity
   );
-  if (getComponentProp(id, "zIndex") === min) return;
   modifyComponentProp(id, "zIndex", min - 1);
 }


### PR DESCRIPTION
## Issue

Unable to select all within the textbox using Ctrl or Cmd A.

## Solution

Add a global keyboard listener to listen for when cmd a or ctrl a is pressed, select all text within the textbox, and save the editorStore. Currently it listens for only "text" mode (the mode you are in when editing the textbox), but in the future, we will need to listen in "normal" mode as well

## Risk

idk

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
