### PR TITLE
feat: element hover indicators

### DIFF
--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -25,12 +25,15 @@ function resolve(type: Component["type"], bounds: Bounds) {
 
 function Overlay() {
   const selected = useEditorStore((state) => state.selected)!;
+  const hovered = useEditorStore((state) => state.hovered)!;
   const bounds = useEditorStore((state) => state.mutationBounds);
   const scene = useVisualScene((scene) => scene.components);
   const mode = useEditorStore((scene) => scene.mode);
   const createType = useEditorStore((scene) => scene.createType);
 
   const component = scene[selected];
+  const hoveredComponent = scene[hovered];
+  console.log(hoveredComponent);
 
   function ResolveHandles() {
     switch (component.type) {
@@ -60,6 +63,15 @@ function Overlay() {
           />
           <ResolveHandles />
         </>
+      )}
+      {hoveredComponent && (
+        <Rectangle
+          bounds={hoveredComponent.bounds}
+          rotationOrigin={getBoxCenter(hoveredComponent.bounds.verts)}
+          fill="none"
+          stroke="#747775"
+          strokeWidth={1}
+        />
       )}
       {mode.includes("mutation") &&
         resolve(component?.type ?? createType, bounds)}

--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -33,7 +33,6 @@ function Overlay() {
 
   const component = scene[selected];
   const hoveredComponent = scene[hovered];
-  console.log(hoveredComponent);
 
   function ResolveHandles() {
     switch (component.type) {

--- a/frontend/src/features/authoring/elements/Box.tsx
+++ b/frontend/src/features/authoring/elements/Box.tsx
@@ -16,7 +16,7 @@ function Box(component: BoxComponent) {
     bounds.rotation
   );
   const path = constructPath(verts);
-  return <path d={path} {...filterComponent(component)} />;
+  return <path className="box" d={path} {...filterComponent(component)} />;
 }
 
 export default Box;

--- a/frontend/src/features/authoring/elements/Ellipse.tsx
+++ b/frontend/src/features/authoring/elements/Ellipse.tsx
@@ -25,7 +25,7 @@ function Ellipse(component: EllipseComponent) {
     `A${radius.x} ${radius.y} ${bounds.rotation} 1 1 ${anchors[0].x} ${anchors[0].y}`,
   ].join(" ");
 
-  return <path d={d} {...filterComponent(component)} />;
+  return <path className="ellipse" d={d} {...filterComponent(component)} />;
 }
 
 export default Ellipse;

--- a/frontend/src/features/authoring/elements/Image.tsx
+++ b/frontend/src/features/authoring/elements/Image.tsx
@@ -19,6 +19,7 @@ function Image(component: ImageComponent) {
       width={relative.width}
       height={relative.height}
       transform={transform}
+      className="image"
       {...filterComponent(component)}
     />
   );

--- a/frontend/src/features/authoring/elements/Speech.tsx
+++ b/frontend/src/features/authoring/elements/Speech.tsx
@@ -115,7 +115,7 @@ function Speech(component: SpeechComponent) {
   }
 
   return (
-    <g>
+    <g className="speech">
       <path d={constructPath()} {...filterComponent(component)} />
     </g>
   );

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -45,8 +45,6 @@ export function handleMouseMoveGlobal(e: React.MouseEvent, position: Vec2) {
     return;
   }
 
-  if (!mouseDown) return;
-
   if (mode.includes("resize")) {
     handleResizeDrag(e, position);
   } else if (mode.includes("text")) {

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -40,6 +40,11 @@ export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
 export function handleMouseMoveGlobal(e: React.MouseEvent, position: Vec2) {
   const { mode, mouseDown } = useEditorStore.getState();
 
+  if (!mouseDown) {
+    handleComponentHover(e);
+    return;
+  }
+
   if (!mouseDown) return;
 
   if (mode.includes("resize")) {
@@ -74,6 +79,15 @@ function handleCanvasClick() {
 }
 
 // component handlers
+
+function handleComponentHover(e: React.MouseEvent) {
+  const { setHovered } = useEditorStore.getState();
+
+  const target = e.target as HTMLElement;
+  const id = target.dataset.id as string;
+
+  setHovered(id ?? null);
+}
 
 function handleComponentClick(e: React.MouseEvent, position: Vec2) {
   const { setSelected, setOffset, setMode, setMutationBounds } =

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -9,12 +9,14 @@ type Mode = "normal" | "resize" | "create" | "text" | "mutation";
 interface EditorState {
   loading: boolean;
   selected: string | null;
+  hovered: string | null;
   createType: string | null;
   mouseDown: boolean;
   mutationBounds: Bounds;
   offset: Vec2;
 
   setSelected: (id: string | null) => void;
+  setHovered: (id: string | null) => void;
   setCreateType: (type: string) => void;
   setMouseDown: (mouseDown: boolean) => void;
   setMutationBounds: Dynamic<Bounds>;
@@ -60,6 +62,7 @@ function setter<K extends keyof EditorState>(set: ZustandSet, prop: K) {
 const useEditorStore = create<EditorState>((set) => ({
   loading: false,
   selected: null,
+  hovered: null,
   createType: null,
   mouseDown: false,
   mutationBounds: { verts: [], rotation: 0 },
@@ -67,6 +70,7 @@ const useEditorStore = create<EditorState>((set) => ({
 
   setLoading: (value: boolean) => set({ loading: value }),
   setSelected: (id) => set({ selected: id }),
+  setHovered: (id) => set({ hovered: id }),
   setCreateType: (type: string) => set({ createType: type }),
   setMouseDown: (mouseDown) => set({ mouseDown }),
   setMutationBounds: setter(set, "mutationBounds"),

--- a/frontend/src/features/authoring/text/Text.tsx
+++ b/frontend/src/features/authoring/text/Text.tsx
@@ -57,7 +57,7 @@ function Text({ doc, editable }: { doc: VisualDocument; editable?: boolean }) {
   };
 
   return (
-    <g className="select-none">
+    <g className="select-none text">
       <TextHighlight doc={doc} />
       {isSelected && <Highlight color="#4997ff80" bounds={bounds} />}
       <g className="select-none" transform={transformation}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -262,3 +262,14 @@ body,
 .input.search input {
   @apply grow placeholder:text-primary text-secondary;
 }
+
+svg#main .box,
+svg#main .speech,
+svg#main .ellipse,
+svg#main .image {
+  @apply cursor-move;
+}
+
+svg#main .text {
+  @apply cursor-text;
+}


### PR DESCRIPTION
## Issue

Hovering over scene elements doesn't give any feedback, which makes it difficult to know what element you're clicking and if youre clicking into text mode or move mode on a textbox. 

## Solution

The cursor now reflects the mode that will be entered upon clicking the component, which is a text cursor for text mode and a move cursor for move mode. All the elements are move mode except the text section of a text box. The hovered state (which comopnent is hovered, if any) is now stored in the editor zustand store, allowing us to render an outline for that component in the overlay. This makes it easy to distinguish which element youre about to click, which is unclear when you have multiple elements stacked.

## Risk

The introduction of the new state value shouldn't cause issues since its only used in one place.

## Checklist

- [ ] Acceptance criteria met
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hovering over items in the canvas now shows a subtle outline around the hovered item, not just the selected one.
* **UX Improvements**
  * Canvas elements now display more appropriate cursors: move for shapes/images and text cursor for text.
  * Added consistent styling hooks (CSS classes) across box, ellipse, image, speech, and text elements to improve targeting and visual behavior.
* **Bug Fixes**
  * Hover state now updates correctly when moving the mouse (while not pressed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->