### PR TITLE
fix: reversed the +/- buttons and hid the input field's native increm…

### DIFF
--- a/frontend/src/features/authoring/wrapper/NumberInput.tsx
+++ b/frontend/src/features/authoring/wrapper/NumberInput.tsx
@@ -21,12 +21,12 @@ function NumberInput({
     <div className="join">
       <button
         className="btn btn-xs h-[28px] join-item bg-base-100 shadow-none border-none"
-        onClick={increment}
+        onClick={decrement}
       >
-        <Plus size={14} />
+        <Minus size={14} />
       </button>
       <input
-        className="input input-sm h-[28px] join-item w-10"
+        className="input input-sm h-[28px] join-item w-12 no-number-spinner"
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
         type="number"
@@ -35,9 +35,9 @@ function NumberInput({
       />
       <button
         className="btn btn-xs h-[28px] join-item bg-base-100 shadow-none border-none"
-        onClick={decrement}
+        onClick={increment}
       >
-        <Minus size={14} />
+        <Plus size={14} />
       </button>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -231,6 +231,16 @@ body,
   display: none;
 }
 
+.no-number-spinner {
+  -moz-appearance: textfield;
+}
+
+.no-number-spinner::-webkit-outer-spin-button,
+.no-number-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .btn.btn-phantom {
   @apply btn-ghost font-normal text-primary hover:text-secondary border-none shadow-none bg-transparent;
 }


### PR DESCRIPTION
…ent decrement buttons (they are duplicates)

## Issue

Increment decrement buttons were wrong way around. Additionally, the input field's native increment and decrement is visible
<img width="123" height="70" alt="image" src="https://github.com/user-attachments/assets/989012cc-7058-4d0e-8528-ca24c2e7b934" />


## Solution

swap the two button's onClick and css, added a no-number-spinner utility in index.css

## Risk

None

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
