### PR TITLE
VPS-28/missing thumbnails

### DIFF
--- a/frontend/src/components/ListContainer/ImageListContainer.jsx
+++ b/frontend/src/components/ListContainer/ImageListContainer.jsx
@@ -31,7 +31,7 @@ export default function ImageListContainer({
                 opacity: "0.5",
                 cursor: "pointer",
               },
-              backgroundImage: `url("${item.url}")`, 
+              backgroundImage: `url("${item.url}")`,
               backgroundSize: "cover",
               backgroundPosition: "center",
               boxSizing: "border-box",

--- a/frontend/src/components/ListContainer/ImageListContainer.jsx
+++ b/frontend/src/components/ListContainer/ImageListContainer.jsx
@@ -31,7 +31,7 @@ export default function ImageListContainer({
                 opacity: "0.5",
                 cursor: "pointer",
               },
-              backgroundImage: `url(${item.url})`,
+              backgroundImage: `url("${item.url}")`, 
               backgroundSize: "cover",
               backgroundPosition: "center",
               boxSizing: "border-box",


### PR DESCRIPTION
## Issue

- Images with "()" parentheses in their file name would not load in the "Choose Image" selector menu.
- Browser CSS parser would see the ")" as the closing bracket for url(), resulting in an invalid val and no network request made

For example, this image would not load:
<img width="1386" height="123" alt="image" src="https://github.com/user-attachments/assets/e667719c-34ff-4a44-ba9f-585811411f95" />

## Solution

Placing url() in quotations so filename parentheses are no longer breaking stuff.

## Risk

None :)

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
