### PR TITLE
fix(editor): link back button to create page

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -89,7 +89,7 @@ export default function AuthoringToolPage() {
   }
 
   function goBack() {
-    history.push("/");
+    history.push("/create");
   }
 
   async function save() {


### PR DESCRIPTION
## Issue

The back button was going to the play page

## Solution

Linked it to the create page instead.

## Risk

None.

## Checklist

- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the back button behavior to navigate to the correct previous page location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->