### PR TITLE
VPS 58/ sample group data is xlsx not csv

### DIFF
--- a/frontend/src/features/groups/ManageGroupsPage.jsx
+++ b/frontend/src/features/groups/ManageGroupsPage.jsx
@@ -137,7 +137,7 @@ export default function ManageGroupsPage() {
 
   function downloadSample() {
     window.open(
-      "https://firebasestorage.googleapis.com/v0/b/virtual-patient-simulator.appspot.com/o/_manual-uploads%2Ftesting_group.xlsx?alt=media&token=a9c61c46-c317-4c8c-b8b8-ba049f8c9ff3",
+      "https://firebasestorage.googleapis.com/v0/b/virtual-patient-simulator.appspot.com/o/_manual-uploads%2Ftesting_group.csv?alt=media&token=a7afaae7-f4a6-4eb3-ba1d-634e849fcc6c",
       "_blank",
       "noopener,noreferrer"
     );


### PR DESCRIPTION
## Issue

The sample CSV file for groups is actually an XLSX file when downloaded.

## Solution

Replace the XLSX file in the Firebase storage with a CSV file, and replace the download link in the code.

## Risk

None

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
