### PR TITLE
fix: memoise cursor to avoid rerenders before state update completion

### DIFF
--- a/frontend/src/features/authoring/text/Cursor.tsx
+++ b/frontend/src/features/authoring/text/Cursor.tsx
@@ -6,6 +6,7 @@ import useEditorStore from "../stores/editor";
 import shallow from "zustand/shallow";
 import useVisualScene from "../stores/visual";
 import { getStyleForSelection } from "../scene/operations/text";
+import { memo } from "react";
 
 function Cursor({ bounds }: { bounds: RelativeBounds }) {
   const visualSelection = useEditorStore((state) => state.visualSelection);
@@ -42,4 +43,4 @@ function Cursor({ bounds }: { bounds: RelativeBounds }) {
   return <path d={path} fill={color ?? "#000000"} />;
 }
 
-export default Cursor;
+export default memo(Cursor);


### PR DESCRIPTION
## Issue

Deleting an empty block sometimes crashes the application, because the cursor is still trying to render at the old (non-existent) position.

## Solution

Memoised the cursor so that it only rerenders once the new selection state has been set in the zustand store. 

## Risk

The memoisation is simply a patch fix. The deeper problem is the cursor state change is not in sync with other state changes affecting components higher up in the tree, which could be the history listener on the root.

## Checklist

- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the responsiveness of the text cursor during editing, helping reduce unnecessary re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->