### PR TITLE
ci: add vite build check to frontend

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,3 +31,20 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn prettier
       - run: yarn lint
+
+  build:
+    name: build
+    needs: lint-format
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+      - run: yarn install --frozen-lockfile
+      - run: yarn build


### PR DESCRIPTION
## Issue

PR template has a check item for CI build passing but there is no CI script for it

## Solution

Add CI script

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date