### PR TITLE
fix: use latest node lts version (24)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
           cache-dependency-path: backend/yarn.lock
       - run: yarn install --frozen-lockfile
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
           cache-dependency-path: backend/yarn.lock
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
           cache-dependency-path: frontend/yarn.lock
       - run: yarn install --frozen-lockfile

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Node.js"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=18.19.0
+ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Vite"


### PR DESCRIPTION
## Issue

Production build fails because new dependencies require a newer version of Node
```shell
42.33 error marked@18.0.2: The engine "node" is incompatible with this module. Expected version ">= 20". Got "18.19.0"
42.34 error Found incompatible module.
```

## Solution

Upgrade frontend and backend to the current latest Node LTS version (24).
https://nodejs.org/en/about/previous-releases
<img width="960" height="500" alt="image" src="https://github.com/user-attachments/assets/2330857f-bc44-4681-a60e-82ac69e60d6a" />

## Risk

Deployment failure. But they are already failing anyway.

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing

Supersedes #384 