### PR TITLE
docs(learn): split getting started content into separate pages

### DIFF
--- a/learn/pages/assignment.md
+++ b/learn/pages/assignment.md
@@ -5,7 +5,7 @@ layout: libdoc_page.liquid
 eleventyNavigation:
   key: Assignment
   parent: Getting Started
-  order: 2
+  order: 4
 ---
 
 ## Assigning to Groups

--- a/learn/pages/assignment.md
+++ b/learn/pages/assignment.md
@@ -10,11 +10,11 @@ eleventyNavigation:
 
 ## Assigning to Groups
 
-To assign a scenario to a group, you need to upload a CSV file with rows for every player, the group they're in, and their role within the group. To do this, you need to navigate to the groups page via the editor, by pressing the **Groups** button at the top right of the page. From this groups page, you can upload by pressing the **Upload** button at the top right, and subsequently download from the button next to it.
+To assign a scenario to a group, you need to upload a CSV file with rows for each player, their group, and their role within that group. To do this, navigate to the groups page via the editor by pressing the **Groups** button at the top right of the page. From this group's page, you can upload by pressing the **Upload** button at the top right, and download by pressing the button next to it.
 
 ### Group CSV Format
 
-You can find the specific format that is expected by downloading the sample CSV, which you can do by pressing the **Sample** button at the top right. For reference, heres the example in table format:
+You can find the expected format by downloading the sample CSV; press the **Sample** button at the top right. For reference, here's the example in table format:
 
 | email                     | name  | role     | group |
 | ------------------------- | ----- | -------- | ----- |

--- a/learn/pages/dashboard.md
+++ b/learn/pages/dashboard.md
@@ -5,7 +5,7 @@ layout: libdoc_page.liquid
 eleventyNavigation:
   key: Dashboard
   parent: Getting Started
-  order: 3
+  order: 5
 ---
 
 The dashboard allows you to analyse the general flow of players through scenarios so that you can adjust them accordingly, or view the fine grained progress of specific groups / players.
@@ -20,7 +20,7 @@ What you can see in the progress view for the group are the members of the group
 
 To make viewing the exact path the group took step by step easier, you can roll forward and back through the playthrough by using the **Next** and **Prev** buttons on the flow chart.
 
-The [tracked values](/editor/#tracked-values) under the **State Variables** section are the current values at this point in time. You can use these to check things like player score at the end of a playthorugh, but also as an easier way to track the path. For example, instead of analysing the flowchart for every group to see if they visited a certain scene, you can use a tracked value like _has_visited_scene_x_, and just look at this for every group.
+The [tracked values](/state/) under the **State Variables** section are the current values at this point in time. You can use these to check things like player score at the end of a playthorugh, but also as an easier way to track the path. For example, instead of analysing the flowchart for every group to see if they visited a certain scene, you can use a tracked value like _has_visited_scene_x_, and just look at this for every group.
 
 ## Exporting
 

--- a/learn/pages/dashboard.md
+++ b/learn/pages/dashboard.md
@@ -1,6 +1,6 @@
 ---
 title: Dashboard
-description: The dashboard is how scenario authors can view the progress of players that have been assigned to that scenario, either individually or as groups.
+description: The dashboard is where scenario authors can view the progress of players assigned to that scenario, either individually or as groups.
 layout: libdoc_page.liquid
 eleventyNavigation:
   key: Dashboard
@@ -8,7 +8,7 @@ eleventyNavigation:
   order: 5
 ---
 
-The dashboard allows you to analyse the general flow of players through scenarios so that you can adjust them accordingly, or view the fine grained progress of specific groups / players.
+The dashboard allows you to analyse the overall flow of players through a scenario so that you can adjust it accordingly, or view the fine-grained progress of specific groups/players.
 
 ## Selecting a Playthrough
 
@@ -16,11 +16,11 @@ To select a specific playthrough to analyse, find the group in the groups table 
 
 ## Viewing the Progress
 
-What you can see in the progress view for the group are the members of the group, the tracked values and the specific path for that group's playthrough. To navigate the **Scenario Overview** flowchart, use your cursor to pan and your scroll wheel to zoom. You can also move the scenes around to make viewing certain sections clearer. The grey paths represent unvisited paths, which are links between scenes that exist but haven't been used by this group. The green paths represent the links that this group has used. The multiplier represents the number of times that link has been travelled. The number at the top right of each scene represents the number of times that scene has been navigated to.
+What you can see in the progress view for the group are the group's members, the tracked values, and the specific path for that group's playthrough. To navigate the **Scenario Overview** flowchart, use your cursor to pan and your scroll wheel to zoom. You can also rearrange the scenes to make certain sections easier to see. The grey paths represent unvisited paths, which are links between scenes that exist but haven't been used by this group. The green paths represent the links that this group has used. The multiplier represents the number of times that link has been travelled. The number at the top right of each scene represents the number of times that scene has been navigated to.
 
 To make viewing the exact path the group took step by step easier, you can roll forward and back through the playthrough by using the **Next** and **Prev** buttons on the flow chart.
 
-The [tracked values](/state/) under the **State Variables** section are the current values at this point in time. You can use these to check things like player score at the end of a playthorugh, but also as an easier way to track the path. For example, instead of analysing the flowchart for every group to see if they visited a certain scene, you can use a tracked value like _has_visited_scene_x_, and just look at this for every group.
+The [tracked values](/state/) in the **State Variables** section are the current values at this time. You can use these to check things like player score at the end of a playthrough, but also as an easier way to track the path. For example, instead of analysing the flowchart for every group to see if they visited a certain scene, you can use a tracked value like _has_visited_scene_x_, and look at this for every group.
 
 ## Exporting
 

--- a/learn/pages/editor.md
+++ b/learn/pages/editor.md
@@ -32,79 +32,11 @@ Scene transitions are performed when the player presses any scene content that h
 
 Importantly, if an element doesn't have a link or action attached to it, that element will become _passthrough_, which means that it wont respond to mouse input at all. Therefore you can put other interactive elements underneath, and they will work as expected.
 
-## How to Track Scenario Progress
-
-Scenario progress in VPS is managed by **tracked values** and **actions**.
-
-### Tracked Values
-
-Tracked values are any values that you want to keep track of as the player progresses through the scenario. Some examples of useful tracked values are:
-
-- A player's score
-- Whether a specific choice has been made
-- A character's health
-- Some player input
-
-To create a tracked value, press the **State Variables** button on the very left of the toolbar. On the modal, enter a name that describes what this value is tracking, the type of the value, and what the value should be initially (when the player first begins the scenario), and then press **Create** on the bottom right of the input section.
-
-This table explains the different types:
-
-| Name    | Meaning                                  | Example                                             |
-| ------- | ---------------------------------------- | --------------------------------------------------- |
-| String  | A text value                             | A character's mood can be "happy", "sad" or "angry" |
-| Number  | A positive or negative number            | A player's score                                    |
-| Boolean | A value that can be either true or false | Whether a player has visited a specific scene       |
-
-### Actions
-
-To make tracked values useful, you need to update them as the player progresses through the scenario. To do this, you need to add actions to **scene elements**, just like adding links. After selecting an element, press the plus button on the **State Operations** section on the right, which should show a modal. On this dialog, select the tracked value you want to update and how you want to update it. This can be either:
-
-- Set
-- Add (number only)
-
-Set will just set the tracked value to the value you specify in the input. For example, you might set the tracked value character mood to "happy". The add action will just perform addition to the tracked value. To perform subtraction, use the add action with a negative value.
-
-A good way to think of actions are as sentences in the order _action type_, _tracked value_, _action value_, _scene element_:
-
-- **Set** the **player-health** to **0**, when the player presses _the wrong option_.
-- **Set** whether the player **has-requested-scans** to **true**, when the player presses _the request scans button_.
-- **Add** to the **player-score** by **1**, when the player presses _the correct answer_.
-
-## Showing the Scenario Progress
-
-To let the user know about their progress, you can use a special format inside of any text in the scene, to display a tracked value inside of the text. This format is the tracked value name surrounded by two dollar signs on each side: `$$tracked-value$$`. For example, if we we're tracking the player health using a tracked value called `player-health`, we could write:
-
-> Your current health is $$player-health$$ points
-
-And then we could put this text in the top left of all of our scenes, so the player can always see it.
-
-A more complex example would be tracking user input for prescribing medicine. You would have buttons with increment and decrement actions on a tracked value for dosage of each medication, and then a text box with $$medicine-x-dosage$$ above each pair of buttons. This way, you can create a numerical input within the scenario.
-
-## Adding Resources
-
-Resources are persistent media that the player can access from within any scene, which exist to give context to players as they make decisions. These resources can either be images or PDFs. To upload a resource, press the resources button at the top right of the editor, which will take you to the resources page. From here, you can upload, delete and group resources into collections.
-
-To get started, you need to first create a collection by pressing the **Create** button next to the collections header. Once you've created the collection, you can press the plus button on the collection to upload the media for that resource. The player will now be able to access this resource while progressing through the scenario.
-
-### Conditionally Showing Resources
-
-Sometimes you might not want to have a resource always available for the player. For example, the scenario could involve the player requesting certain scans to be done on a patient. In this case, you would only want the player to see the 'scan' resource after they've made that decision. You can do this in the app using [tracked values](#tracked-values).
-
-First, you need to setup the tracked value for that resource if it doesn't yet exist. Then, you can select a resource and press the plus button on the **State Conditionals** section on the right. In the modal that appears, you need to select the _comparator_ and the _comparison value_. The comparator can be either:
-
-| Comparator | Meaning                                                       |
-| ---------- | ------------------------------------------------------------- |
-| =          | The tracked value is the same as the comparison value         |
-| !=         | The tracked value is **not** the same as the comparison value |
-| >          | The tracked value is greater than the comparison value        |
-| <          | The tracked value is less than the comparison value           |
-
-Once you set this, the resource will only be shown to the player as long as that condition holds true. Therefore, you can swap resources easily as the player progresses to create a sense of change due to time or choice etc. In our scans example, the condition would be: _has_requested_scans_ **=** _true_.
-
-## Timing Scenes
-
-Not yet implemented.
-
 ## Assigning Roles
 
 Since the multiplayer playthrough of scenarios is intended to be role-based asynchronous multiplayer, you should be assigning roles to scenes. You can do this by selecting all of the roles that should be able to access that scene in the **Roles** input in the **Scene Details** section on the right.
+
+## Next Steps
+
+- Track player choices and scores using [State & Logic](/state/).
+- Add images and PDFs for players to reference from [Resources](/resources/).

--- a/learn/pages/editor.md
+++ b/learn/pages/editor.md
@@ -1,6 +1,6 @@
 ---
 title: Editor
-description: The scenario editor consists of a few different features that makes both simple and complex scenarios possible.
+description: The scenario editor includes several features that enable both simple and complex scenarios.
 layout: libdoc_page.liquid
 eleventyNavigation:
   key: Editor
@@ -10,7 +10,7 @@ eleventyNavigation:
 
 ## Creating a Scene
 
-To create a new scene, press the plus button at the bottom of the scenes list, which is on the left side of the screen. This will create an empty scene with a default name. To rename the scene, expand the scene details section and modify the name input.
+To create a new scene, press the plus button at the bottom of the scenes list on the left side of the screen. This will create an empty scene with a default name. To rename the scene, expand the scene details section and modify the name input.
 
 ## Manipulating Scene Content
 
@@ -24,17 +24,17 @@ A scene can contain images, text and a few different shapes. To add any of these
 
 ### Audio Content
 
-You can also add audio to a scene, by expanding the **Audio Elements** section and pressing the plus button. The app only supports `.mp3` audio files. All audio content in a scene will begin playing as soon as player navigates to the scene. The **Loop Audio** toggle adjusts whether the audio should continue playing as long as the user is on the scene, or whether it should end once it plays through once. Regardless of this option, the audio playback will end as soon as the player navigates away from the scene.
+You can also add audio to a scene by expanding the **Audio Elements** section and pressing the plus button. The app only supports `.mp3` audio files. All audio content in a scene will begin playing as soon as the player navigates to the scene. The **Loop Audio** toggle controls whether the audio continues to play as long as the user is on the scene, or ends after it plays once. Regardless of this option, the audio playback will end as soon as the player navigates away from the scene.
 
 ## Transitioning Between Scenes
 
 Scene transitions are performed when the player presses any scene content that has a **link** attached to it. This can be images, textboxes or shapes. To add a link to a scene element, select the element and then expand the **Link Details** section that appears on the right. Press the **Next Scene** input to select the scene this element should link to.
 
-Importantly, if an element doesn't have a link or action attached to it, that element will become _passthrough_, which means that it wont respond to mouse input at all. Therefore you can put other interactive elements underneath, and they will work as expected.
+Importantly, if an element doesn't have a link or action attached to it, that element will become _passthrough_, which means that it won't respond to mouse input at all. Therefore, you can put other interactive elements underneath, and they will work as expected.
 
 ## Assigning Roles
 
-Since the multiplayer playthrough of scenarios is intended to be role-based asynchronous multiplayer, you should be assigning roles to scenes. You can do this by selecting all of the roles that should be able to access that scene in the **Roles** input in the **Scene Details** section on the right.
+Since the multiplayer playthrough of scenarios is intended to be role-based and asynchronous, you should assign roles to scenes. You can do this by selecting all of the roles that should be able to access that scene in the **Roles** input in the **Scene Details** section on the right.
 
 ## Next Steps
 

--- a/learn/pages/resources.md
+++ b/learn/pages/resources.md
@@ -1,0 +1,32 @@
+---
+title: Resources
+description: Resources are persistent media that players can access from within any scene to help them make decisions.
+layout: libdoc_page.liquid
+eleventyNavigation:
+  key: Resources
+  parent: Getting Started
+  order: 3
+---
+
+Resources are persistent media that the player can access from within any scene, which exist to give context to players as they make decisions. These resources can either be images or PDFs.
+
+## Adding Resources
+
+To upload a resource, press the **Resources** button at the top right of the editor, which will take you to the resources page. From here, you can upload, delete and group resources into collections.
+
+To get started, you need to first create a collection by pressing the **Create** button next to the collections header. Once you've created the collection, you can press the plus button on the collection to upload the media for that resource. The player will now be able to access this resource while progressing through the scenario.
+
+## Conditionally Showing Resources
+
+Sometimes you might not want a resource to be available to the player at all times. For example, the scenario could involve the player requesting certain scans to be done on a patient — in that case, you would only want the player to see the scan results after they've made that decision. You can do this using [tracked values](/state/).
+
+First, set up the tracked value for that resource if it doesn't yet exist. Then, select a resource and press the plus button on the **State Conditionals** section on the right. In the modal that appears, select the _comparator_ and the _comparison value_. The comparator can be either:
+
+| Comparator | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| =          | The tracked value is the same as the comparison value         |
+| !=         | The tracked value is **not** the same as the comparison value |
+| >          | The tracked value is greater than the comparison value        |
+| <          | The tracked value is less than the comparison value           |
+
+Once set, the resource will only be shown to the player while that condition holds true. This lets you swap resources in and out as the player progresses to create a sense of change due to time or choice. In the scans example, the condition would be: _has_requested_scans_ **=** _true_.

--- a/learn/pages/resources.md
+++ b/learn/pages/resources.md
@@ -8,17 +8,17 @@ eleventyNavigation:
   order: 3
 ---
 
-Resources are persistent media that the player can access from within any scene, which exist to give context to players as they make decisions. These resources can either be images or PDFs.
+Resources are persistent media that the player can access from any scene to provide additional context while they make decisions. These resources can either be images or PDFs.
 
 ## Adding Resources
 
 To upload a resource, press the **Resources** button at the top right of the editor, which will take you to the resources page. From here, you can upload, delete and group resources into collections.
 
-To get started, you need to first create a collection by pressing the **Create** button next to the collections header. Once you've created the collection, you can press the plus button on the collection to upload the media for that resource. The player will now be able to access this resource while progressing through the scenario.
+To get started, you need to first create a collection by pressing the **Create** button next to the collections header. Once you've created the collection, you can press the plus button on the collection to upload the media for that resource. The player can now access this resource as they progress through the scenario.
 
 ## Conditionally Showing Resources
 
-Sometimes you might not want a resource to be available to the player at all times. For example, the scenario could involve the player requesting certain scans to be done on a patient — in that case, you would only want the player to see the scan results after they've made that decision. You can do this using [tracked values](/state/).
+Sometimes you might not want a resource to be available to the player at all times. For example, the scenario could involve the player requesting certain scans for a patient. In that case, you would only want the player to see the scan results after they've made that decision. You can do this using [tracked values](/state/).
 
 First, set up the tracked value for that resource if it doesn't yet exist. Then, select a resource and press the plus button on the **State Conditionals** section on the right. In the modal that appears, select the _comparator_ and the _comparison value_. The comparator can be either:
 
@@ -29,4 +29,4 @@ First, set up the tracked value for that resource if it doesn't yet exist. Then,
 | >          | The tracked value is greater than the comparison value        |
 | <          | The tracked value is less than the comparison value           |
 
-Once set, the resource will only be shown to the player while that condition holds true. This lets you swap resources in and out as the player progresses to create a sense of change due to time or choice. In the scans example, the condition would be: _has_requested_scans_ **=** _true_.
+Once set, the resource will only be shown to the player while they meet the condition. This lets you swap resources in and out as the player progresses, creating a sense of change over time or through choice. In the scans example, the condition would be: _has_requested_scans_ **=** _true_.

--- a/learn/pages/state.md
+++ b/learn/pages/state.md
@@ -31,14 +31,14 @@ This table explains the different types:
 
 ## Actions
 
-To make tracked values useful, you need to update them as the player progresses through the scenario. To do this, you need to add actions to **scene elements**, just like adding links. After selecting an element, press the plus button on the **State Operations** section on the right, which should show a modal. On this dialog, select the tracked value you want to update and how you want to update it. This can be either:
+To make tracked values useful, you need to update them as the player progresses through the scenario. To do this, you need to add actions to **scene elements**, just like adding links. After selecting an element, press the plus button in the **State Operations** section on the right; a modal should appear. In this dialog box, select the tracked value you want to update and how to update it. This can be either:
 
 - Set
 - Add (number only)
 
-Set will just set the tracked value to the value you specify in the input. For example, you might set the tracked value character mood to "happy". The add action will just perform addition to the tracked value. To perform subtraction, use the add action with a negative value.
+Set will just set the tracked value to the value you specify in the input. For example, you might set the tracked value character mood to "happy". The add action will perform addition to the tracked value. To perform subtraction, use the add action with a negative value.
 
-A good way to think of actions are as sentences in the order _action type_, _tracked value_, _action value_, _scene element_:
+A good way to think of actions is as sentences in the order _action type_, _tracked value_, _action value_, _scene element_:
 
 - **Set** the **player-health** to **0**, when the player presses _the wrong option_.
 - **Set** whether the player **has-requested-scans** to **true**, when the player presses _the request scans button_.
@@ -52,7 +52,7 @@ To let the player know about their progress, you can embed a tracked value direc
 
 You can place this text in the top left of all your scenes so the player can always see it.
 
-A more complex example would be tracking user input for prescribing medicine. You would have buttons with increment and decrement actions on a tracked value for dosage of each medication, and then a text box with $$medicine-x-dosage$$ above each pair of buttons. This way, you can create a numerical input within the scenario.
+A more complex example would be tracking user input for prescribing medicine. You would have buttons with increment and decrement actions on a tracked value for the dosage of each medication, and a text box labelled $$medicine-x-dosage$$ above each pair of buttons. This way, you can create a numerical input within the scenario.
 
 ## Next Steps
 

--- a/learn/pages/state.md
+++ b/learn/pages/state.md
@@ -1,0 +1,59 @@
+---
+title: State & Logic
+description: Tracked values and actions let you record player choices and drive conditional behaviour as a player progresses through a scenario.
+layout: libdoc_page.liquid
+eleventyNavigation:
+  key: State & Logic
+  parent: Getting Started
+  order: 2
+---
+
+Scenario progress in VPS is managed by **tracked values** and **actions**.
+
+## Tracked Values
+
+Tracked values are any values that you want to keep track of as the player progresses through the scenario. Some examples of useful tracked values are:
+
+- A player's score
+- Whether a specific choice has been made
+- A character's health
+- Some player input
+
+To create a tracked value, press the **State Variables** button on the very left of the toolbar. On the modal, enter a name that describes what this value is tracking, the type of the value, and what the value should be initially (when the player first begins the scenario), and then press **Create** on the bottom right of the input section.
+
+This table explains the different types:
+
+| Name    | Meaning                                  | Example                                             |
+| ------- | ---------------------------------------- | --------------------------------------------------- |
+| String  | A text value                             | A character's mood can be "happy", "sad" or "angry" |
+| Number  | A positive or negative number            | A player's score                                    |
+| Boolean | A value that can be either true or false | Whether a player has visited a specific scene       |
+
+## Actions
+
+To make tracked values useful, you need to update them as the player progresses through the scenario. To do this, you need to add actions to **scene elements**, just like adding links. After selecting an element, press the plus button on the **State Operations** section on the right, which should show a modal. On this dialog, select the tracked value you want to update and how you want to update it. This can be either:
+
+- Set
+- Add (number only)
+
+Set will just set the tracked value to the value you specify in the input. For example, you might set the tracked value character mood to "happy". The add action will just perform addition to the tracked value. To perform subtraction, use the add action with a negative value.
+
+A good way to think of actions are as sentences in the order _action type_, _tracked value_, _action value_, _scene element_:
+
+- **Set** the **player-health** to **0**, when the player presses _the wrong option_.
+- **Set** whether the player **has-requested-scans** to **true**, when the player presses _the request scans button_.
+- **Add** to the **player-score** by **1**, when the player presses _the correct answer_.
+
+## Displaying Tracked Values
+
+To let the player know about their progress, you can embed a tracked value directly inside any text in the scene. Wrap the tracked value name in two dollar signs on each side: `$$tracked-value$$`. For example, if you were tracking player health using a tracked value called `player-health`, you could write:
+
+> Your current health is $$player-health$$ points
+
+You can place this text in the top left of all your scenes so the player can always see it.
+
+A more complex example would be tracking user input for prescribing medicine. You would have buttons with increment and decrement actions on a tracked value for dosage of each medication, and then a text box with $$medicine-x-dosage$$ above each pair of buttons. This way, you can create a numerical input within the scenario.
+
+## Next Steps
+
+Tracked values can also control which [Resources](/resources/) are visible to the player at any given point in the scenario.


### PR DESCRIPTION
## Issue

The learning guide might be useful in the user tests coming up soon.

## Solution

Organise current content and fix grammar and spelling for clarity.

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guides for scenario state, resources, and editor usage.
  * Expanded the editor documentation with clearer instructions for scenes, audio playback, transitions, roles, and next steps.
  * Updated dashboard and assignment docs for clearer progress and group CSV guidance.
  * Improved wording, navigation order, and links across the learning pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->