### PR TITLE
Added tick when role selected in scene settings

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -1,4 +1,5 @@
 import { useContext, useState, useEffect } from "react";
+import { Check } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import {
@@ -105,7 +106,10 @@ export default function SceneSettings() {
                     className={active ? "text-secondary" : "text-primary"}
                     key={i}
                   >
-                    <a onClick={() => changeRole(role, !active)}>{role}</a>
+                    <a onClick={() => changeRole(role, !active)}>
+                      {role}
+                      {active && <Check className="ml-auto" size={14} />}
+                    </a>
                   </li>
                 );
               })}


### PR DESCRIPTION
## Issue

Selected roles in the Scene Settings dropdown weren't visually clear. It was hard to tell at a glance which roles were active.

## Solution

Added a checkmark icon (Lucide Check) to the right side of selected roles in the dropdown.

<img width="476" height="711" alt="image" src="https://github.com/user-attachments/assets/64c54143-fcec-435b-9964-a890f7e66a52" />

## Risk

Low, as it's purely cosmetic change.

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
