### PR TITLE
fix: redirect index to new play page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from "@material-ui/core";
 import { useEffect } from "react";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom";
 
 import AuthenticationContextProvider from "./context/AuthenticationContextProvider";
 import ScenarioContextProvider from "./context/ScenarioContextProvider";
@@ -10,9 +10,7 @@ import LoginPage from "./features/login/LoginPage/LoginPage";
 import ManageGroupsPage from "./features/groups/ManageGroupsPage";
 import PlayScenarioResolver from "./features/playScenario/PlayScenarioResolver";
 import PlayLandingPage from "./features/playScenario/PlayLandingPage";
-import ScenarioSelectionPage from "./features/scenarioSelection/ScenarioSelectionPage";
 import ScenarioInfo from "./features/scenarioInfo/ScenarioInfo";
-import PlayPage from "./features/play/PlayPage";
 import Dashboard from "./features/dashboard/Dashboard";
 import DashboardLandingPage from "./features/dashboard/DashboardLandingPage";
 import AboutUsPage from "./features/aboutUs/AboutUsPage";
@@ -77,9 +75,7 @@ export default function App() {
                 <Route exact path="/login" component={LoginPage} />
 
                 <ProtectedRoute exact path="/">
-                  <ScenarioContextProvider>
-                    <ScenarioSelectionPage />
-                  </ScenarioContextProvider>
+                  <Redirect to="/play" />
                 </ProtectedRoute>
 
                 <ProtectedRoute path="/play/:scenarioId">
@@ -118,12 +114,6 @@ export default function App() {
                 </ProtectedRoute>
 
                 <Route path="/aboutus" component={AboutUsPage} />
-
-                <ProtectedRoute path="/play-page">
-                  <ScenarioContextProvider>
-                    <PlayPage />
-                  </ScenarioContextProvider>
-                </ProtectedRoute>
 
                 <ScenarioContextProvider>
                   <Switch>


### PR DESCRIPTION
## Issue

The website was directing to the old play page

## Solution

the default url now re-directs to the new play page, using the same naming routes as the rest of the routes

/play -> play page 
/create -> create scenario 
/dashboard -> dashboard access

## Risk

I havent fully testing it, so it should be fine but it depends. But it should work, unless there is a freaky bug

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Modified application routing structure; the home page now redirects to the play section instead of displaying the scenario selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->