### PR TITLE
Vps-53/line-stroke-and-colour-picker-invisible

### DIFF
--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -9,8 +9,9 @@ export const defaults = {
     type: "textbox",
     padding: 20,
     clickable: true,
-    fill: "#00000000",
-    strokeWidth: 0,
+    fill: "#ffffffff", // default fill alpha 100
+    stroke: "#ffffffff", // default stroke alpha 100
+    strokeWidth: 3, // default stroke width 3 
     bounds: {
       verts: [
         { x: 0, y: 0 },
@@ -47,7 +48,8 @@ export const defaults = {
   speech: {
     type: "speech",
     fill: "#b7b7b7ff",
-    strokeWidth: 0,
+    stroke: "#ffffffff",
+    strokewidth: 3,
     bounds: {
       verts: [
         { x: 0, y: 0 },
@@ -61,7 +63,8 @@ export const defaults = {
     type: "box",
     clickable: true,
     fill: "#b7b7b7ff",
-    strokeWidth: 0,
+    stroke: "#ffffffff",
+    strokewidth: 3,
     bounds: {
       verts: [
         { x: 0, y: 0 },
@@ -74,7 +77,8 @@ export const defaults = {
     type: "ellipse",
     fill: "#b7b7b7ff",
     clickable: true,
-    strokeWidth: 0,
+    stroke: "#ffffffff",
+    strokewidth: 3,
     bounds: {
       verts: [
         { x: 0, y: 0 },

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -11,7 +11,7 @@ export const defaults = {
     clickable: true,
     fill: "#ffffffff", // default fill alpha 100
     stroke: "#ffffffff", // default stroke alpha 100
-    strokeWidth: 3, // default stroke width 3 
+    strokeWidth: 3, // default stroke width 3
     bounds: {
       verts: [
         { x: 0, y: 0 },


### PR DESCRIPTION
## Issue

line stroke and fill colour had alpha at 0 by default

## Solution

fill colour from #00000000 to #ffffffff (white alpha 100), i did this for all elements default not just text box
stroke width was 0 now 3 and colour also stroke colour now #ffffff also done for all elements

## Risk

<img width="498" height="330" alt="image" src="https://github.com/user-attachments/assets/5b692ccc-12be-48dd-8df8-c9a5159f77c4" />

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
