### PR TITLE
fix(frontend): detangle saving and scene switching logic

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-select": "^5.10.2",
     "styled-components": "^6.1.19",
     "uuid": "^14.0.0",
+    "typescript-event-target": "^1.1.2",
     "zustand": "3"
   },
   "devDependencies": {

--- a/frontend/src/components/StateVariables/EditStateVariable.jsx
+++ b/frontend/src/components/StateVariables/EditStateVariable.jsx
@@ -97,14 +97,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
           }),
         }));
 
-        const updatePromises = updatedScenes.map((scene) =>
-          modifyScene({
-            _id: scene._id,
-            fields: {},
-            components: scene.components,
-            deletedComponentIds: [],
-          })
-        );
+        const updatePromises = updatedScenes.map(modifyScene);
 
         await Promise.all(updatePromises);
         await reFetch();

--- a/frontend/src/components/StateVariables/EditStateVariable.jsx
+++ b/frontend/src/components/StateVariables/EditStateVariable.jsx
@@ -11,7 +11,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
   const { user } = useContext(AuthenticationContext);
   const { setStateVariables } = useContext(ScenarioContext);
   const sceneContext = useContext(SceneContext);
-  const { scenes, saveScenePatch, reFetch } = sceneContext || {
+  const { scenes, modifyScene, reFetch } = sceneContext || {
     scenes: [],
     saveScenePatch: async () => {},
     reFetch: async () => {},
@@ -71,7 +71,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
 
       // Clean up all state operations that reference this deleted state variable
       // Only do this if we have access to scenes (SceneContext is available)
-      if (scenes && scenes.length > 0 && saveScenePatch) {
+      if (scenes && scenes.length > 0 && modifyScene) {
         const updatedScenes = scenes.map((scene) => ({
           ...scene,
           components: scene.components.map((component) => {
@@ -98,7 +98,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
         }));
 
         const updatePromises = updatedScenes.map((scene) =>
-          saveScenePatch({
+          modifyScene({
             _id: scene._id,
             fields: {},
             components: scene.components,

--- a/frontend/src/components/StateVariables/EditStateVariable.jsx
+++ b/frontend/src/components/StateVariables/EditStateVariable.jsx
@@ -14,8 +14,8 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
   const sceneContext = useContext(SceneContext);
   const { scenes, modifyScene, reFetch } = sceneContext || {
     scenes: [],
-    saveScenePatch: async () => { },
-    reFetch: async () => { },
+    saveScenePatch: async () => {},
+    reFetch: async () => {},
   };
 
   const { name, type, value } = stateVariable;
@@ -75,27 +75,29 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
       if (scenes && scenes.length > 0 && modifyScene) {
         const updatedScenes = scenes.map((scene) => ({
           ...scene,
-          components: arrayToObject(scene.components.map((component) => {
-            if (!component.stateOperations) return component;
+          components: arrayToObject(
+            scene.components.map((component) => {
+              if (!component.stateOperations) return component;
 
-            // Filter out state operations that reference the deleted state variable
-            const filteredOperations = component.stateOperations.filter(
-              (operation) => {
-                // Check both UUID and name references
-                const referencesDeletedVariable =
-                  (operation.stateVariableId &&
-                    operation.stateVariableId === stateVariable.id) ||
-                  (!operation.stateVariableId && operation.name === name);
+              // Filter out state operations that reference the deleted state variable
+              const filteredOperations = component.stateOperations.filter(
+                (operation) => {
+                  // Check both UUID and name references
+                  const referencesDeletedVariable =
+                    (operation.stateVariableId &&
+                      operation.stateVariableId === stateVariable.id) ||
+                    (!operation.stateVariableId && operation.name === name);
 
-                return !referencesDeletedVariable;
-              }
-            );
+                  return !referencesDeletedVariable;
+                }
+              );
 
-            return {
-              ...component,
-              stateOperations: filteredOperations,
-            };
-          })),
+              return {
+                ...component,
+                stateOperations: filteredOperations,
+              };
+            })
+          ),
         }));
 
         const updatePromises = updatedScenes.map(modifyScene);
@@ -126,8 +128,9 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
     <>
       <fieldset
         key={stateVariable.name}
-        className={`fieldset bg-base-200 border-base-300 rounded-box border p-4 ${isEditing ? "ring-2 ring-grey" : ""
-          }`}
+        className={`fieldset bg-base-200 border-base-300 rounded-box border p-4 ${
+          isEditing ? "ring-2 ring-grey" : ""
+        }`}
       >
         <div className="flex wrap gap-xs">
           <div className="flex-1 flex flex-col">

--- a/frontend/src/components/StateVariables/EditStateVariable.jsx
+++ b/frontend/src/components/StateVariables/EditStateVariable.jsx
@@ -6,6 +6,7 @@ import ScenarioContext from "../../context/ScenarioContext";
 import SceneContext from "../../context/SceneContext";
 import SelectInput from "../../features/authoring/components/Select";
 import { stateTypes } from "./stateTypes";
+import { arrayToObject } from "../../features/authoring/scene/util";
 
 const EditStateVariable = ({ stateVariable, scenarioId }) => {
   const { user } = useContext(AuthenticationContext);
@@ -13,8 +14,8 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
   const sceneContext = useContext(SceneContext);
   const { scenes, modifyScene, reFetch } = sceneContext || {
     scenes: [],
-    saveScenePatch: async () => {},
-    reFetch: async () => {},
+    saveScenePatch: async () => { },
+    reFetch: async () => { },
   };
 
   const { name, type, value } = stateVariable;
@@ -74,7 +75,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
       if (scenes && scenes.length > 0 && modifyScene) {
         const updatedScenes = scenes.map((scene) => ({
           ...scene,
-          components: scene.components.map((component) => {
+          components: arrayToObject(scene.components.map((component) => {
             if (!component.stateOperations) return component;
 
             // Filter out state operations that reference the deleted state variable
@@ -94,7 +95,7 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
               ...component,
               stateOperations: filteredOperations,
             };
-          }),
+          })),
         }));
 
         const updatePromises = updatedScenes.map(modifyScene);
@@ -125,9 +126,8 @@ const EditStateVariable = ({ stateVariable, scenarioId }) => {
     <>
       <fieldset
         key={stateVariable.name}
-        className={`fieldset bg-base-200 border-base-300 rounded-box border p-4 ${
-          isEditing ? "ring-2 ring-grey" : ""
-        }`}
+        className={`fieldset bg-base-200 border-base-300 rounded-box border p-4 ${isEditing ? "ring-2 ring-grey" : ""
+          }`}
       >
         <div className="flex wrap gap-xs">
           <div className="flex-1 flex flex-col">

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -1,14 +1,15 @@
-import { useCallback, useContext, useEffect } from "react";
+import { useContext } from "react";
 import AuthenticationContext from "./AuthenticationContext";
 import SceneContext from "./SceneContext";
-import { useParams } from "react-router-dom";
+import { useParams, useHistory } from "react-router-dom";
 import { api } from "../util/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import LoadingPage from "../features/status/LoadingPage";
 import GenericErrorPage from "../features/status/GenericErrorPage";
 import toast from "react-hot-toast";
 import { parseMedia } from "../firebase/storage";
-import { init } from "../features/authoring/scene/history";
+import useEditorStore from "../features/authoring/stores/editor";
+import { replace } from "../features/authoring/scene/operations/modifiers";
 
 async function getAllScenes(user, id) {
   const res = await api.get(user, `api/scenario/${id}/scene/all`);
@@ -23,7 +24,7 @@ function deleteScene(user, scenarioId, sceneId) {
   return api.delete(user, `/api/scenario/${scenarioId}/scene/${sceneId}`);
 }
 
-async function saveScenePatch(user, scenarioId, patch) {
+async function modifyScene(user, scenarioId, patch) {
   const parsedComponents = await parseMedia(
     patch.components,
     scenarioId,
@@ -37,6 +38,62 @@ async function saveScenePatch(user, scenarioId, patch) {
   });
 }
 
+function generatePatch(modified, saved) {
+  const components = [];
+  const deletedComponentIds = [];
+  const fields = {};
+
+  const currentComponents = modified.components ?? {};
+  const savedComponents = saved.components ?? [];
+
+  Object.entries(currentComponents).forEach(([id, component]) => {
+    if (
+      JSON.stringify(component) !==
+      JSON.stringify(savedComponents.find((c) => c.id === id))
+    ) {
+      components.push(structuredClone(component));
+    }
+  });
+
+  savedComponents.forEach((c) => {
+    if (!currentComponents[c.id]) deletedComponentIds.push(c.id);
+  });
+
+  ["name", "roles", "time", "directLink", "timerStateOperations"].forEach(
+    (field) => {
+      if (JSON.stringify(modified[field]) !== JSON.stringify(saved[field])) {
+        fields[field] = structuredClone(modified[field]);
+      }
+    }
+  );
+
+  return {
+    _id: modified._id,
+    fields,
+    components,
+    deletedComponentIds,
+  };
+}
+
+function applyPatch(scene, patch) {
+  const { fields = {}, components = [], deletedComponentIds = [] } = patch;
+
+  const updated = [];
+  const seen = new Set();
+
+  for (const c of scene.components) {
+    if (deletedComponentIds.includes(c.id)) continue;
+    updated.push(components.find((uc) => uc.id === c.id) ?? c);
+    seen.add(c.id);
+  }
+
+  for (const c of components) {
+    if (!seen.has(c.id)) updated.push(c);
+  }
+
+  return { ...scene, ...fields, components: updated };
+}
+
 /**
  * This is a Context Provider made with the React Context API
  * SceneContextProvider allows access to scene info and the refetch function
@@ -44,6 +101,7 @@ async function saveScenePatch(user, scenarioId, patch) {
 export default function SceneContextProvider({ children }) {
   const { user } = useContext(AuthenticationContext);
   const { scenarioId } = useParams();
+  const history = useHistory();
 
   const queryClient = useQueryClient();
 
@@ -95,25 +153,50 @@ export default function SceneContextProvider({ children }) {
     },
   });
 
-  const saveScenePatchMutation = useMutation({
-    mutationFn: (patch) => saveScenePatch(user, scenarioId, patch),
-    onError: () => {
+  const modifyMutation = useMutation({
+    mutationFn: (patch) => modifyScene(user, scenarioId, patch),
+    onMutate: async (patch) => {
+      await queryClient.cancelQueries(["scenes", scenarioId]);
+      const previousScenes = queryClient.getQueryData(["scenes", scenarioId]);
+
+      queryClient.setQueryData(["scenes", scenarioId], (prev) => {
+        return prev.map((s) =>
+          s._id === patch._id ? applyPatch(s, patch) : s
+        );
+      });
+
+      return { previousScenes };
+    },
+    onError: (error, _id, context) => {
+      if (context?.previousScenes) {
+        queryClient.setQueryData(
+          ["scenes", scenarioId],
+          context.previousScenes
+        );
+      }
+
       toast.error(
-        "Something went wrong updating the scene, your last changes weren't saved"
+        "Something went wrong modifying the scene, your last changes weren't saved"
       );
     },
   });
 
-  const saveScenePatchWrapper = useCallback(
-    (patch) => saveScenePatchMutation.mutateAsync(patch),
-    [saveScenePatchMutation.mutateAsync]
-  );
+  function modifyMutationWrapper(scene) {
+    modifyMutation.mutate(
+      generatePatch(
+        scene,
+        scenesQuery.data.find((s) => s._id === scene._id)
+      )
+    );
+  }
 
-  useEffect(() => {
-    if (scenesQuery.data && scenarioId) {
-      init(scenesQuery.data, scenarioId, saveScenePatchWrapper);
-    }
-  }, [scenesQuery.data, scenarioId, saveScenePatchWrapper]);
+  async function switchScene(scene, id) {
+    await modifyMutationWrapper(scene);
+    useEditorStore.getState().clear();
+    replace(scenesQuery.data.find((s) => s._id === id));
+    history.push({ pathname: `/scenario/${scenarioId}/scene/${id}` });
+    localStorage.setItem(`${scenarioId}:activeScene`, id);
+  }
 
   if (scenesQuery.isLoading) {
     return <LoadingPage text="Getting scenes..." />;
@@ -128,10 +211,11 @@ export default function SceneContextProvider({ children }) {
     <SceneContext.Provider
       value={{
         scenes: scenesQuery.data,
-        reorderScenes: reorderMutation.mutate,
-        saveScenePatch: saveScenePatchWrapper,
-        deleteScene: deleteMutation.mutate,
         reFetch: scenesQuery.refetch,
+        reorderScenes: reorderMutation.mutate,
+        deleteScene: deleteMutation.mutate,
+        modifyScene: modifyMutationWrapper,
+        switchScene,
       }}
     >
       {children}

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -148,7 +148,7 @@ export default function SceneContextProvider({ children }) {
 
       toast.error(
         error?.response?.data?.error ||
-          "Something went wrong updating the scenes, your last changes weren't saved"
+        "Something went wrong updating the scenes, your last changes weren't saved"
       );
     },
   });
@@ -158,6 +158,7 @@ export default function SceneContextProvider({ children }) {
     onMutate: async (patch) => {
       await queryClient.cancelQueries(["scenes", scenarioId]);
       const previousScenes = queryClient.getQueryData(["scenes", scenarioId]);
+      const previousScene = previousScenes.find((s) => s._id === patch._id);
 
       queryClient.setQueryData(["scenes", scenarioId], (prev) => {
         return prev.map((s) =>
@@ -165,14 +166,16 @@ export default function SceneContextProvider({ children }) {
         );
       });
 
-      return { previousScenes };
+      return { previousScene };
     },
     onError: (error, _id, context) => {
-      if (context?.previousScenes) {
-        queryClient.setQueryData(
-          ["scenes", scenarioId],
-          context.previousScenes
-        );
+      const previousScene = context?.previousScene;
+      if (previousScene) {
+        queryClient.setQueryData(["scenes", scenarioId], (prev) => {
+          return prev.map((s) =>
+            s._id === previousScene._id ? previousScene : s
+          );
+        });
       }
 
       toast.error(
@@ -181,7 +184,6 @@ export default function SceneContextProvider({ children }) {
     },
   });
 
-  // NOTE: this is optimistic on purpose, it assumes success and rolls back on failure
   const modifyMutationWrapper = useCallback(
     (scene) => {
       const saved = scenesQuery.data?.find((s) => s._id === scene._id);
@@ -189,7 +191,7 @@ export default function SceneContextProvider({ children }) {
         console.warn("scene not found in cache, skipping save");
         return;
       }
-      modifyMutation.mutate(generatePatch(scene, saved));
+      return modifyMutation.mutateAsync(generatePatch(scene, saved));
     },
     [scenesQuery.data]
   );

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -148,7 +148,7 @@ export default function SceneContextProvider({ children }) {
 
       toast.error(
         error?.response?.data?.error ||
-          "Something went wrong updating the scenes, your last changes weren't saved"
+        "Something went wrong updating the scenes, your last changes weren't saved"
       );
     },
   });
@@ -168,6 +168,10 @@ export default function SceneContextProvider({ children }) {
 
       return { previousScene };
     },
+    // NOTE: on failure, the changes are wiped from the scenes context, but NOT the active scene,
+    // which means on the next save the changes will be retried. 
+    // However, if its a save triggered by a switch, then those changes are fully gone. A proper failure
+    // handler needs to be developed to prefer retry over rollback.
     onError: (error, _id, context) => {
       const previousScene = context?.previousScene;
       if (previousScene) {

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -148,7 +148,7 @@ export default function SceneContextProvider({ children }) {
 
       toast.error(
         error?.response?.data?.error ||
-        "Something went wrong updating the scenes, your last changes weren't saved"
+          "Something went wrong updating the scenes, your last changes weren't saved"
       );
     },
   });

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -148,7 +148,7 @@ export default function SceneContextProvider({ children }) {
 
       toast.error(
         error?.response?.data?.error ||
-        "Something went wrong updating the scenes, your last changes weren't saved"
+          "Something went wrong updating the scenes, your last changes weren't saved"
       );
     },
   });
@@ -169,7 +169,7 @@ export default function SceneContextProvider({ children }) {
       return { previousScene };
     },
     // NOTE: on failure, the changes are wiped from the scenes context, but NOT the active scene,
-    // which means on the next save the changes will be retried. 
+    // which means on the next save the changes will be retried.
     // However, if its a save triggered by a switch, then those changes are fully gone. A proper failure
     // handler needs to be developed to prefer retry over rollback.
     onError: (error, _id, context) => {

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import AuthenticationContext from "./AuthenticationContext";
 import SceneContext from "./SceneContext";
 import { useParams, useHistory } from "react-router-dom";
@@ -182,21 +182,29 @@ export default function SceneContextProvider({ children }) {
   });
 
   function modifyMutationWrapper(scene) {
-    modifyMutation.mutate(
-      generatePatch(
-        scene,
-        scenesQuery.data.find((s) => s._id === scene._id)
-      )
-    );
+    const saved = scenesQuery.data?.find((s) => s._id === scene._id);
+    if (!saved) {
+      console.warn("scene not found in cache, skipping save");
+      return;
+    }
+    modifyMutation.mutate(generatePatch(scene, saved));
   }
 
-  async function switchScene(scene, id) {
-    await modifyMutationWrapper(scene);
-    useEditorStore.getState().clear();
-    replace(scenesQuery.data.find((s) => s._id === id));
-    history.push({ pathname: `/scenario/${scenarioId}/scene/${id}` });
-    localStorage.setItem(`${scenarioId}:activeScene`, id);
-  }
+  const switchScene = useCallback(
+    (scene, id) => {
+      modifyMutationWrapper(scene);
+      const target = scenesQuery.data.find((s) => s._id === id);
+      if (!target) {
+        console.warn("target scene for switch not found");
+        return;
+      }
+      useEditorStore.getState().clear();
+      replace(target);
+      history.push({ pathname: `/scenario/${scenarioId}/scene/${id}` });
+      localStorage.setItem(`${scenarioId}:activeScene`, id);
+    },
+    [scenesQuery.data]
+  );
 
   if (scenesQuery.isLoading) {
     return <LoadingPage text="Getting scenes..." />;

--- a/frontend/src/context/SceneContextProvider.jsx
+++ b/frontend/src/context/SceneContextProvider.jsx
@@ -181,19 +181,24 @@ export default function SceneContextProvider({ children }) {
     },
   });
 
-  function modifyMutationWrapper(scene) {
-    const saved = scenesQuery.data?.find((s) => s._id === scene._id);
-    if (!saved) {
-      console.warn("scene not found in cache, skipping save");
-      return;
-    }
-    modifyMutation.mutate(generatePatch(scene, saved));
-  }
+  // NOTE: this is optimistic on purpose, it assumes success and rolls back on failure
+  const modifyMutationWrapper = useCallback(
+    (scene) => {
+      const saved = scenesQuery.data?.find((s) => s._id === scene._id);
+      if (!saved) {
+        console.warn("scene not found in cache, skipping save");
+        return;
+      }
+      modifyMutation.mutate(generatePatch(scene, saved));
+    },
+    [scenesQuery.data]
+  );
 
   const switchScene = useCallback(
     (scene, id) => {
+      if (scene._id === id) return; // switch to same scene is a no-op
       modifyMutationWrapper(scene);
-      const target = scenesQuery.data.find((s) => s._id === id);
+      const target = scenesQuery.data?.find((s) => s._id === id);
       if (!target) {
         console.warn("target scene for switch not found");
         return;
@@ -203,7 +208,7 @@ export default function SceneContextProvider({ children }) {
       history.push({ pathname: `/scenario/${scenarioId}/scene/${id}` });
       localStorage.setItem(`${scenarioId}:activeScene`, id);
     },
-    [scenesQuery.data]
+    [scenesQuery.data, modifyMutationWrapper]
   );
 
   if (scenesQuery.isLoading) {

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -9,13 +9,15 @@ import SceneNavigator from "./SceneNavigator/SceneNavigator";
 import Canvas from "./canvas/Canvas";
 import Topbar from "./topbar/Topbar";
 import useVisualScene from "./stores/visual";
-import { getScenePatch, commitSavedScene } from "./scene/scene";
 import { copy, cut, paste } from "./handlers/keyboard/clipboard";
 import useEditorStore from "./stores/editor";
 import { useHistory } from "react-router-dom";
-import { replace } from "./scene/operations/modifiers";
+import { replace, replaceComponent } from "./scene/operations/modifiers";
 import { ArrowLeftIcon, FilesIcon, PlayIcon, UsersIcon } from "lucide-react";
 import { handleGlobal } from "./handlers/keyboard/keyboard";
+import { historyEvents } from "./scene/history";
+import { debounce } from "../../util/debounce";
+import { getScene } from "./scene/scene";
 
 const listeners = [
   ["copy", copy],
@@ -24,28 +26,44 @@ const listeners = [
   ["keydown", handleGlobal],
 ];
 
-const AUTOSAVE_INTERVAL = 30000; // 30 secs
+// const AUTOSAVE_INTERVAL = 30000; // 30 secs
 
 /**
  * This page allows the user to edit a scene.
  * @container
  */
 export default function AuthoringToolPage() {
-  const { scenes, saveScenePatch } = useContext(SceneContext);
+  const { scenes, modifyScene, switchScene } = useContext(SceneContext);
   const { scenarioId } = useParams();
 
   const sceneId = useVisualScene((scene) => scene.id);
+  const setSelected = useEditorStore((state) => state.setSelected);
 
   const history = useHistory();
 
   const [saving, setSaving] = useState(false);
 
-  // autosave setup
+  // NOTE: this is both the autosaver and the history actioner, which are distinct
+  // operations, but are both here due to the limitations of the scene context
   useEffect(() => {
-    if (!sceneId) return;
-    const autosave = setInterval(save, AUTOSAVE_INTERVAL);
-    return () => clearInterval(autosave);
-  }, [sceneId]);
+    const debounced = debounce(save, 2000);
+
+    const listener = async ({ operation, record }) => {
+      if (operation === "undo" || operation === "redo") {
+        if (record.sceneId !== sceneId)
+          await switchScene(getScene(), record.sceneId);
+        if (record.state === null) setSelected(null);
+        replaceComponent(record.id, record.state);
+        setSelected(record.id);
+      }
+
+      setSaving(true);
+      debounced();
+    };
+
+    historyEvents.addEventListener("update", listener);
+    return () => historyEvents.removeEventListener("update", listener);
+  }, []);
 
   // if the active scene was deleted, switch to the first available scene
   useEffect(() => {
@@ -93,25 +111,12 @@ export default function AuthoringToolPage() {
   }
 
   async function save() {
-    if (saving) return; // we dont want to interrupt in progress saves (usually uploading media)
+    // we dont want to interrupt in progress saves (usually uploading media)
+    if (saving) return;
+
     setSaving(true);
-
-    const patch = getScenePatch();
-
-    const hasChanges =
-      Object.keys(patch.fields).length > 0 ||
-      patch.components.length > 0 ||
-      patch.deletedComponentIds.length > 0;
-
-    if (!hasChanges) {
-      setSaving(false);
-      return;
-    }
-
-    await saveScenePatch(patch);
-    commitSavedScene();
-
-    setTimeout(() => setSaving(false), 5000);
+    await modifyScene(getScene());
+    setSaving(false);
   }
 
   return (

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -46,10 +46,13 @@ export default function AuthoringToolPage() {
   // NOTE: this is both the autosaver and the history actioner, which are distinct
   // operations, but are both here due to the limitations of the scene context
   useEffect(() => {
-    const debounced = debounce(() => {
+    const debounced = debounce(async () => {
       setSaving(true);
-      modifyScene(getScene());
-      setSaving(false);
+      try {
+        await modifyScene(getScene());
+      } finally {
+        setSaving(false);
+      }
     }, 5000);
 
     const listener = async ({ operation, record }) => {
@@ -114,10 +117,13 @@ export default function AuthoringToolPage() {
     history.push("/create");
   }
 
-  function save() {
+  async function save() {
     setSaving(true);
-    modifyScene(getScene());
-    setSaving(false);
+    try {
+      await modifyScene(getScene());
+    } finally {
+      setSaving(false);
+    }
   }
 
   return (

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -53,7 +53,7 @@ export default function AuthoringToolPage() {
       } finally {
         setSaving(false);
       }
-    }, 5000);
+    }, 2500);
 
     const listener = async ({ operation, record }) => {
       if (operation === "undo" || operation === "redo") {

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -15,7 +15,7 @@ import { useHistory } from "react-router-dom";
 import { replace, replaceComponent } from "./scene/operations/modifiers";
 import { ArrowLeftIcon, FilesIcon, PlayIcon, UsersIcon } from "lucide-react";
 import { handleGlobal } from "./handlers/keyboard/keyboard";
-import { historyEvents } from "./scene/history";
+import { clearHistory, historyEvents } from "./scene/history";
 import { debounce } from "../../util/debounce";
 import { getScene } from "./scene/scene";
 
@@ -90,6 +90,8 @@ export default function AuthoringToolPage() {
     if (target) replace(target);
 
     useEditorStore.getState().clear();
+
+    clearHistory();
 
     listeners.forEach(([event, fn]) => document.addEventListener(event, fn));
 

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -1,6 +1,6 @@
 import "./AuthoringToolPage.css";
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import SceneContext from "context/SceneContext";
 import CanvasSideBar from "./CanvasSideBar/CanvasSideBar";
@@ -43,15 +43,17 @@ export default function AuthoringToolPage() {
 
   const [saving, setSaving] = useState(false);
 
+  const pendingSavesRef = useRef(0);
+
   // NOTE: this is both the autosaver and the history actioner, which are distinct
   // operations, but are both here due to the limitations of the scene context
   useEffect(() => {
     const debounced = debounce(async () => {
-      setSaving(true);
       try {
         await modifyScene(getScene());
       } finally {
-        setSaving(false);
+        pendingSavesRef.current--;
+        if (pendingSavesRef.current === 0) setSaving(false);
       }
     }, 2500);
 
@@ -64,7 +66,8 @@ export default function AuthoringToolPage() {
         if (state !== null) setSelected(record.id);
       }
 
-      setSaving(true);
+      pendingSavesRef.current++;
+      if (pendingSavesRef.current > 0) setSaving(true);
       debounced();
     };
 

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -46,14 +46,14 @@ export default function AuthoringToolPage() {
   // NOTE: this is both the autosaver and the history actioner, which are distinct
   // operations, but are both here due to the limitations of the scene context
   useEffect(() => {
-    const debounced = debounce(save, 2000);
+    const debounced = debounce(save, 5000);
 
     const listener = async ({ operation, record }) => {
       if (operation === "undo" || operation === "redo") {
-        if (record.sceneId !== sceneId)
-          await switchScene(getScene(), record.sceneId);
-        if (record.state === null) setSelected(null);
-        replaceComponent(record.id, record.state);
+        if (record.sceneId !== sceneId) switchScene(getScene(), record.sceneId);
+        const state = operation === "undo" ? record.before : record.after;
+        if (state === null) setSelected(null);
+        replaceComponent(record.id, state);
         setSelected(record.id);
       }
 
@@ -63,7 +63,7 @@ export default function AuthoringToolPage() {
 
     historyEvents.addEventListener("update", listener);
     return () => historyEvents.removeEventListener("update", listener);
-  }, []);
+  }, [sceneId, switchScene, setSelected]);
 
   // if the active scene was deleted, switch to the first available scene
   useEffect(() => {
@@ -111,9 +111,6 @@ export default function AuthoringToolPage() {
   }
 
   async function save() {
-    // we dont want to interrupt in progress saves (usually uploading media)
-    if (saving) return;
-
     setSaving(true);
     await modifyScene(getScene());
     setSaving(false);

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -46,7 +46,11 @@ export default function AuthoringToolPage() {
   // NOTE: this is both the autosaver and the history actioner, which are distinct
   // operations, but are both here due to the limitations of the scene context
   useEffect(() => {
-    const debounced = debounce(save, 5000);
+    const debounced = debounce(() => {
+      setSaving(true);
+      modifyScene(getScene());
+      setSaving(false);
+    }, 5000);
 
     const listener = async ({ operation, record }) => {
       if (operation === "undo" || operation === "redo") {
@@ -54,7 +58,7 @@ export default function AuthoringToolPage() {
         const state = operation === "undo" ? record.before : record.after;
         if (state === null) setSelected(null);
         replaceComponent(record.id, state);
-        setSelected(record.id);
+        if (state !== null) setSelected(record.id);
       }
 
       setSaving(true);
@@ -63,7 +67,7 @@ export default function AuthoringToolPage() {
 
     historyEvents.addEventListener("update", listener);
     return () => historyEvents.removeEventListener("update", listener);
-  }, [sceneId, switchScene, setSelected]);
+  }, [sceneId, switchScene, setSelected, modifyScene]);
 
   // if the active scene was deleted, switch to the first available scene
   useEffect(() => {
@@ -110,9 +114,9 @@ export default function AuthoringToolPage() {
     history.push("/create");
   }
 
-  async function save() {
+  function save() {
     setSaving(true);
-    await modifyScene(getScene());
+    modifyScene(getScene());
     setSaving(false);
   }
 

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -3,7 +3,7 @@ import { Check } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import { generateUniqueSceneName } from "../../../utils/sceneUtils";
-import { getScenePatch, commitSavedScene } from "../scene/scene";
+import { getScene } from "../scene/scene";
 
 import useVisualScene from "../stores/visual";
 import { modifySceneProp } from "../scene/operations/modifiers";
@@ -17,7 +17,7 @@ import TimerStateOperationMenu from "../../../components/StateVariables/TimerSta
  * @component
  */
 export default function SceneSettings() {
-  const { scenes, saveScenePatch, reFetch } = useContext(SceneContext);
+  const { scenes, modifyScene } = useContext(SceneContext);
   const { roleList } = useContext(ScenarioContext);
 
   const name = useVisualScene((scene) => scene.name);
@@ -81,9 +81,7 @@ export default function SceneSettings() {
     setSceneName(safeName);
 
     try {
-      await saveScenePatch(getScenePatch());
-      commitSavedScene();
-      await reFetch(); // sync ui with db
+      await modifyScene(getScene());
     } catch (error) {
       console.error(error);
       toast.error("Could not save the scene name.");

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -81,7 +81,7 @@ export default function SceneSettings() {
     setSceneName(safeName);
 
     try {
-      await modifyScene(getScene());
+      modifyScene(getScene());
     } catch (error) {
       console.error(error);
       toast.error("Could not save the scene name.");

--- a/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
+++ b/frontend/src/features/authoring/SceneNavigator/ContextableThumb.tsx
@@ -4,19 +4,12 @@ import { api, handleGeneric } from "../../../util/api";
 import Thumbnail from "../components/Thumbnail";
 import AuthenticationContext from "../../../context/AuthenticationContext";
 import SceneContext from "../../../context/SceneContext";
-import { useParams, useHistory } from "react-router-dom";
-import { applySceneSwitch, saveCurrentScene } from "../scene/scene";
+import { useParams } from "react-router-dom";
+import { getScene } from "../scene/scene";
 import { handle } from "../../../components/ContextMenu/portal";
 import { CopyPlusIcon, Trash2Icon } from "lucide-react";
 import type { User } from "firebase/auth";
-import type { Scene, Component } from "../types";
-
-type SaveScenePatch = (patch: {
-  _id: string;
-  fields: Record<string, unknown>;
-  components: Component[];
-  deletedComponentIds: string[];
-}) => Promise<void>;
+import type { Scene } from "../types";
 
 const SceneMenu = ({
   id,
@@ -62,14 +55,13 @@ function ContextableThumb({
   const { user } = useContext(AuthenticationContext) as { user: User };
 
   const { scenarioId } = useParams<{ scenarioId: string }>();
-  const history = useHistory();
 
-  const { scenes, reFetch, saveScenePatch, deleteScene } = useContext(
+  const { scenes, reFetch, switchScene, deleteScene } = useContext(
     SceneContext
   ) as {
     scenes: Scene[];
     reFetch: () => Promise<void>;
-    saveScenePatch: SaveScenePatch;
+    switchScene: (scene: Scene, id: string) => void;
     deleteScene: (id: string) => void;
   };
 
@@ -79,16 +71,6 @@ function ContextableThumb({
       .then(reFetch)
       .catch(handleGeneric);
   };
-
-  async function switchScene(s: Scene) {
-    if (active) return;
-
-    await saveCurrentScene(saveScenePatch);
-    await reFetch();
-
-    applySceneSwitch(s, scenarioId);
-    history.push({ pathname: `/scenario/${scenarioId}/scene/${s._id}` });
-  }
 
   return (
     <RightContextMenu
@@ -104,9 +86,7 @@ function ContextableThumb({
         <p className="w-5.5 text--1 text-right mr-1.5">{index + 1}</p>
         <button
           type="button"
-          onMouseDown={() => {
-            void switchScene(scene);
-          }}
+          onMouseDown={() => switchScene(getScene(), scene._id)}
           className="w-[160px] relative rounded-sm overflow-hidden border-3 hover:border-primary"
           style={active ? { border: "3px solid #035084" } : {}}
           key={scene._id}

--- a/frontend/src/features/authoring/scene/history.ts
+++ b/frontend/src/features/authoring/scene/history.ts
@@ -10,17 +10,20 @@ interface HistoryObject {
   after: Component | null;
 }
 
-interface HistoryEventMap {
-  update: HistoryEvent;
-}
-
 type HistoryOperation = "do" | "undo" | "redo";
 
-class HistoryEvent extends Event {
-  operation: HistoryOperation;
-  record: HistoryObject;
+interface HistoryEventMap {
+  update: HistoryEvent<HistoryOperation>;
+}
 
-  constructor(operation: HistoryOperation, record: HistoryObject) {
+class HistoryEvent<T extends HistoryOperation> extends Event {
+  operation: T;
+  record: T extends "undo" | "redo" ? HistoryObject : HistoryObject | undefined;
+
+  constructor(
+    operation: T,
+    record: T extends "undo" | "redo" ? HistoryObject : HistoryObject | undefined
+  ) {
     super("update");
     this.operation = operation;
     this.record = record;
@@ -36,10 +39,23 @@ function cloneHistoryRecord(record: HistoryObject): HistoryObject {
   };
 }
 
-const undoStack: HistoryObject[] = [];
+let undoStack: HistoryObject[] = [];
 let redoStack: HistoryObject[] = [];
 
 export const historyEvents = new TypedEventTarget<HistoryEventMap>();
+
+export function clearHistory() {
+  undoStack = [];
+  redoStack = [];
+}
+
+// NOTE: this should only be used for scene modifications that don't support undo/redo
+export function dispatchModification() {
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("do", undefined)
+  );
+}
 
 export function updateHistory(id: string, prevState: Component | null) {
   const current = getComponent(id);

--- a/frontend/src/features/authoring/scene/history.ts
+++ b/frontend/src/features/authoring/scene/history.ts
@@ -1,16 +1,7 @@
 import { fastIsEqual } from "fast-is-equal";
-import type { Component, Scene } from "../types";
-import {
-  applySceneSwitch,
-  getComponent,
-  getScene,
-  getSceneId,
-  getScenePatch,
-  saveCurrentScene,
-} from "./scene";
-import useVisualScene from "../stores/visual";
-import { buildVisualComponent } from "../pipeline";
-import useEditorStore from "../stores/editor";
+import type { Component } from "../types";
+import { getComponent, getSceneId } from "./scene";
+import { TypedEventTarget } from "typescript-event-target";
 
 interface HistoryObject {
   sceneId: string;
@@ -18,70 +9,67 @@ interface HistoryObject {
   state: Component | null;
 }
 
-let undoStack: HistoryObject[] = [];
-let redoStack: HistoryObject[] = [];
-let scenes: Scene[] = [];
-let scenarioId: string | null = null;
-let saveScene:
-  | ((patch: ReturnType<typeof getScenePatch>) => Promise<void>)
-  | null = null;
-
-export function init(
-  _scenes: Scene[],
-  _scenarioId: string,
-  _saveScene: (patch: ReturnType<typeof getScenePatch>) => Promise<void>
-) {
-  if (_scenarioId !== scenarioId) {
-    undoStack = [];
-    redoStack = [];
-  }
-  scenes = _scenes;
-  scenarioId = _scenarioId;
-  saveScene = _saveScene;
+interface HistoryEventMap {
+  update: HistoryEvent;
 }
 
+type HistoryOperation = "do" | "undo" | "redo";
+
+class HistoryEvent extends Event {
+  operation: HistoryOperation;
+  record: HistoryObject;
+
+  constructor(operation: HistoryOperation, record: HistoryObject) {
+    super("update");
+    this.operation = operation;
+    this.record = record;
+  }
+}
+
+const undoStack: HistoryObject[] = [];
+let redoStack: HistoryObject[] = [];
+
+export const historyEvents = new TypedEventTarget<HistoryEventMap>();
+
 export function updateHistory(id: string, prevState: Component | null) {
-  if (fastIsEqual(prevState, getComponent(id))) return;
+  const current = getComponent(id);
+  if (fastIsEqual(prevState, current)) return;
+
   const sceneId = getSceneId();
   undoStack.push({ sceneId, id, state: prevState });
   if (undoStack.length > 100) undoStack.shift();
   redoStack = [];
+
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("do", { sceneId, id, state: structuredClone(current) })
+  );
 }
 
 export function undo() {
-  const prev = undoStack.pop();
-  if (!prev) return;
-  switchToScene(prev.sceneId);
-  const current = structuredClone(getComponent(prev.id));
-  restoreComponent(prev.id, prev.state);
-  redoStack.push({ sceneId: prev.sceneId, id: prev.id, state: current });
+  const record = undoStack.pop();
+  if (!record) return;
+
+  const { id, sceneId } = record;
+  const current = structuredClone(getComponent(id));
+  redoStack.push({ sceneId, id, state: current });
+
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("undo", { sceneId, id, state: record.state })
+  );
 }
 
 export function redo() {
-  const entry = redoStack.pop();
-  if (!entry) return;
-  switchToScene(entry.sceneId);
-  const current = structuredClone(getComponent(entry.id));
-  restoreComponent(entry.id, entry.state);
-  undoStack.push({ sceneId: entry.sceneId, id: entry.id, state: current });
-}
+  const record = redoStack.pop();
+  if (!record) return;
 
-function switchToScene(targetSceneId: string) {
-  if (targetSceneId === getSceneId()) return;
-  const targetScene = scenes.find((s) => s._id === targetSceneId);
-  if (!targetScene) return;
-  if (saveScene) void saveCurrentScene(saveScene);
-  applySceneSwitch(targetScene, scenarioId!);
-}
+  const { id, sceneId } = record;
+  const current = structuredClone(getComponent(id));
+  undoStack.push({ sceneId, id, state: current });
 
-function restoreComponent(id: string, state: Component | null) {
-  const { setSelected } = useEditorStore.getState();
-  if (state === null) {
-    setSelected(null);
-    delete getScene().components[id];
-    useVisualScene.getState().deleteComponent(id);
-  } else {
-    getScene().components[id] = structuredClone(state);
-    useVisualScene.getState().updateComponent(buildVisualComponent(state));
-  }
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("redo", { sceneId, id, state: record.state })
+  );
 }

--- a/frontend/src/features/authoring/scene/history.ts
+++ b/frontend/src/features/authoring/scene/history.ts
@@ -6,7 +6,8 @@ import { TypedEventTarget } from "typescript-event-target";
 interface HistoryObject {
   sceneId: string;
   id: string;
-  state: Component | null;
+  before: Component | null;
+  after: Component | null;
 }
 
 interface HistoryEventMap {
@@ -36,40 +37,34 @@ export function updateHistory(id: string, prevState: Component | null) {
   if (fastIsEqual(prevState, current)) return;
 
   const sceneId = getSceneId();
-  undoStack.push({ sceneId, id, state: prevState });
+  const record = {
+    sceneId,
+    id,
+    before: prevState,
+    after: structuredClone(current),
+  };
+
+  undoStack.push(record);
   if (undoStack.length > 100) undoStack.shift();
   redoStack = [];
 
-  historyEvents.dispatchTypedEvent(
-    "update",
-    new HistoryEvent("do", { sceneId, id, state: structuredClone(current) })
-  );
+  historyEvents.dispatchTypedEvent("update", new HistoryEvent("do", record));
 }
 
 export function undo() {
   const record = undoStack.pop();
   if (!record) return;
 
-  const { id, sceneId } = record;
-  const current = structuredClone(getComponent(id));
-  redoStack.push({ sceneId, id, state: current });
+  redoStack.push(record);
 
-  historyEvents.dispatchTypedEvent(
-    "update",
-    new HistoryEvent("undo", { sceneId, id, state: record.state })
-  );
+  historyEvents.dispatchTypedEvent("update", new HistoryEvent("undo", record));
 }
 
 export function redo() {
   const record = redoStack.pop();
   if (!record) return;
 
-  const { id, sceneId } = record;
-  const current = structuredClone(getComponent(id));
-  undoStack.push({ sceneId, id, state: current });
+  undoStack.push(record);
 
-  historyEvents.dispatchTypedEvent(
-    "update",
-    new HistoryEvent("redo", { sceneId, id, state: record.state })
-  );
+  historyEvents.dispatchTypedEvent("update", new HistoryEvent("redo", record));
 }

--- a/frontend/src/features/authoring/scene/history.ts
+++ b/frontend/src/features/authoring/scene/history.ts
@@ -27,6 +27,15 @@ class HistoryEvent extends Event {
   }
 }
 
+function cloneHistoryRecord(record: HistoryObject): HistoryObject {
+  return {
+    sceneId: record.sceneId,
+    id: record.id,
+    before: structuredClone(record.before),
+    after: structuredClone(record.after),
+  };
+}
+
 const undoStack: HistoryObject[] = [];
 let redoStack: HistoryObject[] = [];
 
@@ -40,7 +49,7 @@ export function updateHistory(id: string, prevState: Component | null) {
   const record = {
     sceneId,
     id,
-    before: prevState,
+    before: structuredClone(prevState),
     after: structuredClone(current),
   };
 
@@ -48,7 +57,10 @@ export function updateHistory(id: string, prevState: Component | null) {
   if (undoStack.length > 100) undoStack.shift();
   redoStack = [];
 
-  historyEvents.dispatchTypedEvent("update", new HistoryEvent("do", record));
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("do", cloneHistoryRecord(record))
+  );
 }
 
 export function undo() {
@@ -57,7 +69,10 @@ export function undo() {
 
   redoStack.push(record);
 
-  historyEvents.dispatchTypedEvent("update", new HistoryEvent("undo", record));
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("undo", cloneHistoryRecord(record))
+  );
 }
 
 export function redo() {
@@ -66,5 +81,8 @@ export function redo() {
 
   undoStack.push(record);
 
-  historyEvents.dispatchTypedEvent("update", new HistoryEvent("redo", record));
+  historyEvents.dispatchTypedEvent(
+    "update",
+    new HistoryEvent("redo", cloneHistoryRecord(record))
+  );
 }

--- a/frontend/src/features/authoring/scene/history.ts
+++ b/frontend/src/features/authoring/scene/history.ts
@@ -22,7 +22,9 @@ class HistoryEvent<T extends HistoryOperation> extends Event {
 
   constructor(
     operation: T,
-    record: T extends "undo" | "redo" ? HistoryObject : HistoryObject | undefined
+    record: T extends "undo" | "redo"
+      ? HistoryObject
+      : HistoryObject | undefined
   ) {
     super("update");
     this.operation = operation;
@@ -51,10 +53,7 @@ export function clearHistory() {
 
 // NOTE: this should only be used for scene modifications that don't support undo/redo
 export function dispatchModification() {
-  historyEvents.dispatchTypedEvent(
-    "update",
-    new HistoryEvent("do", undefined)
-  );
+  historyEvents.dispatchTypedEvent("update", new HistoryEvent("do", undefined));
 }
 
 export function updateHistory(id: string, prevState: Component | null) {

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -2,7 +2,7 @@ import { v4 } from "uuid";
 import { buildVisualComponent, buildVisualScene } from "../../pipeline";
 import useVisualScene, { type VisualSceneState } from "../../stores/visual";
 import { updateHistory } from "../history";
-import { commitSavedScene, getComponent, getScene, setScene } from "../scene";
+import { getComponent, getScene, setScene } from "../scene";
 import type { Component, Scene } from "../../types";
 import { arrayToObject } from "../util";
 
@@ -12,7 +12,6 @@ export function replace(scene: Scene) {
     clone.components as unknown as { id: string }[]
   ) as Record<string, Component>;
   setScene(clone);
-  commitSavedScene();
   useVisualScene.getState().setVisualScene(buildVisualScene(clone));
 }
 
@@ -68,4 +67,13 @@ export function add(props: Record<string, any>, history = true) {
     .updateComponent(buildVisualComponent(props as Component));
 
   return id;
+}
+
+export function replaceComponent(
+  id: string,
+  state: Component | null,
+  history = false
+) {
+  if (state === null) remove(id, history);
+  else add(state, history);
 }

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -1,7 +1,7 @@
 import { v4 } from "uuid";
 import { buildVisualComponent, buildVisualScene } from "../../pipeline";
 import useVisualScene, { type VisualSceneState } from "../../stores/visual";
-import { updateHistory } from "../history";
+import { dispatchModification, updateHistory } from "../history";
 import { getComponent, getScene, setScene } from "../scene";
 import type { Component, Scene } from "../../types";
 import { arrayToObject } from "../util";
@@ -21,13 +21,14 @@ export function modifySceneProp<K extends keyof VisualSceneState>(
 ) {
   (getScene() as unknown as Record<string, unknown>)[prop as string] = value;
   useVisualScene.setState({ [prop]: value } as Pick<VisualSceneState, K>);
+  dispatchModification();
 }
 
 // wrapper for state mutating functions, will capture both state and operation
 export function modify<A extends [string, ...unknown[]], R>(
   fn: (...args: A) => R
 ) {
-  return function (...args: A): R | undefined {
+  return function(...args: A): R | undefined {
     const id = args[0];
     const component = getComponent(id);
     if (!component) return undefined;

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -28,7 +28,7 @@ export function modifySceneProp<K extends keyof VisualSceneState>(
 export function modify<A extends [string, ...unknown[]], R>(
   fn: (...args: A) => R
 ) {
-  return function(...args: A): R | undefined {
+  return function (...args: A): R | undefined {
     const id = args[0];
     const component = getComponent(id);
     if (!component) return undefined;

--- a/frontend/src/features/authoring/scene/scene.ts
+++ b/frontend/src/features/authoring/scene/scene.ts
@@ -1,13 +1,9 @@
-import { arrayToObject, getObject } from "./util";
-import type { Component, Scene } from "../types";
-import useVisualScene from "../stores/visual";
-import { buildVisualScene } from "../pipeline";
-import useEditorStore from "../stores/editor";
+import { getObject } from "./util";
+import type { Scene } from "../types";
 
 let scene: Scene = {} as Scene;
-let savedScene: Scene = {} as Scene;
 
-(window as Window & { scene: Scene }).scene = scene;
+(window as unknown as Window & { scene: Scene }).scene = scene;
 
 export function getScene() {
   return scene;
@@ -33,70 +29,4 @@ export function getComponentProp(id: string, prop: string): unknown {
     component as unknown as Record<PropertyKey, unknown>
   );
   return object[key];
-}
-
-export function commitSavedScene() {
-  savedScene = structuredClone(scene);
-}
-
-export async function saveCurrentScene(
-  saveFn: (patch: ReturnType<typeof getScenePatch>) => Promise<void>
-): Promise<void> {
-  const patch = getScenePatch();
-  if (
-    Object.keys(patch.fields).length === 0 &&
-    patch.components.length === 0 &&
-    patch.deletedComponentIds.length === 0
-  )
-    return;
-  await saveFn(patch);
-  commitSavedScene();
-}
-
-export function applySceneSwitch(targetScene: Scene, scenarioId: string) {
-  const clone = structuredClone(targetScene);
-  clone.components = arrayToObject(
-    clone.components as unknown as { id: string }[]
-  ) as Record<string, Component>;
-  setScene(clone);
-  commitSavedScene();
-  useEditorStore.getState().clear();
-  useVisualScene.getState().setVisualScene(buildVisualScene(clone));
-  localStorage.setItem(`${scenarioId}:activeScene`, targetScene._id);
-}
-
-export function getScenePatch() {
-  const components: Component[] = [];
-  const deletedComponentIds: string[] = [];
-
-  const currentComponents = scene.components ?? {};
-  const savedComponents = savedScene.components ?? {};
-
-  Object.entries(currentComponents).forEach(([id, component]) => {
-    if (JSON.stringify(component) !== JSON.stringify(savedComponents[id])) {
-      components.push(structuredClone(component));
-    }
-  });
-
-  Object.keys(savedComponents).forEach((id) => {
-    if (!currentComponents[id]) deletedComponentIds.push(id);
-  });
-
-  const fields: Record<string, unknown> = {};
-
-  ["name", "roles", "time", "directLink", "timerStateOperations"].forEach(
-    (field) => {
-      const key = field as keyof Scene;
-      if (JSON.stringify(scene[key]) !== JSON.stringify(savedScene[key])) {
-        fields[field] = structuredClone(scene[key]);
-      }
-    }
-  );
-
-  return {
-    _id: scene._id,
-    fields,
-    components,
-    deletedComponentIds,
-  };
 }

--- a/frontend/src/util/debounce.ts
+++ b/frontend/src/util/debounce.ts
@@ -1,0 +1,11 @@
+export function debounce<T extends (...args: unknown[]) => void>(
+  fn: T,
+  timeout: number
+) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return (...args: Parameters<T>) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(args), timeout);
+  };
+}

--- a/frontend/src/util/debounce.ts
+++ b/frontend/src/util/debounce.ts
@@ -6,6 +6,6 @@ export function debounce<T extends (...args: unknown[]) => void>(
 
   return (...args: Parameters<T>) => {
     if (timeoutId) clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => fn(args), timeout);
+    timeoutId = setTimeout(() => fn(...args), timeout);
   };
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5005,6 +5005,11 @@ typescript-eslint@^8.30.1:
     "@typescript-eslint/typescript-estree" "8.44.1"
     "@typescript-eslint/utils" "8.44.1"
 
+typescript-event-target@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/typescript-event-target/-/typescript-event-target-1.1.2.tgz#e9f71d416fb160b376fbfc26d8c933fdb3773a27"
+  integrity sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==
+
 typescript@~5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"


### PR DESCRIPTION
## Issue

The scene saving dispatch logic, especially the scene switching, is tangled throughout the history, scene, operation and scene context parts of the code base. The result is scene switching and saving behavior that feels sluggish to use.

## Solution

Scene switching logic has been moved to a central place: SceneContext, and it is only called from one place: AuthoringTool. Instead of class-like initialisation of the history module that was required to allow the history functions to perform actions, the history module is now just a store of the history undo/redo stack that dispatches events when those functions are called. The actual actioning of the undo and redo is performed in the same place as the logic it requires, making use of the SceneContext.

### Important!

MANUAL SAVE is mostly removed in this PR, in favour of a modification-aware autosave. With the addition of the history events, the autosave now just listens for any of these events to be dispatched as a sign of "modification". To prevent against server overload, there is a 2000ms debounce.

I didn't initially intend to change this behaviour, but it became a natural extension using the history events system.

There is a NOTE in the code about the combining of the save functionality and the "history actioning" functionality in the AuthoringTool component. **This is not ideal**, but i've done it this way due to the limitation of SceneContext only being accessible from within the React tree. If we move the scene context into a zustand store, this should be separated for better structuring of the codebase.

## Risk

Both saving and history are modified in this PR, so its actually quite risky. Need to test well.

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified scene persistence around a direct “modify” workflow with optimistic updates and error rollback.
  * Reworked undo/redo into a purely event-driven history model that restores editor state via update events.
  * Simplified scene switching and component/state restoration to keep the authoring UI and persisted scene in sync.
  * Updated supporting authoring flows (scene name changes, sidebar scene switching, state variable edits) to use the new modify workflow.
* **Chores**
  * Added typed event/history support (including a small dependency) and introduced a reusable typed debounce helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->