### PR TITLE
feat: detailed error page for crashes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 import AuthenticationContextProvider from "./context/AuthenticationContextProvider";
 import ScenarioContextProvider from "./context/ScenarioContextProvider";
@@ -40,7 +41,7 @@ export default function App() {
   }, []);
 
   return (
-    <>
+    <ErrorBoundary>
       {/* Toaster container */}
       <Toaster
         position="bottom-right"
@@ -134,6 +135,6 @@ export default function App() {
           </BrowserRouter>
         </QueryClientProvider>
       </AuthenticationContextProvider>
-    </>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,111 @@
+import { Component } from "react";
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, componentStack: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ componentStack: info.componentStack });
+  }
+
+  reset = () => {
+    this.setState({ error: null, componentStack: null });
+  };
+
+  render() {
+    const { error, componentStack } = this.state;
+
+    if (!error) return this.props.children;
+
+    if (!import.meta.env.DEV) {
+      return (
+        <div className="flex flex-col gap-4 items-center h-screen justify-center">
+          <h1 className="text-xl">{"Something went wrong :\\"}</h1>
+          <p className="text-sm opacity-70">
+            An unexpected error occurred. Please refresh the page or try again
+            later.
+          </p>
+          <button className="btn btn-primary" onClick={this.reset}>
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="min-h-screen bg-red-950 text-red-100 p-6">
+        <div className="mx-auto flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-bold text-red-300">
+              Unhandled React Error
+            </h1>
+            <span className="ml-2 text-red-400 opacity-70">dev mode</span>
+          </div>
+
+          {/* Error message */}
+          <div className="bg-red-900/60 border border-red-700 rounded-lg p-4">
+            <p className="text-red-200 font-semibold text-sm mb-1">
+              {error.name}
+            </p>
+            <p className="text-white text-base">{error.message}</p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <button className="btn btn-sm btn-error" onClick={this.reset}>
+              Try again
+            </button>
+            <button
+              className="btn btn-sm btn-ghost text-red-300"
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+            <button
+              className="btn btn-sm btn-ghost text-red-300"
+              onClick={() =>
+                navigator.clipboard.writeText(
+                  `${error.name}: ${error.message}\n\nStack:\n${error.stack}\n\nComponent stack:${componentStack}`
+                )
+              }
+            >
+              Copy to clipboard
+            </button>
+          </div>
+
+          {/* JS stack */}
+          {error.stack && (
+            <details open>
+              <summary className="cursor-pointer text-sm text-red-300 mb-2 select-none">
+                JS stack trace
+              </summary>
+              <pre className="bg-black/40 border border-red-800 rounded p-3 text-xs text-red-200 overflow-auto max-h-64 whitespace-pre-wrap">
+                {error.stack}
+              </pre>
+            </details>
+          )}
+
+          {/* Component stack */}
+          {componentStack && (
+            <details open>
+              <summary className="cursor-pointer text-sm text-red-300 mb-2 select-none">
+                React component stack
+              </summary>
+              <pre className="bg-black/40 border border-red-800 rounded p-3 text-xs text-red-200 overflow-auto max-h-64 whitespace-pre-wrap">
+                {componentStack.trim()}
+              </pre>
+            </details>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Issue

App crashes fall back to a blank page with no information

## Solution

- Dev mode: show error details
- Prod mode: show generic error message

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a top-level error fallback so the app shows a friendly message instead of a blank screen when something goes wrong.
  * Improved the recovery experience with options to retry or refresh the page.
  * In development, error details and stack information are now shown to help with troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->