### PR TITLE
feat(authoring,play): single-scene timer and state operations

### DIFF
--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -199,7 +199,7 @@ const patchScene = async (sceneId, patch) => {
   const { fields = {}, components = [], deletedComponentIds = [] } = patch;
 
   const allowedFields = {};
-  ["name", "roles", "time"].forEach((field) => {
+  ["name", "roles", "time", "timerStateOperations"].forEach((field) => {
     if (Object.prototype.hasOwnProperty.call(fields, field)) {
       allowedFields[field] = fields[field];
     }

--- a/backend/src/db/models/scene.js
+++ b/backend/src/db/models/scene.js
@@ -16,6 +16,11 @@ const sceneSchema = new Schema({
   time: {
     type: Number,
   },
+  timerStateOperations: [
+    {
+      type: Object,
+    },
+  ],
   visited: {
     type: Number,
     default: 0,

--- a/backend/src/routes/api/navigate/group.js
+++ b/backend/src/routes/api/navigate/group.js
@@ -19,7 +19,7 @@ const createInvalidError = (roles) =>
 export const getSimpleScene = async (sceneId) => {
   const scene = await Scene.findOne(
     { _id: sceneId },
-    { roles: 1, components: 1 }
+    { roles: 1, components: 1, time: 1, timerStateOperations: 1 }
   ).lean();
   if (!scene)
     throw new HttpError("No scene exists with that id", STATUS.NOT_FOUND);

--- a/backend/src/routes/api/navigate/user.js
+++ b/backend/src/routes/api/navigate/user.js
@@ -18,7 +18,7 @@ const getConnectedScenes = async (sceneID, active = true) => {
     .filter(Boolean);
   const connected = await Scene.find(
     { _id: { $in: connectedIds } },
-    { components: 1 }
+    { components: 1, time: 1, timerStateOperations: 1 }
   ).lean();
   return {
     active: scene._id,

--- a/frontend/src/components/StateVariables/CreateTimerOperationModal.jsx
+++ b/frontend/src/components/StateVariables/CreateTimerOperationModal.jsx
@@ -6,7 +6,14 @@ import SelectInput from "../../features/authoring/components/Select";
 import ModalDialog from "../ModalDialogue";
 import useVisualScene from "../../features/authoring/stores/visual";
 
-export function OperationField({ type, operation, value, onOperationChange, onValueChange, onValueBlur }) {
+export function OperationField({
+  type,
+  operation,
+  value,
+  onOperationChange,
+  onValueChange,
+  onValueBlur,
+}) {
   return (
     <div className="join">
       <SelectInput
@@ -15,7 +22,11 @@ export function OperationField({ type, operation, value, onOperationChange, onVa
         onChange={onOperationChange}
       />
       {type === stateTypes.BOOLEAN ? (
-        <SelectInput values={[true, false]} value={value} onChange={onValueChange} />
+        <SelectInput
+          values={[true, false]}
+          value={value}
+          onChange={onValueChange}
+        />
       ) : (
         <input
           type={type === stateTypes.STRING ? "text" : "number"}
@@ -71,11 +82,15 @@ export default function CreateTimerOperationModal({ open, onClose }) {
   const isSubmittable = selectedState && operation && value != null;
 
   return (
-    <ModalDialog title="Add Timeout State Operation" open={open} onClose={onClose}>
+    <ModalDialog
+      title="Add Timeout State Operation"
+      open={open}
+      onClose={onClose}
+    >
       {!stateVariables?.length ? (
         <div className="text-s">
-          No state variables found for this scenario. You can create some in
-          the &apos;State Variables&apos; menu in the toolbar above.
+          No state variables found for this scenario. You can create some in the
+          &apos;State Variables&apos; menu in the toolbar above.
         </div>
       ) : (
         <fieldset className="fieldset">

--- a/frontend/src/components/StateVariables/CreateTimerOperationModal.jsx
+++ b/frontend/src/components/StateVariables/CreateTimerOperationModal.jsx
@@ -1,0 +1,113 @@
+import { useContext, useEffect, useState } from "react";
+import ScenarioContext from "context/ScenarioContext";
+import { getDefaultValue, stateTypes, validOperations } from "./stateTypes";
+import { modifySceneProp } from "../../features/authoring/scene/operations/modifiers";
+import SelectInput from "../../features/authoring/components/Select";
+import ModalDialog from "../ModalDialogue";
+import useVisualScene from "../../features/authoring/stores/visual";
+
+export function OperationField({ type, operation, value, onOperationChange, onValueChange, onValueBlur }) {
+  return (
+    <div className="join">
+      <SelectInput
+        values={validOperations[type]}
+        value={operation}
+        onChange={onOperationChange}
+      />
+      {type === stateTypes.BOOLEAN ? (
+        <SelectInput values={[true, false]} value={value} onChange={onValueChange} />
+      ) : (
+        <input
+          type={type === stateTypes.STRING ? "text" : "number"}
+          value={value ?? ""}
+          onChange={(e) => onValueChange(e.target.value)}
+          onBlur={onValueBlur}
+          placeholder="Value"
+          className="input join-item"
+        />
+      )}
+    </div>
+  );
+}
+
+export default function CreateTimerOperationModal({ open, onClose }) {
+  const { stateVariables } = useContext(ScenarioContext);
+  const timerStateOperations = useVisualScene((s) => s.timerStateOperations);
+
+  const [selectedState, setSelectedState] = useState(null);
+  const [operation, setOperation] = useState(null);
+  const [value, setValue] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedState(null);
+      setOperation(null);
+      setValue(null);
+    }
+  }, [open]);
+
+  function onVariableChange(variable) {
+    setSelectedState(variable);
+    setOperation(null);
+    setValue(getDefaultValue(variable.type));
+  }
+
+  function handleCreate() {
+    if (!selectedState?.id || !operation) return;
+
+    modifySceneProp("timerStateOperations", [
+      ...(timerStateOperations ?? []),
+      {
+        stateVariableId: selectedState.id,
+        displayName: selectedState.name,
+        operation,
+        value: selectedState.type === stateTypes.NUMBER ? Number(value) : value,
+      },
+    ]);
+
+    onClose();
+  }
+
+  const isSubmittable = selectedState && operation && value != null;
+
+  return (
+    <ModalDialog title="Add Timeout State Operation" open={open} onClose={onClose}>
+      {!stateVariables?.length ? (
+        <div className="text-s">
+          No state variables found for this scenario. You can create some in
+          the &apos;State Variables&apos; menu in the toolbar above.
+        </div>
+      ) : (
+        <fieldset className="fieldset">
+          <label className="label">State Variable</label>
+          <SelectInput
+            values={stateVariables}
+            value={selectedState}
+            display={(s) => s.name}
+            onChange={onVariableChange}
+          />
+          {selectedState && (
+            <>
+              <label className="label">Operation</label>
+              <OperationField
+                type={selectedState.type}
+                operation={operation}
+                value={value}
+                onOperationChange={setOperation}
+                onValueChange={setValue}
+              />
+            </>
+          )}
+        </fieldset>
+      )}
+      <div className="modal-action flex gap-2">
+        <button
+          className={`btn ${!isSubmittable && "btn-disabled"}`}
+          onClick={handleCreate}
+        >
+          Add
+        </button>
+      </div>
+    </ModalDialog>
+  );
+}

--- a/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
@@ -1,0 +1,217 @@
+import { useContext, useEffect, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import ScenarioContext from "context/ScenarioContext";
+import { getDefaultValue, stateTypes, validOperations } from "./stateTypes";
+import { modifySceneProp } from "../../features/authoring/scene/operations/modifiers";
+import SelectInput from "../../features/authoring/components/Select";
+import ModalDialog from "../ModalDialogue";
+import useVisualScene from "../../features/authoring/stores/visual";
+
+function TimerOperationRow({ operation, index, operations }) {
+  const { stateVariables } = useContext(ScenarioContext);
+
+  const stateVariable = stateVariables?.find(
+    (v) => v.id === operation.stateVariableId
+  );
+
+  const [localOperation, setLocalOperation] = useState(operation.operation);
+  const [localValue, setLocalValue] = useState(operation.value);
+
+  useEffect(() => {
+    setLocalOperation(operation.operation);
+    setLocalValue(operation.value);
+  }, [operation]);
+
+  if (!stateVariable) return null;
+
+  function saveOperation(v) {
+    setLocalOperation(v);
+    const updated = operations.map((op, i) =>
+      i === index ? { ...op, operation: v } : op
+    );
+    modifySceneProp("timerStateOperations", updated);
+  }
+
+  function saveValue(v) {
+    setLocalValue(v);
+    const updated = operations.map((op, i) =>
+      i === index ? { ...op, value: v } : op
+    );
+    modifySceneProp("timerStateOperations", updated);
+  }
+
+  function deleteOperation() {
+    modifySceneProp(
+      "timerStateOperations",
+      operations.toSpliced(index, 1)
+    );
+  }
+
+  return (
+    <div className="bg-base-300 mt-xs px-[1rem] py-[0.5rem]">
+      <div>
+        <span className="text--1">{stateVariable.name}</span>
+        <span className="text-xs ml-2xs text-primary">{`${stateVariable.type} operation`}</span>
+        <button
+          className="btn btn-xs btn-phantom float-right"
+          onClick={deleteOperation}
+        >
+          Delete
+        </button>
+      </div>
+      <fieldset className="fieldset mt-[0.5rem]">
+        <div className="join">
+          <SelectInput
+            values={validOperations[stateVariable.type]}
+            value={localOperation}
+            onChange={saveOperation}
+          />
+          {stateVariable.type === stateTypes.BOOLEAN ? (
+            <SelectInput
+              values={[true, false]}
+              value={localValue}
+              onChange={saveValue}
+            />
+          ) : (
+            <input
+              type={stateVariable.type === stateTypes.STRING ? "text" : "number"}
+              value={localValue}
+              onChange={(e) => setLocalValue(e.target.value)}
+              onBlur={() => saveValue(localValue)}
+              placeholder="Value"
+              className="input join-item"
+            />
+          )}
+        </div>
+      </fieldset>
+    </div>
+  );
+}
+
+export default function TimerStateOperationMenu() {
+  const { stateVariables } = useContext(ScenarioContext);
+  const timerStateOperations = useVisualScene((s) => s.timerStateOperations);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const [selectedState, setSelectedState] = useState(null);
+  const [operation, setOperation] = useState(null);
+  const [value, setValue] = useState(null);
+
+  function openCreate() {
+    setSelectedState(null);
+    setOperation(null);
+    setValue(null);
+    setCreateOpen(true);
+  }
+
+  function onVariableChange(variable) {
+    setSelectedState(variable);
+    setOperation(null);
+    setValue(getDefaultValue(variable.type));
+  }
+
+  function handleCreate() {
+    if (!selectedState?.id || !operation) return;
+
+    const newOperation = {
+      stateVariableId: selectedState.id,
+      displayName: selectedState.name,
+      operation,
+      value: selectedState.type === stateTypes.NUMBER ? Number(value) : value,
+    };
+
+    modifySceneProp("timerStateOperations", [
+      ...(timerStateOperations ?? []),
+      newOperation,
+    ]);
+
+    setCreateOpen(false);
+  }
+
+  const isSubmittable = selectedState && operation && value != null;
+  const ops = timerStateOperations ?? [];
+
+  return (
+    <>
+      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
+        <input type="checkbox" />
+        <div className="collapse-title flex items-center justify-between">
+          On Timeout
+          <PlusIcon size={18} onClick={openCreate} className="z-1" />
+        </div>
+        <div className="collapse-content text--1 bg-base-200 px-0">
+          {ops.map((op, i) => (
+            <TimerOperationRow
+              key={i}
+              operation={op}
+              index={i}
+              operations={ops}
+            />
+          ))}
+        </div>
+      </div>
+
+      <ModalDialog
+        title="Add Timeout State Operation"
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+      >
+        {!stateVariables?.length ? (
+          <div className="text-s">
+            No state variables found for this scenario. You can create some in
+            the &apos;State Variables&apos; menu in the toolbar above.
+          </div>
+        ) : (
+          <fieldset className="fieldset">
+            <label className="label">State Variable</label>
+            <SelectInput
+              values={stateVariables}
+              value={selectedState}
+              display={(s) => s.name}
+              onChange={onVariableChange}
+            />
+            {selectedState && (
+              <>
+                <label className="label">Operation</label>
+                <div className="join">
+                  <SelectInput
+                    values={validOperations[selectedState.type]}
+                    value={operation}
+                    onChange={setOperation}
+                  />
+                  {selectedState.type === stateTypes.BOOLEAN ? (
+                    <SelectInput
+                      values={[true, false]}
+                      value={value}
+                      onChange={setValue}
+                    />
+                  ) : (
+                    <input
+                      type={
+                        selectedState.type === stateTypes.STRING
+                          ? "text"
+                          : "number"
+                      }
+                      value={value ?? ""}
+                      onChange={(e) => setValue(e.target.value)}
+                      placeholder="Value"
+                      className="input join-item"
+                    />
+                  )}
+                </div>
+              </>
+            )}
+          </fieldset>
+        )}
+        <div className="modal-action flex gap-2">
+          <button
+            className={`btn ${!isSubmittable ? "btn-disabled" : ""}`}
+            onClick={handleCreate}
+          >
+            Add
+          </button>
+        </div>
+      </ModalDialog>
+    </>
+  );
+}

--- a/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
@@ -7,7 +7,7 @@ import SelectInput from "../../features/authoring/components/Select";
 import ModalDialog from "../ModalDialogue";
 import useVisualScene from "../../features/authoring/stores/visual";
 
-function TimerOperationRow({ operation, index, operations }) {
+function TimerOperationRow({ operation, index }) {
   const { stateVariables } = useContext(ScenarioContext);
 
   const stateVariable = stateVariables?.find(
@@ -24,27 +24,26 @@ function TimerOperationRow({ operation, index, operations }) {
 
   if (!stateVariable) return null;
 
+  function getCurrent() {
+    return useVisualScene.getState().timerStateOperations ?? [];
+  }
+
   function saveOperation(v) {
     setLocalOperation(v);
-    const updated = operations.map((op, i) =>
+    modifySceneProp("timerStateOperations", getCurrent().map((op, i) =>
       i === index ? { ...op, operation: v } : op
-    );
-    modifySceneProp("timerStateOperations", updated);
+    ));
   }
 
   function saveValue(v) {
     setLocalValue(v);
-    const updated = operations.map((op, i) =>
+    modifySceneProp("timerStateOperations", getCurrent().map((op, i) =>
       i === index ? { ...op, value: v } : op
-    );
-    modifySceneProp("timerStateOperations", updated);
+    ));
   }
 
   function deleteOperation() {
-    modifySceneProp(
-      "timerStateOperations",
-      operations.toSpliced(index, 1)
-    );
+    modifySceneProp("timerStateOperations", getCurrent().toSpliced(index, 1));
   }
 
   return (
@@ -141,12 +140,7 @@ export default function TimerStateOperationMenu() {
         </div>
         <div className="collapse-content text--1 bg-base-200 px-0">
           {ops.map((op, i) => (
-            <TimerOperationRow
-              key={i}
-              operation={op}
-              index={i}
-              operations={ops}
-            />
+            <TimerOperationRow key={i} operation={op} index={i} />
           ))}
         </div>
       </div>

--- a/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
@@ -4,7 +4,9 @@ import ScenarioContext from "context/ScenarioContext";
 import { stateTypes } from "./stateTypes";
 import { modifySceneProp } from "../../features/authoring/scene/operations/modifiers";
 import useVisualScene from "../../features/authoring/stores/visual";
-import CreateTimerOperationModal, { OperationField } from "./CreateTimerOperationModal";
+import CreateTimerOperationModal, {
+  OperationField,
+} from "./CreateTimerOperationModal";
 
 function TimerOperationRow({ operation, index }) {
   const { stateVariables } = useContext(ScenarioContext);
@@ -88,7 +90,11 @@ export default function TimerStateOperationMenu() {
         <input type="checkbox" />
         <div className="collapse-title flex items-center justify-between">
           On Timeout
-          <PlusIcon size={18} onClick={() => setCreateOpen(true)} className="z-1" />
+          <PlusIcon
+            size={18}
+            onClick={() => setCreateOpen(true)}
+            className="z-1"
+          />
         </div>
         <div className="collapse-content text--1 bg-base-200 px-0">
           {ops.map((op, i) => (

--- a/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
@@ -1,11 +1,10 @@
 import { useContext, useEffect, useState } from "react";
 import { PlusIcon } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
-import { getDefaultValue, stateTypes, validOperations } from "./stateTypes";
+import { stateTypes } from "./stateTypes";
 import { modifySceneProp } from "../../features/authoring/scene/operations/modifiers";
-import SelectInput from "../../features/authoring/components/Select";
-import ModalDialog from "../ModalDialogue";
 import useVisualScene from "../../features/authoring/stores/visual";
+import CreateTimerOperationModal, { OperationField } from "./CreateTimerOperationModal";
 
 function TimerOperationRow({ operation, index }) {
   const { stateVariables } = useContext(ScenarioContext);
@@ -37,11 +36,15 @@ function TimerOperationRow({ operation, index }) {
   }
 
   function saveValue(v) {
-    setLocalValue(v);
     modifySceneProp(
       "timerStateOperations",
       getCurrent().map((op, i) => (i === index ? { ...op, value: v } : op))
     );
+  }
+
+  function handleValueChange(v) {
+    setLocalValue(v);
+    if (stateVariable.type === stateTypes.BOOLEAN) saveValue(v);
   }
 
   function deleteOperation() {
@@ -61,77 +64,22 @@ function TimerOperationRow({ operation, index }) {
         </button>
       </div>
       <fieldset className="fieldset mt-[0.5rem]">
-        <div className="join">
-          <SelectInput
-            values={validOperations[stateVariable.type]}
-            value={localOperation}
-            onChange={saveOperation}
-          />
-          {stateVariable.type === stateTypes.BOOLEAN ? (
-            <SelectInput
-              values={[true, false]}
-              value={localValue}
-              onChange={saveValue}
-            />
-          ) : (
-            <input
-              type={
-                stateVariable.type === stateTypes.STRING ? "text" : "number"
-              }
-              value={localValue}
-              onChange={(e) => setLocalValue(e.target.value)}
-              onBlur={() => saveValue(localValue)}
-              placeholder="Value"
-              className="input join-item"
-            />
-          )}
-        </div>
+        <OperationField
+          type={stateVariable.type}
+          operation={localOperation}
+          value={localValue}
+          onOperationChange={saveOperation}
+          onValueChange={handleValueChange}
+          onValueBlur={() => saveValue(localValue)}
+        />
       </fieldset>
     </div>
   );
 }
 
 export default function TimerStateOperationMenu() {
-  const { stateVariables } = useContext(ScenarioContext);
   const timerStateOperations = useVisualScene((s) => s.timerStateOperations);
   const [createOpen, setCreateOpen] = useState(false);
-
-  const [selectedState, setSelectedState] = useState(null);
-  const [operation, setOperation] = useState(null);
-  const [value, setValue] = useState(null);
-
-  function openCreate() {
-    setSelectedState(null);
-    setOperation(null);
-    setValue(null);
-    setCreateOpen(true);
-  }
-
-  function onVariableChange(variable) {
-    setSelectedState(variable);
-    setOperation(null);
-    setValue(getDefaultValue(variable.type));
-  }
-
-  function handleCreate() {
-    if (!selectedState?.id || !operation) return;
-
-    const newOperation = {
-      stateVariableId: selectedState.id,
-      displayName: selectedState.name,
-      operation,
-      value: selectedState.type === stateTypes.NUMBER ? Number(value) : value,
-    };
-
-    modifySceneProp("timerStateOperations", [
-      ...(timerStateOperations ?? []),
-      newOperation,
-    ]);
-
-    setCreateOpen(false);
-  }
-
-  const isSubmittable = selectedState && operation && value != null;
   const ops = timerStateOperations ?? [];
 
   return (
@@ -140,7 +88,7 @@ export default function TimerStateOperationMenu() {
         <input type="checkbox" />
         <div className="collapse-title flex items-center justify-between">
           On Timeout
-          <PlusIcon size={18} onClick={openCreate} className="z-1" />
+          <PlusIcon size={18} onClick={() => setCreateOpen(true)} className="z-1" />
         </div>
         <div className="collapse-content text--1 bg-base-200 px-0">
           {ops.map((op, i) => (
@@ -149,67 +97,10 @@ export default function TimerStateOperationMenu() {
         </div>
       </div>
 
-      <ModalDialog
-        title="Add Timeout State Operation"
+      <CreateTimerOperationModal
         open={createOpen}
         onClose={() => setCreateOpen(false)}
-      >
-        {!stateVariables?.length ? (
-          <div className="text-s">
-            No state variables found for this scenario. You can create some in
-            the &apos;State Variables&apos; menu in the toolbar above.
-          </div>
-        ) : (
-          <fieldset className="fieldset">
-            <label className="label">State Variable</label>
-            <SelectInput
-              values={stateVariables}
-              value={selectedState}
-              display={(s) => s.name}
-              onChange={onVariableChange}
-            />
-            {selectedState && (
-              <>
-                <label className="label">Operation</label>
-                <div className="join">
-                  <SelectInput
-                    values={validOperations[selectedState.type]}
-                    value={operation}
-                    onChange={setOperation}
-                  />
-                  {selectedState.type === stateTypes.BOOLEAN ? (
-                    <SelectInput
-                      values={[true, false]}
-                      value={value}
-                      onChange={setValue}
-                    />
-                  ) : (
-                    <input
-                      type={
-                        selectedState.type === stateTypes.STRING
-                          ? "text"
-                          : "number"
-                      }
-                      value={value ?? ""}
-                      onChange={(e) => setValue(e.target.value)}
-                      placeholder="Value"
-                      className="input join-item"
-                    />
-                  )}
-                </div>
-              </>
-            )}
-          </fieldset>
-        )}
-        <div className="modal-action flex gap-2">
-          <button
-            className={`btn ${!isSubmittable ? "btn-disabled" : ""}`}
-            onClick={handleCreate}
-          >
-            Add
-          </button>
-        </div>
-      </ModalDialog>
+      />
     </>
   );
 }

--- a/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/TimerStateOperationMenu.jsx
@@ -30,16 +30,18 @@ function TimerOperationRow({ operation, index }) {
 
   function saveOperation(v) {
     setLocalOperation(v);
-    modifySceneProp("timerStateOperations", getCurrent().map((op, i) =>
-      i === index ? { ...op, operation: v } : op
-    ));
+    modifySceneProp(
+      "timerStateOperations",
+      getCurrent().map((op, i) => (i === index ? { ...op, operation: v } : op))
+    );
   }
 
   function saveValue(v) {
     setLocalValue(v);
-    modifySceneProp("timerStateOperations", getCurrent().map((op, i) =>
-      i === index ? { ...op, value: v } : op
-    ));
+    modifySceneProp(
+      "timerStateOperations",
+      getCurrent().map((op, i) => (i === index ? { ...op, value: v } : op))
+    );
   }
 
   function deleteOperation() {
@@ -73,7 +75,9 @@ function TimerOperationRow({ operation, index }) {
             />
           ) : (
             <input
-              type={stateVariable.type === stateTypes.STRING ? "text" : "number"}
+              type={
+                stateVariable.type === stateTypes.STRING ? "text" : "number"
+              }
               value={localValue}
               onChange={(e) => setLocalValue(e.target.value)}
               onBlur={() => saveValue(localValue)}

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -9,6 +9,7 @@ import useVisualScene from "../stores/visual";
 import { modifySceneProp } from "../scene/operations/modifiers";
 import shallow from "zustand/shallow";
 import toast from "react-hot-toast";
+import TimerStateOperationMenu from "../../../components/StateVariables/TimerStateOperationMenu";
 
 /**
  * This component displays the settings of a scene, such as the scene name
@@ -20,14 +21,20 @@ export default function SceneSettings() {
 
   const name = useVisualScene((scene) => scene.name);
   const roles = useVisualScene((scene) => scene.roles);
+  const time = useVisualScene((scene) => scene.time);
 
   const [selectedRoles, setSelectedRoles] = useState(roles ?? []);
   const [sceneName, setSceneName] = useState(name ?? "");
+  const [timerDuration, setTimerDuration] = useState(time ?? "");
 
   useEffect(() => {
     if (!name || name === sceneName) return;
     setSceneName(name);
   }, [name]);
+
+  useEffect(() => {
+    setTimerDuration(time ?? "");
+  }, [time]);
 
   useEffect(() => {
     if (!roleList || !roles) return;
@@ -37,6 +44,11 @@ export default function SceneSettings() {
 
   function saveSceneRoles() {
     modifySceneProp("roles", selectedRoles);
+  }
+
+  function saveTimerDuration() {
+    const parsed = parseInt(timerDuration, 10);
+    modifySceneProp("time", !isNaN(parsed) && parsed > 0 ? parsed : null);
   }
 
   async function saveSceneName() {
@@ -79,53 +91,67 @@ export default function SceneSettings() {
   }
 
   return (
-    <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
-      <input type="checkbox" />
-      <div className="collapse-title">Scene Details</div>
-      <div className="collapse-content text--1 bg-base-200">
-        <fieldset className="fieldset pt-2">
-          {/* input for scene name */}
-          <label className="label">Name</label>
-          <input
-            type="text"
-            value={sceneName}
-            onChange={changeSceneName}
-            onBlur={saveSceneName}
-            className="input"
-            placeholder="Awesome Scene"
-          />
-          {/* input for scene roles */}
-          <label className="label">Roles</label>
-          <div className="dropdown" onBlur={saveSceneRoles}>
-            <div
-              tabIndex={0}
-              role="button"
-              className="justify-start input mb-1 font-normal"
-            >
-              {selectedRoles?.join(", ") || "All"}
+    <>
+      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
+        <input type="checkbox" />
+        <div className="collapse-title">Scene Details</div>
+        <div className="collapse-content text--1 bg-base-200">
+          <fieldset className="fieldset pt-2">
+            {/* input for scene name */}
+            <label className="label">Name</label>
+            <input
+              type="text"
+              value={sceneName}
+              onChange={changeSceneName}
+              onBlur={saveSceneName}
+              className="input"
+              placeholder="Awesome Scene"
+            />
+            {/* input for timer duration */}
+            <label className="label">Timer Duration (seconds)</label>
+            <input
+              type="number"
+              min="1"
+              value={timerDuration}
+              onChange={(e) => setTimerDuration(e.target.value)}
+              onBlur={saveTimerDuration}
+              className="input"
+              placeholder="No timer"
+            />
+            {/* input for scene roles */}
+            <label className="label">Roles</label>
+            <div className="dropdown" onBlur={saveSceneRoles}>
+              <div
+                tabIndex={0}
+                role="button"
+                className="justify-start input mb-1 font-normal"
+              >
+                {selectedRoles?.join(", ") || "All"}
+              </div>
+              <ul
+                tabIndex={0}
+                className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
+              >
+                {roleList?.map((role, i) => {
+                  const active = selectedRoles.includes(role);
+                  return (
+                    <li
+                      className={active ? "text-secondary" : "text-primary"}
+                      key={i}
+                    >
+                      <a onClick={() => changeRole(role, !active)}>
+                        {role}
+                        {active && <Check className="ml-auto" size={14} />}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
-            <ul
-              tabIndex={0}
-              className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
-            >
-              {roleList?.map((role, i) => {
-                const active = selectedRoles.includes(role);
-                return (
-                  <li
-                    className={active ? "text-secondary" : "text-primary"}
-                    key={i}
-                  >
-                    <a onClick={() => changeRole(role, !active)}>
-                      {role}
-                      {active && <Check className="ml-auto" size={14} />}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>
-    </div>
+      {time > 0 && <TimerStateOperationMenu />}
+    </>
   );
 }

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -33,7 +33,9 @@ export default function SceneSettings() {
   }, [name]);
 
   useEffect(() => {
-    setTimerDuration(time ?? "");
+    const stored = time ?? "";
+    if (stored == timerDuration) return;
+    setTimerDuration(stored);
   }, [time]);
 
   useEffect(() => {
@@ -97,7 +99,6 @@ export default function SceneSettings() {
         <div className="collapse-title">Scene Details</div>
         <div className="collapse-content text--1 bg-base-200">
           <fieldset className="fieldset pt-2">
-            {/* input for scene name */}
             <label className="label">Name</label>
             <input
               type="text"
@@ -107,7 +108,6 @@ export default function SceneSettings() {
               className="input"
               placeholder="Awesome Scene"
             />
-            {/* input for timer duration */}
             <label className="label">Timer Duration (seconds)</label>
             <input
               type="number"
@@ -118,7 +118,6 @@ export default function SceneSettings() {
               className="input"
               placeholder="No timer"
             />
-            {/* input for scene roles */}
             <label className="label">Roles</label>
             <div className="dropdown" onBlur={saveSceneRoles}>
               <div

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -1,8 +1,8 @@
 interface SelectInputProps {
-  values: string[];
-  value: string | null;
-  display?: (v: SelectInputProps["value"]) => string;
-  onChange: (v: SelectInputProps["value"]) => void;
+  values: any[];
+  value: any;
+  display?: (v: any) => string;
+  onChange: (v: any) => void;
   nullable?: boolean;
 }
 
@@ -13,9 +13,9 @@ function SelectInput({
   nullable = false,
   onChange,
 }: SelectInputProps) {
-  const render = display ? display : (v: string) => v;
+  const render = display ?? ((v: any) => String(v));
 
-  function handleClick(v: typeof value) {
+  function handleClick(v: any) {
     (document.activeElement as HTMLDivElement).blur();
     onChange(v);
   }
@@ -27,13 +27,13 @@ function SelectInput({
         role="button"
         className="justify-start input mb-1 font-normal join-item w-full"
       >
-        {value ? render(value) : "None"}
+        {value != null ? render(value) : "None"}
       </div>
       <ul
         tabIndex={0}
         className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
       >
-        {values.map((v: string, i: number) => (
+        {values.map((v: any, i: number) => (
           <li key={i}>
             <a onClick={() => handleClick(v)}>{render(v)}</a>
           </li>

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -26,6 +26,14 @@ export function modifySceneProp<K extends keyof VisualSceneState>(
   if (prop === "roles") {
     useVisualScene.setState({ roles: value as string[] | null });
   }
+
+  if (prop === "time") {
+    useVisualScene.setState({ time: value as number | null });
+  }
+
+  if (prop === "timerStateOperations") {
+    useVisualScene.setState({ timerStateOperations: value as any[] | null });
+  }
 }
 
 // wrapper for state mutating functions, will capture both state and operation

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -19,21 +19,7 @@ export function modifySceneProp<K extends keyof VisualSceneState>(
   value: VisualSceneState[K]
 ) {
   getScene()[prop] = value;
-  if (prop === "name") {
-    useVisualScene.setState({ name: value as string | null });
-  }
-
-  if (prop === "roles") {
-    useVisualScene.setState({ roles: value as string[] | null });
-  }
-
-  if (prop === "time") {
-    useVisualScene.setState({ time: value as number | null });
-  }
-
-  if (prop === "timerStateOperations") {
-    useVisualScene.setState({ timerStateOperations: value as any[] | null });
-  }
+  useVisualScene.setState({ [prop]: value } as Pick<VisualSceneState, K>);
 }
 
 // wrapper for state mutating functions, will capture both state and operation

--- a/frontend/src/features/authoring/scene/scene.ts
+++ b/frontend/src/features/authoring/scene/scene.ts
@@ -84,7 +84,7 @@ export function getScenePatch() {
 
   const fields: Record<string, any> = {};
 
-  ["name", "roles", "time"].forEach((field) => {
+  ["name", "roles", "time", "timerStateOperations"].forEach((field) => {
     if (JSON.stringify(scene[field]) !== JSON.stringify(savedScene[field])) {
       fields[field] = structuredClone(scene[field]);
     }

--- a/frontend/src/features/authoring/stores/visual.ts
+++ b/frontend/src/features/authoring/stores/visual.ts
@@ -27,7 +27,8 @@ const useVisualScene = create<VisualSceneState>((set) => ({
   time: null,
   timerStateOperations: null,
 
-  setVisualScene: (scene) => set({ time: null, timerStateOperations: null, ...scene }),
+  setVisualScene: (scene) =>
+    set({ time: null, timerStateOperations: null, ...scene }),
   setComponents: (components) => set({ components }),
   updateComponent: (component) =>
     set((state) => ({

--- a/frontend/src/features/authoring/stores/visual.ts
+++ b/frontend/src/features/authoring/stores/visual.ts
@@ -27,7 +27,7 @@ const useVisualScene = create<VisualSceneState>((set) => ({
   time: null,
   timerStateOperations: null,
 
-  setVisualScene: (scene) => set({ ...scene }),
+  setVisualScene: (scene) => set({ time: null, timerStateOperations: null, ...scene }),
   setComponents: (components) => set({ components }),
   updateComponent: (component) =>
     set((state) => ({

--- a/frontend/src/features/authoring/stores/visual.ts
+++ b/frontend/src/features/authoring/stores/visual.ts
@@ -10,6 +10,8 @@ export interface VisualSceneState {
   id: string | null;
   name: string | null;
   roles: string[] | null;
+  time: number | null;
+  timerStateOperations: any[] | null;
 
   setVisualScene: (scene: { id: string; components: VisualComponents }) => void;
   setComponents: (components: VisualComponents) => void;
@@ -22,6 +24,8 @@ const useVisualScene = create<VisualSceneState>((set) => ({
   id: null,
   name: null,
   roles: null,
+  time: null,
+  timerStateOperations: null,
 
   setVisualScene: (scene) => set({ ...scene }),
   setComponents: (components) => set({ components }),

--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -14,6 +14,7 @@ import NotesDisplayCard from "./modals/NotesModal/NotesModal";
 import ResourcesModal from "./modals/ResourcesModal/ResourcesModal";
 import PlayPageSideButton from "./components/PlayPageSideButton/PlayPageSideButton";
 import ResourcesPanel from "./components/ResourcesPanel";
+import SceneTimer from "./components/SceneTimer";
 
 const sceneCache = new Map();
 
@@ -191,6 +192,13 @@ export default function PlayScenarioPage({ group }) {
     };
   }, [scenarioId]);
 
+  const handleTimerTimeout = () => {
+    const timerStateOperations = currScene?.timerStateOperations;
+    if (!timerStateOperations?.length) return;
+    setStateVersion((v) => v + 1);
+    setStateVariables((prev) => applyStateOperations(prev, timerStateOperations));
+  };
+
   const buttonPressed = async (component) => {
     const currentSceneId = sceneId;
     const nextSceneId = component.nextScene;
@@ -238,6 +246,15 @@ export default function PlayScenarioPage({ group }) {
 
   return (
     <div className="w-full h-full relative">
+      {currScene?.time > 0 && (
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 z-30">
+          <SceneTimer
+            key={sceneId}
+            duration={currScene.time}
+            onTimeout={handleTimerTimeout}
+          />
+        </div>
+      )}
       <PlayScenarioCanvas
         scene={currScene}
         incrementor={isMultiplayer ? incrementor : undefined}

--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -196,7 +196,9 @@ export default function PlayScenarioPage({ group }) {
     const timerStateOperations = currScene?.timerStateOperations;
     if (!timerStateOperations?.length) return;
     setStateVersion((v) => v + 1);
-    setStateVariables((prev) => applyStateOperations(prev, timerStateOperations));
+    setStateVariables((prev) =>
+      applyStateOperations(prev, timerStateOperations)
+    );
   };
 
   const buttonPressed = async (component) => {

--- a/frontend/src/features/playScenario/components/SceneTimer.jsx
+++ b/frontend/src/features/playScenario/components/SceneTimer.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function SceneTimer({ duration, onTimeout }) {
+  const [secondsLeft, setSecondsLeft] = useState(duration);
+  const onTimeoutRef = useRef(onTimeout);
+  onTimeoutRef.current = onTimeout;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setSecondsLeft((s) => Math.max(0, s - 1));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (secondsLeft === 0) {
+      onTimeoutRef.current();
+    }
+  }, [secondsLeft]);
+
+  const minutes = Math.floor(secondsLeft / 60);
+  const seconds = secondsLeft % 60;
+  const display = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  const isLow = secondsLeft > 0 && secondsLeft <= Math.min(10, Math.floor(duration * 0.2));
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-4 py-2 rounded-full font-mono text-sm font-semibold shadow-md transition-colors ${
+        secondsLeft === 0
+          ? "bg-error text-error-content"
+          : isLow
+          ? "bg-error text-error-content animate-pulse"
+          : "bg-neutral text-neutral-content"
+      }`}
+      role="timer"
+      aria-live="off"
+      aria-label={`Time remaining: ${display}`}
+    >
+      <span>⏱</span>
+      <span>{display}</span>
+    </div>
+  );
+}

--- a/frontend/src/features/playScenario/components/SceneTimer.jsx
+++ b/frontend/src/features/playScenario/components/SceneTimer.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { TimerIcon } from "lucide-react";
 
 export default function SceneTimer({ duration, onTimeout }) {
   const [secondsLeft, setSecondsLeft] = useState(duration);
@@ -21,7 +22,8 @@ export default function SceneTimer({ duration, onTimeout }) {
   const minutes = Math.floor(secondsLeft / 60);
   const seconds = secondsLeft % 60;
   const display = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
-  const isLow = secondsLeft > 0 && secondsLeft <= Math.min(10, Math.floor(duration * 0.2));
+  const isLow =
+    secondsLeft > 0 && secondsLeft <= Math.min(10, Math.floor(duration * 0.2));
 
   return (
     <div
@@ -29,14 +31,14 @@ export default function SceneTimer({ duration, onTimeout }) {
         secondsLeft === 0
           ? "bg-error text-error-content"
           : isLow
-          ? "bg-error text-error-content animate-pulse"
-          : "bg-neutral text-neutral-content"
+            ? "bg-error text-error-content animate-pulse"
+            : "bg-neutral text-neutral-content"
       }`}
       role="timer"
       aria-live="off"
       aria-label={`Time remaining: ${display}`}
     >
-      <span>⏱</span>
+      <TimerIcon size={16} className="-mt-px" />
       <span>{display}</span>
     </div>
   );

--- a/wiki/Specifications/Timer.md
+++ b/wiki/Specifications/Timer.md
@@ -1,6 +1,6 @@
 # Timer
 
-This is the feature that will allow authors to do two things: 
+This is the feature that will allow authors to do two things:
 
 - Simulate the idea of "pressure" within a scene or group of scenes
 - Provide deadlines for members of groups, or full groups, to have completed sections of the scenario by
@@ -41,8 +41,8 @@ To avoid a situation like this, we can lock the scene(s) to a certain role, disa
 
 When a timer ends, the author probably wants to perform some meaningful action. The most likely "actions" in this case are scene and state transitions. For example:
 
-- *decrement health by 20*
-- *set out_of_time to true*
+- _decrement health by 20_
+- _set out_of_time to true_
 
 The second one might seem useless, but it could be an important metric used by the author when reviewing the stats for players of the scenario. Especially if its used for grading an educational scenario.
 
@@ -62,3 +62,67 @@ Since the scene graph can get fairly complex, we need to validate a few things b
 This way, cycling between the roles is actually possible within the section. We can just traverse the graph from the start point and switch the role assigned to every scene we encounter. If we didn't do this validation, we might end up overwriting roles on scenes unrelated to the critical section, due to a mistake on the author's part.
 
 The switching order should just cycle between the roles based on the definition order, aka the order they are stored in the scenario properties. Fine control over this order is unnecessary, and would introduce too much complexity.
+
+---
+
+## Implementation
+
+### What Is Implemented
+
+The **single-scene timer** is implemented. Authors can set a countdown duration on any scene and attach a list of state variable operations that fire when the timer reaches zero.
+
+#### Authoring
+
+**Scene Settings sidebar** (`SceneSettings.jsx`)
+
+- A "Timer Duration (seconds)" number input. Saving on blur calls `modifySceneProp("time", ...)`, which persists the value via autosave.
+- When `time > 0`, an "On Timeout" collapse panel appears below the scene details panel.
+
+**On Timeout panel** (`TimerStateOperationMenu.jsx`)
+
+- Lists the current timeout state operations for the scene.
+- A `+` button opens a modal to add a new operation (same action schema as button state operations: variable → operation → value).
+- Each row can edit or delete its operation inline.
+- All changes call `modifySceneProp("timerStateOperations", ...)` and are included in the autosave patch.
+
+#### Data Model
+
+Scene document (MongoDB):
+
+```js
+{
+  time: Number,                 // countdown duration in seconds; null = no timer
+  timerStateOperations: [{      // operations applied on timeout
+    stateVariableId: String,
+    displayName: String,
+    operation: String,          // e.g. "set", "add"
+    value: Any                  // string | number | boolean
+  }]
+}
+```
+
+Both fields are included in the `patchScene` allowlist and projected by the play navigation routes (`getSimpleScene`, `getConnectedScenes`).
+
+#### Play
+
+**`SceneTimer` component** (`SceneTimer.jsx`)
+
+- Counts down from `duration` seconds using `setInterval`.
+- Visual states:
+  - **Neutral** — more than the warning threshold remains
+  - **Pulsing red** — within the warning window: `min(10s, 20% of duration)`
+  - **Solid red** — timer has reached zero
+- Mounted with `key={sceneId}` in `PlayScenarioPage`, so it resets automatically on every scene transition.
+- Fires `onTimeout` exactly once when `secondsLeft` reaches zero.
+
+**`handleTimerTimeout`** (in `PlayScenarioPage.jsx`)
+
+- Reads `currScene.timerStateOperations` and calls `applyStateOperations`.
+- Increments `stateVersion` to trigger a re-render with updated state.
+
+### What Is Not Yet Implemented
+
+- **Multi-scene and global timers** — only per-scene timers exist.
+- **Scene transition on timeout** — only state variable operations are supported; navigating to a specific scene on timeout is not wired up.
+- **Backend timer for multiplayer sync** — the timer runs entirely client-side. In multiplayer, each player's timer is independent; there is no shared server-side source of truth.
+- **Role switch action** — not implemented.


### PR DESCRIPTION
## Issue

Missing timer feature documented in https://github.com/UoaWDCC/VPS/blob/master/wiki/Specifications/Timer.md

## Solution

Implement the single-scene timer.

- Play: A new timer component that can execute state variable transitions on timeout.
- Authoring: New "Timer Duration" input, "On Timeout" settings dropdown, and "Add Timeout State Operation" modal.

https://github.com/user-attachments/assets/4ced01b5-83ee-4948-9412-cbeeb4b1b34c

<img width="3644" height="2370" alt="image" src="https://github.com/user-attachments/assets/24a19914-7dee-444c-9794-6afc1f34de32" />

<img width="3644" height="2370" alt="image" src="https://github.com/user-attachments/assets/673d13e2-d7d9-4fbc-93ba-95e5a6235195" />

## Risk

- `Select.tsx` input component dependents

## Other

I don't like the settings for the timer is split into scene settings and a separate timeout settings dropdown but I'm pretty limited unless I completely change the dropdown-style ui.

Maybe I could create a mm:ss time input component if inputting seconds is too cumbersome for the user when they want to set longer timers (e.g. 8 minutes) and they don't want to convert minutes to seconds in their head.

We might want a top bar separate from the play area for the timer and resources button so that they don't cover potential clickable areas in the scene.

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [x] Continuous integration build passing
