### PR TITLE
feat(authoring): start play from the currently viewed scene

### DIFF
--- a/backend/src/db/daos/accessDao.js
+++ b/backend/src/db/daos/accessDao.js
@@ -105,10 +105,17 @@ const revokeAccess = async (scenarioId, userId) => {
   return { status: 200, message: "Revoked" };
 };
 
+const isAuthor = async (scenarioId, uid) => {
+  const accessList = await getAccessList(scenarioId);
+  if (!accessList) return false;
+  return accessList.ownerId === uid || accessList.users.has(uid);
+};
+
 export {
   getAccessList,
   createAccessList,
   deleteAccessList,
   grantAccess,
   revokeAccess,
+  isAuthor,
 };

--- a/backend/src/routes/api/navigate/user.js
+++ b/backend/src/routes/api/navigate/user.js
@@ -83,7 +83,12 @@ const updateStateVariables = async (user, scenarioId, component) => {
 };
 
 export const userNavigate = async (req) => {
-  const { uid, currentScene, componentId, startScene: startSceneParam } = req.body;
+  const {
+    uid,
+    currentScene,
+    componentId,
+    startScene: startSceneParam,
+  } = req.body;
   const { scenarioId } = req.params;
 
   const [user, authorised] = await Promise.all([
@@ -101,7 +106,8 @@ export const userNavigate = async (req) => {
 
   // the first time the user is navigating
   if (!path) {
-    const firstSceneId = startScene || (await getScenarioFirstScene(scenarioId));
+    const firstSceneId =
+      startScene || (await getScenarioFirstScene(scenarioId));
     const [, scenes, [stateVariables, stateVersion]] = await Promise.all([
       addSceneToPath(user._id, scenarioId, null, firstSceneId),
       getConnectedScenes(firstSceneId),
@@ -120,10 +126,16 @@ export const userNavigate = async (req) => {
     // Replace the entire path rather than appending: the prior history is invalid after jumping to an arbitrary scene.
     const updatePromise =
       startScene && startScene !== path[0]
-        ? User.updateOne({ uid }, { $set: { [`paths.${scenarioId}`]: [startScene] } })
+        ? User.updateOne(
+            { uid },
+            { $set: { [`paths.${scenarioId}`]: [startScene] } }
+          )
         : Promise.resolve();
 
-    const [, scenes] = await Promise.all([updatePromise, getConnectedScenes(activeSceneId)]);
+    const [, scenes] = await Promise.all([
+      updatePromise,
+      getConnectedScenes(activeSceneId),
+    ]);
 
     const [stateVariables, stateVersion] = await syncStateVariables(
       user,

--- a/backend/src/routes/api/navigate/user.js
+++ b/backend/src/routes/api/navigate/user.js
@@ -1,6 +1,7 @@
 import { getStateVariables } from "../../../db/daos/scenarioDao.js";
 import { getComponent } from "../../../db/daos/sceneDao.js";
 import { setUserStateVariables } from "../../../db/daos/userDao.js";
+import { isAuthor } from "../../../db/daos/accessDao.js";
 import Scene from "../../../db/models/scene.js";
 import User from "../../../db/models/user.js";
 
@@ -82,18 +83,25 @@ const updateStateVariables = async (user, scenarioId, component) => {
 };
 
 export const userNavigate = async (req) => {
-  const { uid, currentScene, componentId } = req.body;
+  const { uid, currentScene, componentId, startScene: startSceneParam } = req.body;
   const { scenarioId } = req.params;
 
-  const user = await User.findOne(
-    { uid },
-    { paths: 1, _id: 1, stateVariables: 1, stateVersions: 1 }
-  ).lean();
+  const [user, authorised] = await Promise.all([
+    User.findOne(
+      { uid },
+      { paths: 1, _id: 1, stateVariables: 1, stateVersions: 1 }
+    ).lean(),
+    // Only hit the access list when startScene is present — avoids an extra DB query on every normal player request.
+    startSceneParam ? isAuthor(scenarioId, uid) : false,
+  ]);
+
+  // Non-authors cannot jump to an arbitrary scene even if they manually craft a URL with startScene.
+  const startScene = authorised ? startSceneParam : null;
   const path = user.paths[scenarioId];
 
-  // the first time the user  is navigating
+  // the first time the user is navigating
   if (!path) {
-    const firstSceneId = await getScenarioFirstScene(scenarioId);
+    const firstSceneId = startScene || (await getScenarioFirstScene(scenarioId));
     const [, scenes, [stateVariables, stateVersion]] = await Promise.all([
       addSceneToPath(user._id, scenarioId, null, firstSceneId),
       getConnectedScenes(firstSceneId),
@@ -107,7 +115,15 @@ export const userNavigate = async (req) => {
 
   // the first time the user is navigating in their session
   if (!currentScene) {
-    const scenes = await getConnectedScenes(path[0]);
+    const activeSceneId = startScene || path[0];
+
+    // Replace the entire path rather than appending: the prior history is invalid after jumping to an arbitrary scene.
+    const updatePromise =
+      startScene && startScene !== path[0]
+        ? User.updateOne({ uid }, { $set: { [`paths.${scenarioId}`]: [startScene] } })
+        : Promise.resolve();
+
+    const [, scenes] = await Promise.all([updatePromise, getConnectedScenes(activeSceneId)]);
 
     const [stateVariables, stateVersion] = await syncStateVariables(
       user,

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -64,7 +64,8 @@ export default function AuthoringToolPage() {
   }, []);
 
   function playScenario() {
-    window.open(`/play/${scenarioId}`, "_blank");
+    const startScene = sceneId ? `?startScene=${sceneId}` : "";
+    window.open(`/play/${scenarioId}${startScene}`, "_blank");
   }
 
   function goToGroups() {

--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useState } from "react";
-import { useParams, useHistory } from "react-router-dom";
+import { useContext, useEffect, useRef, useState } from "react";
+import { useParams, useHistory, useLocation } from "react-router-dom";
 import axios from "axios";
 import { toast } from "react-hot-toast";
 
@@ -23,7 +23,8 @@ const navigateSingleplayer = async (
   currentScene,
   addFlags,
   removeFlags,
-  componentId
+  componentId,
+  startScene
 ) => {
   const token = await user.getIdToken();
   const config = {
@@ -33,7 +34,7 @@ const navigateSingleplayer = async (
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    data: { currentScene, addFlags, removeFlags, componentId },
+    data: { currentScene, addFlags, removeFlags, componentId, startScene },
   };
   const res = await axios.request(config);
   if (res.data.scenes) {
@@ -98,7 +99,10 @@ export default function PlayScenarioPage({ group }) {
   const { user, loading, error: authError } = useContext(AuthenticationContext);
   const { scenarioId } = useParams();
   const history = useHistory();
-  const isMultiplayer = history.location.pathname.includes("/multiplayer/");
+  const location = useLocation();
+  const isMultiplayer = location.pathname.includes("/multiplayer/");
+  // Ref so it survives re-renders without triggering them; consumed once by the initial navigate call and then cleared.
+  const startSceneRef = useRef(new URLSearchParams(location.search).get("startScene"));
 
   const [sceneId, setSceneId] = useState(null);
   const [stateVariables, setStateVariables] = useState([]);
@@ -143,6 +147,9 @@ export default function PlayScenarioPage({ group }) {
       }
     }
 
+    const startScene = startSceneRef.current;
+    startSceneRef.current = null; // Clear before the await so a concurrent retry (409 handler) never replays it.
+
     try {
       const { newSceneId, stateVariables, newStateVersion } = isMultiplayer
         ? await navigateMultiplayer(
@@ -159,7 +166,8 @@ export default function PlayScenarioPage({ group }) {
             sceneId,
             addFlags,
             removeFlags,
-            componentId
+            componentId,
+            startScene
           );
 
       if (isMultiplayer) {

--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -102,7 +102,9 @@ export default function PlayScenarioPage({ group }) {
   const location = useLocation();
   const isMultiplayer = location.pathname.includes("/multiplayer/");
   // Ref so it survives re-renders without triggering them; consumed once by the initial navigate call and then cleared.
-  const startSceneRef = useRef(new URLSearchParams(location.search).get("startScene"));
+  const startSceneRef = useRef(
+    new URLSearchParams(location.search).get("startScene")
+  );
 
   const [sceneId, setSceneId] = useState(null);
   const [stateVariables, setStateVariables] = useState([]);

--- a/frontend/src/features/playScenario/PlayScenarioResolver.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioResolver.jsx
@@ -1,6 +1,12 @@
 import axios from "axios";
 import { useContext, useEffect, useState } from "react";
-import { Route, Switch, useHistory, useLocation, useParams } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  useHistory,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 
 import AuthenticationContext from "context/AuthenticationContext";
 
@@ -41,10 +47,14 @@ export default function PlayScenarioResolver() {
       const fetchedGroup = await getGroup(user, scenarioId);
       if (!fetchedGroup) {
         setGroup("none");
-        return history.replace(`/play/${scenarioId}/singleplayer${location.search}`);
+        return history.replace(
+          `/play/${scenarioId}/singleplayer${location.search}`
+        );
       }
       setGroup(fetchedGroup);
-      return history.replace(`/play/${scenarioId}/multiplayer${location.search}`);
+      return history.replace(
+        `/play/${scenarioId}/multiplayer${location.search}`
+      );
     };
     resolveType();
   }, [scenarioId]);

--- a/frontend/src/features/playScenario/PlayScenarioResolver.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioResolver.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useContext, useEffect, useState } from "react";
-import { Route, Switch, useHistory, useParams } from "react-router-dom";
+import { Route, Switch, useHistory, useLocation, useParams } from "react-router-dom";
 
 import AuthenticationContext from "context/AuthenticationContext";
 
@@ -26,6 +26,7 @@ export default function PlayScenarioResolver() {
   const { user, loading, error: authError } = useContext(AuthenticationContext);
   const { scenarioId } = useParams();
   const history = useHistory();
+  const location = useLocation();
   const [group, setGroup] = useState(null);
 
   if (loading) return <LoadingPage text="Loading Scenario..." />;
@@ -40,10 +41,10 @@ export default function PlayScenarioResolver() {
       const fetchedGroup = await getGroup(user, scenarioId);
       if (!fetchedGroup) {
         setGroup("none");
-        return history.replace(`/play/${scenarioId}/singleplayer/`);
+        return history.replace(`/play/${scenarioId}/singleplayer${location.search}`);
       }
       setGroup(fetchedGroup);
-      return history.replace(`/play/${scenarioId}/multiplayer/`);
+      return history.replace(`/play/${scenarioId}/multiplayer${location.search}`);
     };
     resolveType();
   }, [scenarioId]);

--- a/wiki/Backend API.md
+++ b/wiki/Backend API.md
@@ -337,14 +337,14 @@ Body:
 
 ```json
 {
+    "uid":          "firebase-uid",
     "currentScene": "scene-id-or-null",
     "componentId":  "component-id-or-null",
-    "addFlags":     [],
-    "removeFlags":  [],
     "startScene":   "scene-id-or-null"
 }
 ```
 
+- `uid`: the Firebase UID of the authenticated user.
 - `currentScene`: the scene the user is currently on. `null` on the first request of a session.
 - `componentId`: the component the user interacted with. `null` on the first request of a session.
 - `startScene`: _(authors only)_ override the starting scene for this session. Ignored for non-authors. When provided, the user's path is reset to this scene so subsequent navigation stays consistent.
@@ -362,6 +362,7 @@ Returns:
 
 - `active`: the scene the user should now be on.
 - `scenes`: the current scene plus directly reachable next scenes, preloaded for the client cache.
+- `active` and `scenes` are omitted when the interacted component does not lead to a different scene.
 
 **Reset (singleplayer):\***
 
@@ -371,6 +372,7 @@ Body:
 
 ```json
 {
+    "uid":          "firebase-uid",
     "currentScene": "scene-id"
 }
 ```
@@ -383,19 +385,46 @@ Returns: `200 OK` (no body)
 
 `POST /api/navigate/group/:groupId`
 
-Same body and response shape as the singleplayer navigate endpoint, operating on the group's shared state instead of an individual user's path. Does not support `startScene`.
+Body:
+
+```json
+{
+    "uid":          "firebase-uid",
+    "currentScene": "scene-id-or-null",
+    "componentId":  "component-id-or-null",
+    "addFlags":     [],
+    "removeFlags":  []
+}
+```
+
+- `uid`: the Firebase UID of the authenticated user.
+- `currentScene`: the scene the user is currently on. `null` on the first request of a session.
+- `componentId`: the component the user interacted with. `null` on the first request of a session.
+- `addFlags`: flags to add to the group's current flags on this navigation step.
+- `removeFlags`: flags to remove from the group's current flags on this navigation step.
+
+Response shape is the same as the singleplayer navigate endpoint, operating on the group's shared state instead of an individual user's path. Does not support `startScene`.
 
 **Reset (multiplayer):\***
 
 `POST /api/navigate/group/reset/:groupId`
 
-Same behaviour as the singleplayer reset, applied to the group.
+Body:
+
+```json
+{
+    "uid":          "firebase-uid",
+    "currentScene": "scene-id"
+}
+```
+
+Same behaviour as the singleplayer reset, applied to the group. Additionally clears all notes for the group and resets the group's current flags.
 
 **Get multiplayer resources:\***
 
 `GET /api/navigate/group/resources/:groupId`
 
-Returns the resources available to the group filtered by the current state variables.
+Returns the resources available to the group filtered by the group's current flags.
 
 ---
 

--- a/wiki/Backend API.md
+++ b/wiki/Backend API.md
@@ -323,6 +323,82 @@ Returns:
     "note deleted"
 }
 ```
+---
+
+## Navigate
+
+All navigate endpoints require an authorisation header.
+
+**Navigate (singleplayer):\***
+
+`POST /api/navigate/user/:scenarioId`
+
+Body:
+
+```json
+{
+    "currentScene": "scene-id-or-null",
+    "componentId":  "component-id-or-null",
+    "addFlags":     [],
+    "removeFlags":  [],
+    "startScene":   "scene-id-or-null"
+}
+```
+
+- `currentScene`: the scene the user is currently on. `null` on the first request of a session.
+- `componentId`: the component the user interacted with. `null` on the first request of a session.
+- `startScene`: _(authors only)_ override the starting scene for this session. Ignored for non-authors. When provided, the user's path is reset to this scene so subsequent navigation stays consistent.
+
+Returns:
+
+```json
+{
+    "active": "scene-id",
+    "scenes": [],
+    "stateVariables": [],
+    "stateVersion": 1
+}
+```
+
+- `active`: the scene the user should now be on.
+- `scenes`: the current scene plus directly reachable next scenes, preloaded for the client cache.
+
+**Reset (singleplayer):\***
+
+`POST /api/navigate/user/reset/:scenarioId`
+
+Body:
+
+```json
+{
+    "currentScene": "scene-id"
+}
+```
+
+Clears the user's path for this scenario, allowing them to start from the beginning. Only valid when the current scene contains a `RESET_BUTTON` component.
+
+Returns: `200 OK` (no body)
+
+**Navigate (multiplayer):\***
+
+`POST /api/navigate/group/:groupId`
+
+Same body and response shape as the singleplayer navigate endpoint, operating on the group's shared state instead of an individual user's path. Does not support `startScene`.
+
+**Reset (multiplayer):\***
+
+`POST /api/navigate/group/reset/:groupId`
+
+Same behaviour as the singleplayer reset, applied to the group.
+
+**Get multiplayer resources:\***
+
+`GET /api/navigate/group/resources/:groupId`
+
+Returns the resources available to the group filtered by the current state variables.
+
+---
+
 **Reorder scenes for a given Scenario Id:\***
 
 `PUT /api/scenario/:scenarioId/scene/reorder`


### PR DESCRIPTION
## Issue

Authors can not easily restart their scenario play-test.

## Solution

Clicking "Play" will start a play session from the currently viewed scene in the editor.

https://github.com/user-attachments/assets/0dea7701-c9e5-405a-a561-6563fe6a5e9e

## Technical

- Play button passes current scene as ?startScene query param
- Resolver preserves the query param through the singleplayer/multiplayer redirect
- PlayScenarioPage sends startScene to the navigate API on first load only
- Navigate endpoint verifies the user is an author before honouring startScene; regular players cannot use it to jump to arbitrary scenes
- Resets the user's path to the requested scene so forward navigation stays consistent

## Risk

- The startScene override is gated behind `isAuthor` but I have not thoroughly tested if actually blocks regular players.
- Currently no option to edit state variables that would have been changed by previous scenes

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date
- [x] Continuous integration build passing
