### PR TITLE
fix(autosave): increment pending save inside debounced save

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -50,6 +50,7 @@ export default function AuthoringToolPage() {
   useEffect(() => {
     const debounced = debounce(async () => {
       try {
+        pendingSavesRef.current++;
         await modifyScene(getScene());
       } finally {
         pendingSavesRef.current--;
@@ -66,8 +67,7 @@ export default function AuthoringToolPage() {
         if (state !== null) setSelected(record.id);
       }
 
-      pendingSavesRef.current++;
-      if (pendingSavesRef.current > 0) setSaving(true);
+      setSaving(true);
       debounced();
     };
 


### PR DESCRIPTION
## Issue

The saving status is stuck on "Saving" even after saving is finished.

## Solution

The pending save was being incremented outside the debounce, which means it would be much larger than the actual no. of pending save mutations, so it would never become 0 after successful saves.

## Risk

None

## Checklist

- [ ] Acceptance criteria met
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the saving status indicator so it appears immediately when a save starts.
  * Made the saving state update more reliably during undo and redo actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->