### PR TITLE
feat: add `subtract` operation for number state variables

### DIFF
--- a/backend/src/util/statevariables/stateOperations.js
+++ b/backend/src/util/statevariables/stateOperations.js
@@ -28,6 +28,9 @@ export const applyStateOperations = (stateVariables, stateOperations) => {
         case operations.ADD:
           stateVariable.value += stateOperation.value;
           break;
+        case operations.SUBTRACT:
+          stateVariable.value -= stateOperation.value;
+          break;
         default:
           throw new HttpError(
             `Unknown operation ${stateOperation.operation}`,

--- a/backend/src/util/statevariables/stateTypes.js
+++ b/backend/src/util/statevariables/stateTypes.js
@@ -20,10 +20,11 @@ export const getDefaultValue = (type) => {
 export const operations = {
   SET: "set",
   ADD: "add",
+  SUBTRACT: "subtract",
 };
 
 export const validOperations = {
   [stateTypes.STRING]: [operations.SET],
-  [stateTypes.NUMBER]: [operations.SET, operations.ADD],
+  [stateTypes.NUMBER]: [operations.SET, operations.ADD, operations.SUBTRACT],
   [stateTypes.BOOLEAN]: [operations.SET],
 };

--- a/frontend/src/components/StateVariables/stateOperations.js
+++ b/frontend/src/components/StateVariables/stateOperations.js
@@ -25,6 +25,9 @@ export const applyStateOperations = (stateVariables, stateOperations) => {
         case operations.ADD:
           stateVariable.value += stateOperation.value;
           break;
+        case operations.SUBTRACT:
+          stateVariable.value -= stateOperation.value;
+          break;
         default:
           console.error(`Unknown operation ${stateOperation.operation}`);
       }

--- a/frontend/src/components/StateVariables/stateTypes.js
+++ b/frontend/src/components/StateVariables/stateTypes.js
@@ -20,11 +20,12 @@ export const getDefaultValue = (type) => {
 export const operations = {
   SET: "set",
   ADD: "add",
+  SUBTRACT: "subtract",
 };
 
 export const validOperations = {
   [stateTypes.STRING]: [operations.SET],
-  [stateTypes.NUMBER]: [operations.SET, operations.ADD],
+  [stateTypes.NUMBER]: [operations.SET, operations.ADD, operations.SUBTRACT],
   [stateTypes.BOOLEAN]: [operations.SET],
 };
 


### PR DESCRIPTION
## Issue

Users expect a subtract operation when "add" exists and sometimes confuse "set" for "add".

## Solution

Add a subtract option

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subtraction operations for numeric state variables.
  * Numeric values can now be decreased by a specified amount.
  * Existing set and add operations remain available; string and boolean behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->