### PR TITLE
fix : add a tooltip to direct link section of scene details

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/CanvasSideBar.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/CanvasSideBar.jsx
@@ -14,7 +14,7 @@ export default function CanvasSideBar() {
   const component = selected ? getComponent(selected) : null;
 
   return (
-    <div className="flex pb-m flex-col w-[18vw] gap-s overflow-y-auto no-scrollbar">
+    <div className="flex pb-m flex-col w-[18vw] gap-s overflow-y-auto overflow-x-hidden no-scrollbar">
       <SceneSettings />
       <AudioManager />
       <ComponentProperties component={component} />

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -134,7 +134,7 @@ export default function SceneSettings() {
               </div>
               <ul
                 tabIndex={0}
-                className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
+                className="dropdown-content menu bg-base-300 rounded-box z-1 w-full p-2 shadow-sm"
               >
                 {roleList?.map((role, i) => {
                   const active = selectedRoles.includes(role);
@@ -152,10 +152,10 @@ export default function SceneSettings() {
                 })}
               </ul>
             </div>
-            <label className="label cursor-pointer justify-start gap-3 mt-2">
+            <label className="label cursor-pointer justify-start gap-3 mt-2 mb-2">
               <input
                 type="checkbox"
-                className="toggle"
+                className="toggle" 
                 checked={!!directLink && !directLinkDisabled}
                 disabled={directLinkDisabled}
                 onChange={(e) => {
@@ -173,10 +173,11 @@ export default function SceneSettings() {
                   modifySceneProp("directLink", target);
                 }}
               />
+              
               <span className="label-text">Direct Link</span>
               {directLinkDisabled && (
                 <span
-                  className="tooltip tooltip-warning tooltip-top cursor-help text-warning text-xs before:!whitespace-normal before:!max-w-[150px]"
+                  className="tooltip tooltip-warning tooltip-top cursor-help text-warning text-xs before:!whitespace-normal before:!max-w-[150px] before:!text-[0.75rem]"
                   data-tip={
                     "Disabled: scene has buttons leading to multiple different scenes"
                   }
@@ -184,9 +185,16 @@ export default function SceneSettings() {
                   ⚠
                 </span>
               )}
+              <span
+                className="label-text tooltip tooltip-top cursor-help before:!whitespace-normal before:!max-w-[130px] before:!text-[0.75rem]"
+                data-tip="Directs the user to another scene automatically instead of waiting for a button click."
+              >
+                ⓘ
+              </span>
             </label>
+            
             <select
-              className="select select-bordered"
+              className="select select-bordered w-full"
               disabled={!directLink || directLinkDisabled}
               value={directLink ?? ""}
               onChange={(e) =>

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -155,7 +155,7 @@ export default function SceneSettings() {
             <label className="label cursor-pointer justify-start gap-3 mt-2 mb-2">
               <input
                 type="checkbox"
-                className="toggle" 
+                className="toggle"
                 checked={!!directLink && !directLinkDisabled}
                 disabled={directLinkDisabled}
                 onChange={(e) => {
@@ -173,7 +173,7 @@ export default function SceneSettings() {
                   modifySceneProp("directLink", target);
                 }}
               />
-              
+
               <span className="label-text">Direct Link</span>
               {directLinkDisabled && (
                 <span
@@ -187,12 +187,12 @@ export default function SceneSettings() {
               )}
               <span
                 className="label-text tooltip tooltip-top cursor-help before:!whitespace-normal before:!max-w-[130px] before:!text-[0.75rem]"
-                data-tip="Directs the user to another scene automatically instead of waiting for a button click."
+                data-tip="The player will be sent to this scene when they press either the 'space' or 'right arrow' keyboard button, instead of having to click an on screen element."
               >
                 ⓘ
               </span>
             </label>
-            
+
             <select
               className="select select-bordered w-full"
               disabled={!directLink || directLinkDisabled}


### PR DESCRIPTION
## Issue

no tooltip for the direct link section

## Solution

Added new tooltip, as well as found a thing (issue) with the scene details box, was able to scroll in x direction. Fixed (or not ?) that to make sure the tooltip box did not overflow to the edges. Let me know if this x axis scrolling was intended.

## Risk

Might mess with the layout since i touched the scene details area.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
