### PR TITLE
Fixed State Conditional Resolution

### DIFF
--- a/backend/src/db/models/StoredFile.js
+++ b/backend/src/db/models/StoredFile.js
@@ -29,7 +29,7 @@ const StoredFileSchema = new Schema(
             enum: ["=", "!=", "<", ">"],
             required: true,
           },
-          value: { type: String, required: true },
+          value: { type: Schema.Types.Mixed, required: true },
         },
       ],
       default: [],

--- a/frontend/src/components/StateVariables/CreateStateConditional.jsx
+++ b/frontend/src/components/StateVariables/CreateStateConditional.jsx
@@ -44,7 +44,7 @@ const CreateStateConditional = ({ fileId, open, setOpen, updateFile }) => {
     const stateConditional = {
       stateVariableId: selectedState.id,
       comparator,
-      value,
+      value: selectedState.type === stateTypes.NUMBER ? Number(value) : value,
     };
 
     api

--- a/frontend/src/components/StateVariables/EditStateConditional.jsx
+++ b/frontend/src/components/StateVariables/EditStateConditional.jsx
@@ -58,7 +58,7 @@ const EditStateConditional = ({
     const stateConditional = {
       ...conditional,
       comparator,
-      value,
+      value: stateVariable.type === stateTypes.NUMBER ? Number(value) : value,
     };
 
     api

--- a/frontend/src/utils/stateConditionalEvaluator.js
+++ b/frontend/src/utils/stateConditionalEvaluator.js
@@ -1,5 +1,3 @@
-import { stateTypes } from "../components/StateVariables/stateTypes";
-
 /**
  * Evaluates a single state conditional against current state variables
  * @param {Object} conditional - The state conditional to evaluate

--- a/frontend/src/utils/stateConditionalEvaluator.js
+++ b/frontend/src/utils/stateConditionalEvaluator.js
@@ -23,55 +23,15 @@ function evaluateStateConditional(conditional, stateVariables) {
   const { comparator, value: expectedValue } = conditional;
   const currentValue = stateVariable.value;
 
-  // Handle different comparison types based on state variable type
-  switch (stateVariable.type) {
-    case stateTypes.BOOLEAN: {
-      switch (comparator) {
-        case "=":
-          return currentValue === expectedValue;
-        case "!=":
-          return currentValue !== expectedValue;
-        default:
-          return false;
-      }
-    }
-
-    case stateTypes.NUMBER: {
-      const numExpected = parseFloat(expectedValue);
-      const numCurrent = parseFloat(currentValue);
-
-      if (isNaN(numExpected) || isNaN(numCurrent)) {
-        return false;
-      }
-
-      switch (comparator) {
-        case "=":
-          return numCurrent === numExpected;
-        case "!=":
-          return numCurrent !== numExpected;
-        case ">":
-          return numCurrent > numExpected;
-        case "<":
-          return numCurrent < numExpected;
-        default:
-          return false;
-      }
-    }
-
-    case stateTypes.STRING: {
-      const strExpected = String(expectedValue);
-      const strCurrent = String(currentValue);
-
-      switch (comparator) {
-        case "=":
-          return strCurrent === strExpected;
-        case "!=":
-          return strCurrent !== strExpected;
-        default:
-          return false;
-      }
-    }
-
+  switch (comparator) {
+    case "=":
+      return currentValue === expectedValue;
+    case "!=":
+      return currentValue !== expectedValue;
+    case ">":
+      return currentValue > expectedValue;
+    case "<":
+      return currentValue < expectedValue;
     default:
       return false;
   }

--- a/frontend/src/utils/stateConditionalEvaluator.js
+++ b/frontend/src/utils/stateConditionalEvaluator.js
@@ -26,14 +26,11 @@ function evaluateStateConditional(conditional, stateVariables) {
   // Handle different comparison types based on state variable type
   switch (stateVariable.type) {
     case stateTypes.BOOLEAN: {
-      const boolExpected = expectedValue === "true";
-      const boolCurrent = currentValue === "true";
-
       switch (comparator) {
         case "=":
-          return boolCurrent === boolExpected;
+          return currentValue === expectedValue;
         case "!=":
-          return boolCurrent !== boolExpected;
+          return currentValue !== expectedValue;
         default:
           return false;
       }


### PR DESCRIPTION
## Issue
Problem with evaluating state conditionals for boolean state variables. Results are often incorrect (i.e. for '=', resource never shows). Numbers are also stored as strings, resulting in a need to parse before comparison.

## Solution
Allow for mixed data types for state variables. Now also compares boolean variables directly rather than converting from string format. Numbers properly stored as numbers (for both creating and editing state conditionals). Comparison logic simplified as type-dependent parsing is no longer necessary.

## Risk
None that I'm aware of.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
