### PR TITLE
VPS-29/30/Preserve aspect ratio + increase default image size

### DIFF
--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -39,12 +39,7 @@ async function addExistingImage(image: Image | null) {
 
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
   newImage.href = image.url;
-  const DEFAULT_HEIGHT = 300;
-  const { width, height } = await getImageDimensions(image.url);
-  newImage.bounds!.verts[1] = {
-    x: width * (DEFAULT_HEIGHT / height),
-    y: DEFAULT_HEIGHT,
-  };
+  newImage.bounds!.verts = await getImageDimensions(image.url);
   add(newImage);
 }
 
@@ -85,20 +80,19 @@ async function addNewImage(fileObject: File) {
 
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
   newImage.href = downloadURL;
-  const DEFAULT_HEIGHT = 300;
-  const { width, height } = await getImageDimensions(downloadURL);
-  newImage.bounds!.verts[1] = {
-    x: width * (DEFAULT_HEIGHT / height),
-    y: DEFAULT_HEIGHT,
-  };
+  newImage.bounds!.verts = await getImageDimensions(downloadURL);
   add(newImage);
 }
 
-async function getImageDimensions(url: string) {
+async function getImageDimensions(url: string, defaultHeight = 300) {
   const img = new Image();
   img.src = url;
   await img.decode();
-  return { width: img.naturalWidth, height: img.naturalHeight };
+  const scaledWidth = img.naturalWidth * (defaultHeight / img.naturalHeight);
+  return [
+    { x: 0, y: 0 },
+    { x: scaledWidth, y: defaultHeight },
+  ];
 }
 
 async function fetchImages() {

--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -86,7 +86,7 @@ async function addNewImage(fileObject: File) {
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
   newImage.href = downloadURL;
   const DEFAULT_HEIGHT = 300;
-  const { width, height } = await getImageDimensions(downloadURL);                                                                                                                                                                                                                                                                                                         
+  const { width, height } = await getImageDimensions(downloadURL);
   newImage.bounds!.verts[1] = {
     x: width * (DEFAULT_HEIGHT / height),
     y: DEFAULT_HEIGHT,
@@ -149,7 +149,7 @@ function ImageCreateMenu() {
   }
 
   function handleSubmit() {
-    addExistingImage(selectedImage).catch(handleGeneric);  
+    addExistingImage(selectedImage).catch(handleGeneric);
   }
 
   return (

--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -31,7 +31,7 @@ interface Image {
   url: string;
 }
 
-function addExistingImage(image: Image | null) {
+async function addExistingImage(image: Image | null) {
   if (!image?.url) {
     console.error("invalid image object:", image);
     return;
@@ -39,6 +39,12 @@ function addExistingImage(image: Image | null) {
 
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
   newImage.href = image.url;
+  const DEFAULT_HEIGHT = 300;
+  const { width, height } = await getImageDimensions(image.url);
+  newImage.bounds!.verts[1] = {
+    x: width * (DEFAULT_HEIGHT / height),
+    y: DEFAULT_HEIGHT,
+  };
   add(newImage);
 }
 
@@ -79,7 +85,20 @@ async function addNewImage(fileObject: File) {
 
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
   newImage.href = downloadURL;
+  const DEFAULT_HEIGHT = 300;
+  const { width, height } = await getImageDimensions(downloadURL);                                                                                                                                                                                                                                                                                                         
+  newImage.bounds!.verts[1] = {
+    x: width * (DEFAULT_HEIGHT / height),
+    y: DEFAULT_HEIGHT,
+  };
   add(newImage);
+}
+
+async function getImageDimensions(url: string) {
+  const img = new Image();
+  img.src = url;
+  await img.decode();
+  return { width: img.naturalWidth, height: img.naturalHeight };
 }
 
 async function fetchImages() {
@@ -130,7 +149,7 @@ function ImageCreateMenu() {
   }
 
   function handleSubmit() {
-    addExistingImage(selectedImage);
+    addExistingImage(selectedImage).catch(handleGeneric);  
   }
 
   return (

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -90,7 +90,7 @@ export const defaults = {
     bounds: {
       verts: [
         { x: 0, y: 0 },
-        { x: 100, y: 100 },
+        { x: 300, y: 300 },
       ],
       rotation: 0,
     },


### PR DESCRIPTION
## Issue

Images added to the canvas are in 100x100 format. We received user feedback that this was too small, and furthermore, we wish to preserve the original image dimensions from upload.

## Solution

new helper function takes original image dimensions for the aspect ratio and applies it, keeping a default height of 300.


resolves VPS-30

## Risk

Hopefully none.

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
