### PR TITLE
feat: added new tooltips to the image sections

### DIFF
--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -158,12 +158,14 @@ function ImageCreateMenu() {
           tabIndex={0}
           className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm top-[38px]"
         >
-          <li>
-            <a onClick={showFilePicker}>Upload Image</a>
+          <li className="tooltip tooltip-right tooltip-primary" data-tip="Upload a new image from your device">
+            <a onClick={showFilePicker}>Upload New Image</a>
           </li>
-          <li>
-            <a onClick={showModal}>Choose Image</a>
-          </li>
+          <li className="tooltip tooltip-right tooltip-primary" data-tip="Select an existing image from your uploads">
+            <a onClick={showModal}>
+              Select Existing Image
+            </a>
+          </li> 
         </ul>
       </div>
 

--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -158,14 +158,18 @@ function ImageCreateMenu() {
           tabIndex={0}
           className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm top-[38px]"
         >
-          <li className="tooltip tooltip-right tooltip-primary" data-tip="Upload a new image from your device">
+          <li
+            className="tooltip tooltip-right tooltip-primary"
+            data-tip="Upload a new image from your device"
+          >
             <a onClick={showFilePicker}>Upload New Image</a>
           </li>
-          <li className="tooltip tooltip-right tooltip-primary" data-tip="Select an existing image from your uploads">
-            <a onClick={showModal}>
-              Select Existing Image
-            </a>
-          </li> 
+          <li
+            className="tooltip tooltip-right tooltip-primary"
+            data-tip="Select an existing image from your uploads"
+          >
+            <a onClick={showModal}>Select Existing Image</a>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
## Issue

The image area had  unclear naming for “Upload image” and “Choose image”

## Solution

To add tooltips and rename parts of the buttons.

<img width="708" height="188" alt="image" src="https://github.com/user-attachments/assets/7a4c6f20-156b-4856-9c4a-42f02c31b40e" />

## Risk

_Potential risks that this PR might bring_

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
