### PR TITLE
chore: change the background of the play scenario canvas to black

### DIFF
--- a/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
@@ -195,7 +195,7 @@ export default function PlayScenarioCanvas({
     });
 
   return (
-    <div className="bg-white" style={{ width: "100vw", height: "100vh" }}>
+    <div className="bg-black" style={{ width: "100vw", height: "100vh" }}>
       <svg id="main" className="w-full h-full" viewBox="0 0 1920 1080">
         <rect x="0" y="0" width="1920" height="1080" fill="white" />
         {components}


### PR DESCRIPTION
## Issue

The colour of the background in play scenario canvas is white, making it difficult to tell where the scene's border is. 

## Solution

Changed one line to make the background black :D

## Risk

None

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
