### PR TITLE
fix: two scenes on scenario creation

### DIFF
--- a/frontend/src/context/ScenarioContextProvider.jsx
+++ b/frontend/src/context/ScenarioContextProvider.jsx
@@ -16,12 +16,8 @@ async function getAllScenarios(user) {
   return res.data;
 }
 
-// TODO: this should be unionised into a single endpoint for efficiency
 async function createScenario(user, name) {
   const { data: scenario } = await api.post(user, `/api/scenario`, { name });
-  await api.post(user, `/api/scenario/${scenario._id}/scene`, {
-    name: "Scene 1",
-  });
   return scenario._id;
 }
 


### PR DESCRIPTION
## Issue

Scenario creation will create two initial scenes instead of one.

## Solution

Removed the unecessary scene creation call from the frontend, since the initial scene creation is handled with the create logic.

## Risk

None.

## Checklist

- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a new scenario now returns the scenario immediately without automatically adding an initial default scene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->