### PR TITLE
fix: save null value scene links

### DIFF
--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -133,7 +133,7 @@ export const modifyComponentProp = modify(
 
     const [object, key] = getObject(prop, component);
     if (typeof val === "function") object[key] = val(object[key]);
-    else if (typeof val === "object" && !Array.isArray(val))
+    else if (val !== null && typeof val === "object" && !Array.isArray(val))
       object[key] = merge(object[key], val);
     else object[key] = val;
   }


### PR DESCRIPTION
## Issue

Setting a scene link to **None** doesn't save, making unsetting a link impossible.

## Solution

since null is typeof object, the modification function is trying to perform an object merge after the check. Obviously this property is not an object, so the solution is just to explicity check for null, and if so treat it as direct assignment.

## Risk

No risk.

## Checklist

- [x] Acceptance criteria met
- [ ] Continuous integration build passing
