### PR TITLE
Vps 41/editor scene list overflow

### DIFF
--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -94,7 +94,7 @@ function ContextableThumb({
     >
       <div className="flex">
         {/* if width/margin is increased padding for create thumbnail needs to increased relativly */}
-        <p className="w-5.5 text--1 text-right mr-1.5">{index + 1}</p>  
+        <p className="w-5.5 text--1 text-right mr-1.5">{index + 1}</p>
         <button
           type="button"
           onMouseDown={() => switchScene(scene)}

--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -93,7 +93,7 @@ function ContextableThumb({
       })}
     >
       <div className="flex">
-        <p className="w-6.5 text--1 text-right mr-1">{index + 1}</p>
+        <p className="w-5.5 text--1 text-right mr-1.5">{index + 100}</p> // if width/margin is increased padding for create thumbnail needs to increased relativly
         <button
           type="button"
           onMouseDown={() => switchScene(scene)}

--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -94,7 +94,7 @@ function ContextableThumb({
     >
       <div className="flex">
         {/* if width/margin is increased padding for create thumbnail needs to increased relativly */}
-        <p className="w-5.5 text--1 text-right mr-1.5">{index + 100}</p>  
+        <p className="w-5.5 text--1 text-right mr-1.5">{index + 1}</p>  
         <button
           type="button"
           onMouseDown={() => switchScene(scene)}

--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -93,7 +93,7 @@ function ContextableThumb({
       })}
     >
       <div className="flex">
-        <p className="w-4 text--1">{index + 1}</p>
+        <p className="w-6.5 text--1 text-right mr-1">{index + 1}</p>
         <button
           type="button"
           onMouseDown={() => switchScene(scene)}

--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -93,7 +93,8 @@ function ContextableThumb({
       })}
     >
       <div className="flex">
-        <p className="w-5.5 text--1 text-right mr-1.5">{index + 100}</p> // if width/margin is increased padding for create thumbnail needs to increased relativly
+        {/* if width/margin is increased padding for create thumbnail needs to increased relativly */}
+        <p className="w-5.5 text--1 text-right mr-1.5">{index + 100}</p>  
         <button
           type="button"
           onMouseDown={() => switchScene(scene)}

--- a/frontend/src/features/authoring/SceneNavigator/SceneNavigator.jsx
+++ b/frontend/src/features/authoring/SceneNavigator/SceneNavigator.jsx
@@ -85,24 +85,33 @@ const SceneNavigator = () => {
       collisionDetection={closestCenter}
     >
       <SortableContext items={sceneIds} strategy={verticalListSortingStrategy}>
-        <div className="h-full overflow-y-auto no-scrollbar">
-          <ul className="flex flex-col gap-s pb-m">
-            {scenes.map((scene, index) => (
-              <SceneListItem
-                scene={scene}
-                index={index}
-                key={scene._id}
-                active={scene._id === activeId}
+        <div className="flex h-full">
+          <div className="flex-shrink-0 w-[200px] overflow-y-auto no-scrollbar">
+            <ul className="flex flex-col gap-s pb-m">
+              {scenes.map((scene, index) => (
+                <SceneListItem
+                  scene={scene}
+                  index={index}
+                  key={scene._id}
+                  active={scene._id === activeId}
+                />
+              ))}
+              <div className="w-full pr-3"> 
+                <button className="float-right" onClick={addScene}>
+                  <div className="text-primary hover:text-secondary w-[160px] h-[94px] border-3 border-primary hover:border-secondary rounded-sm flex justify-center items-center">
+                    <PlusIcon />
+                  </div>
+                </button>
+              </div>
+            </ul>
+          </div>
+          <div className="flex-1 p-4 bg-base-100">
+            {scenes.find((s) => s._id === activeId) && (
+              <Thumbnail
+                components={scenes.find((s) => s._id === activeId).components}
               />
-            ))}
-            <div className="w-full">
-              <button className="float-right" onClick={addScene}>
-                <div className="text-primary hover:text-secondary w-[160px] h-[94px] border-3 border-primary hover:border-secondary rounded-sm flex justify-center items-center">
-                  <PlusIcon />
-                </div>
-              </button>
-            </div>
-          </ul>
+            )}
+          </div>
         </div>
       </SortableContext>
       <DragOverlay dropAnimation={null}>

--- a/frontend/src/features/authoring/SceneNavigator/SceneNavigator.jsx
+++ b/frontend/src/features/authoring/SceneNavigator/SceneNavigator.jsx
@@ -96,7 +96,7 @@ const SceneNavigator = () => {
                   active={scene._id === activeId}
                 />
               ))}
-              <div className="w-full pr-3"> 
+              <div className="w-full pr-3">
                 <button className="float-right" onClick={addScene}>
                   <div className="text-primary hover:text-secondary w-[160px] h-[94px] border-3 border-primary hover:border-secondary rounded-sm flex justify-center items-center">
                     <PlusIcon />


### PR DESCRIPTION
## Issue

Both scene list elements and numbering (when over 99 slides)

## Solution

added more width and margin right
also made the current editing slide independent of the slides list so that the width isn't affected when text is increased,
this is the same implementation as google slides, google slides also has a zoom feature which would be easier to implement with this change. 

## Risk

as long as they dont have over 999 slides it doesnt overflow

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
