### PR TITLE
VPS-95/Fixed issue where pasting into input area would paste in slide

### DIFF
--- a/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
@@ -23,7 +23,13 @@ function plainToDoc(text: string) {
   return { style: {}, blocks };
 }
 
+function isInputTarget(e: ClipboardEvent) {
+  const tag = (e.target as HTMLElement)?.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA";
+}
+
 export function copy(e: ClipboardEvent) {
+  if (isInputTarget(e)) return;
   const { selected } = useEditorStore.getState();
   if (!selected) return;
 
@@ -33,6 +39,7 @@ export function copy(e: ClipboardEvent) {
 }
 
 export function cut(e: ClipboardEvent) {
+  if (isInputTarget(e)) return;
   const { selected, setSelected } = useEditorStore.getState();
   if (!selected) return;
 
@@ -44,6 +51,7 @@ export function cut(e: ClipboardEvent) {
 }
 
 export function paste(e: ClipboardEvent) {
+  if (isInputTarget(e)) return;
   e.preventDefault();
   const { mode, selected, selection, setSelected, setSelection } =
     useEditorStore.getState();


### PR DESCRIPTION
## Issue

Pasting text into the scene name input field incorrectly pastes into the slide instead.

## Solution

Added an isInputTarget guard to the global copy, cut, and paste clipboard handlers so they bail out early when the event target is an INPUT or TEXTAREA element, matching the same guard already in the keydown handler.

## Risk

Low. The change only affects clipboard events originating from native input elements, which the global handlers should never have been handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clipboard operations (copy, cut, paste) interfering with form field interactions. Clipboard actions now work correctly when users interact with text input fields without triggering unintended editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->