### PR TITLE
feat: add scene outline overlay

### DIFF
--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -80,6 +80,25 @@ function Canvas() {
         onContextMenu={handleContextMenu}
       >
         <Overlay />
+
+        {/* scene outline */}
+        <svg
+          id="outline"
+          className="w-full h-full absolute pointer-events-none"
+          viewBox={`-50 -50 ${1920 + 50 * 2} ${1080 + 50 * 2}`}
+          style={{ mixBlendMode: "difference" }}
+        >
+          <rect
+            x="0"
+            y="0"
+            width="1920"
+            height="1080"
+            fill="none"
+            stroke="white"
+            strokeWidth="1"
+          />
+        </svg>
+
         <svg
           id="main"
           className="w-full h-full"


### PR DESCRIPTION
## Issue

When an image or shape extends outside the bounds of the scenes, it obscures the boundary. When something covers all or the majority of the edges, it makes it impossible to see whats actually within the scene and what isn't.

## Solution

Added a simple outline that exists between the overlay and content layers of the canvas, which is always present. This uses a blend mode to make sure it is always visible regardless of the content on the scene.

<img width="1230" height="723" alt="image" src="https://github.com/user-attachments/assets/eac35fb6-43e6-42bc-a850-f639970f528d" />


## Risk

None.

## Checklist

- [x] Acceptance criteria met
- [ ] Continuous integration build passing
