### PR TITLE
fix: newline  + deleting selected component crash

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -88,7 +88,10 @@ export default function AuthoringToolPage() {
     if (!sceneId || !scenes) return;
     if (!scenes.find((s) => s._id === sceneId)) {
       const next = scenes[0];
-      if (next) replace(next);
+      if (next){ 
+        useEditorStore.getState().clear();  
+        replace(next);
+      }
     }
   }, [scenes]);
 

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -70,7 +70,6 @@ export default function AuthoringToolPage() {
       if (operation === "undo" || operation === "redo") {
         if (record.sceneId !== sceneId) switchScene(getScene(), record.sceneId);
         const state = operation === "undo" ? record.before : record.after;
-        if (state === null) setSelected(null);
         replaceComponent(record.id, state);
         if (state !== null) setSelected(record.id);
       }

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -88,8 +88,8 @@ export default function AuthoringToolPage() {
     if (!sceneId || !scenes) return;
     if (!scenes.find((s) => s._id === sceneId)) {
       const next = scenes[0];
-      if (next){ 
-        useEditorStore.getState().clear();  
+      if (next) {
+        useEditorStore.getState().clear();
         replace(next);
       }
     }

--- a/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
@@ -40,14 +40,13 @@ export function copy(e: ClipboardEvent) {
 
 export function cut(e: ClipboardEvent) {
   if (isInputTarget(e)) return;
-  const { selected, setSelected } = useEditorStore.getState();
+  const { selected } = useEditorStore.getState();
   if (!selected) return;
 
   e.preventDefault();
 
   addToClipboard(e, selected);
   remove(selected);
-  setSelected(null);
 }
 
 export function paste(e: ClipboardEvent) {

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -46,11 +46,8 @@ function handleCtrlOperations(e: KeyboardEvent) {
 }
 
 function handleComponentOperations(e: KeyboardEvent, selected: string) {
-  const { setSelected } = useEditorStore.getState();
-
   if (e.key === "Backspace") {
     remove(selected);
-    setSelected(null);
   } else if (e.key === "ArrowUp") {
     modifyComponentProp(selected, "bounds.verts", (prev: Vec2[]) =>
       translate(prev, { x: 0, y: -5 })

--- a/frontend/src/features/authoring/handlers/pointer/ComponentContext.tsx
+++ b/frontend/src/features/authoring/handlers/pointer/ComponentContext.tsx
@@ -13,12 +13,10 @@ import {
   sendBackward,
   sendToBack,
 } from "../../scene/operations/component";
-import useEditorStore from "../../stores/editor";
 
 const ComponentMenu = ({ id }: { id: string }) => {
   function removeAndDeselect(id: string) {
     remove(id);
-    useEditorStore.getState().setSelected(null);
   }
 
   return (

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -5,6 +5,7 @@ import { dispatchModification, updateHistory } from "../history";
 import { getComponent, getScene, setScene } from "../scene";
 import type { Component, Scene } from "../../types";
 import { arrayToObject } from "../util";
+import useEditorStore from "../../stores/editor";
 
 export function replace(scene: Scene) {
   const clone = structuredClone(scene);
@@ -47,7 +48,9 @@ export function modify<A extends [string, ...unknown[]], R>(
 export function remove(id: string, history = true) {
   const component = getComponent(id);
   const prev = structuredClone(component);
-
+  if (useEditorStore.getState().selected === id) {
+    useEditorStore.getState().setSelected(null);
+  }
   delete getScene().components[id];
 
   if (history) updateHistory(id, prev);

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -48,9 +48,11 @@ export function modify<A extends [string, ...unknown[]], R>(
 export function remove(id: string, history = true) {
   const component = getComponent(id);
   const prev = structuredClone(component);
+
   if (useEditorStore.getState().selected === id) {
     useEditorStore.getState().setSelected(null);
   }
+
   delete getScene().components[id];
 
   if (history) updateHistory(id, prev);

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -219,10 +219,12 @@ function buildBlock(
 
   const lines = buildVisualLines(block.spans, maxWidth, blockStyle);
 
-  const { y, height } = lines[lines.length - 1];
-  visualBlock.height = y + height;
+  if (lines.length > 0) {
+    const {y, height} = lines[lines.length - 1];
+    visualBlock.height = y + height;
+  }
   visualBlock.lines = lines;
-
+  
   return visualBlock;
 }
 

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -220,11 +220,11 @@ function buildBlock(
   const lines = buildVisualLines(block.spans, maxWidth, blockStyle);
 
   if (lines.length > 0) {
-    const {y, height} = lines[lines.length - 1];
+    const { y, height } = lines[lines.length - 1];
     visualBlock.height = y + height;
   }
   visualBlock.lines = lines;
-  
+
   return visualBlock;
 }
 

--- a/frontend/src/features/authoring/topbar/Topbar.tsx
+++ b/frontend/src/features/authoring/topbar/Topbar.tsx
@@ -69,7 +69,7 @@ function Topbar({ saving, save }: { saving: boolean; save: () => void }) {
         <ShapeCreateMenu />
 
         {/* element properties */}
-        {selected && component && (
+        {selected && (
           <>
             <div className="divider divider-horizontal" />
 

--- a/frontend/src/features/authoring/topbar/Topbar.tsx
+++ b/frontend/src/features/authoring/topbar/Topbar.tsx
@@ -69,7 +69,7 @@ function Topbar({ saving, save }: { saving: boolean; save: () => void }) {
         <ShapeCreateMenu />
 
         {/* element properties */}
-        {selected && (
+        {selected && component && (
           <>
             <div className="divider divider-horizontal" />
 


### PR DESCRIPTION
## Issue

Deleting a selected textbox with a newline (any empty "" span) inside causes the scenario editor to crash.

## Solution

Fixed element properties guard by adding && component.

## Risk

Hopefully none.

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when rendering text blocks that produce no visual lines.
  * Improved editor behavior when the active scene disappears by clearing the editor before navigating to a valid scene.
  * Kept selection consistent after delete, cut, and Backspace actions by avoiding unnecessary selection clearing when components are removed.
  * Updated undo/redo selection behavior to only change selection when a valid scene state is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->