### PR TITLE
fix: theme direct-link scene selector

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -1,5 +1,5 @@
-import { useContext, useState, useEffect } from "react";
-import { Check } from "lucide-react";
+import { useContext, useState, useEffect, useRef } from "react";
+import { Check, ChevronDown } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import { generateUniqueSceneName } from "../../../utils/sceneUtils";
@@ -34,6 +34,10 @@ export default function SceneSettings() {
   const [selectedRoles, setSelectedRoles] = useState(roles ?? []);
   const [sceneName, setSceneName] = useState(name ?? "");
   const [timerDuration, setTimerDuration] = useState(time ?? "");
+  const [rolesOpen, setRolesOpen] = useState(false);
+  const [activeRoleIndex, setActiveRoleIndex] = useState(0);
+  const rolesTriggerRef = useRef(null);
+  const roleOptionRefs = useRef([]);
 
   useEffect(() => {
     if (!name || name === sceneName) return;
@@ -51,6 +55,10 @@ export default function SceneSettings() {
     const selected = roleList.filter((role) => roles.includes(role));
     if (!shallow(selected, selectedRoles)) setSelectedRoles(selected);
   }, [roleList, roles]);
+
+  useEffect(() => {
+    if (rolesOpen) roleOptionRefs.current[activeRoleIndex]?.focus();
+  }, [activeRoleIndex, rolesOpen]);
 
   function saveSceneRoles() {
     modifySceneProp("roles", selectedRoles);
@@ -98,6 +106,77 @@ export default function SceneSettings() {
     else setSelectedRoles((prev) => prev.filter((r) => r !== role));
   }
 
+  function openRoles(index) {
+    if (!roleList?.length) return;
+    const selectedIndex = roleList.findIndex((role) =>
+      selectedRoles.includes(role)
+    );
+    setActiveRoleIndex(index ?? (selectedIndex >= 0 ? selectedIndex : 0));
+    setRolesOpen(true);
+  }
+
+  function closeRoles() {
+    setRolesOpen(false);
+    rolesTriggerRef.current?.focus();
+  }
+
+  function handleRolesBlur(event) {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      setRolesOpen(false);
+      saveSceneRoles();
+    }
+  }
+
+  function handleRolesTriggerKeyDown(event) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (rolesOpen) closeRoles();
+      else openRoles();
+      return;
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      openRoles(
+        event.key === "ArrowUp" ? (roleList?.length ?? 0) - 1 : undefined
+      );
+    }
+  }
+
+  function handleRoleKeyDown(event, index) {
+    const roleCount = roleList?.length ?? 0;
+    let nextIndex = index;
+
+    switch (event.key) {
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        changeRole(roleList[index], !selectedRoles.includes(roleList[index]));
+        return;
+      case "ArrowDown":
+        nextIndex = (index + 1) % roleCount;
+        break;
+      case "ArrowUp":
+        nextIndex = (index - 1 + roleCount) % roleCount;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = roleCount - 1;
+        break;
+      case "Escape":
+        event.preventDefault();
+        closeRoles();
+        return;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    setActiveRoleIndex(nextIndex);
+  }
+
   return (
     <>
       <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
@@ -125,33 +204,60 @@ export default function SceneSettings() {
               placeholder="No timer"
             />
             <label className="label">Roles</label>
-            <div className="dropdown" onBlur={saveSceneRoles}>
-              <div
-                tabIndex={0}
-                role="button"
-                className="justify-start input mb-1 font-normal"
+            <div
+              className={`dropdown ${rolesOpen ? "dropdown-open" : ""}`}
+              onBlur={handleRolesBlur}
+            >
+              <button
+                ref={rolesTriggerRef}
+                type="button"
+                aria-haspopup="listbox"
+                aria-expanded={rolesOpen}
+                onClick={() => (rolesOpen ? closeRoles() : openRoles())}
+                onKeyDown={handleRolesTriggerKeyDown}
+                className="justify-between input mb-1 font-normal w-full"
               >
-                {selectedRoles?.join(", ") || "All"}
-              </div>
-              <ul
-                tabIndex={0}
-                className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
-              >
-                {roleList?.map((role, i) => {
-                  const active = selectedRoles.includes(role);
-                  return (
-                    <li
-                      className={active ? "text-secondary" : "text-primary"}
-                      key={i}
-                    >
-                      <a onClick={() => changeRole(role, !active)}>
-                        {role}
-                        {active && <Check className="ml-auto" size={14} />}
-                      </a>
-                    </li>
-                  );
-                })}
-              </ul>
+                <span className="truncate">
+                  {selectedRoles?.join(", ") || "All"}
+                </span>
+                <ChevronDown
+                  aria-hidden="true"
+                  className={`shrink-0 transition-transform ${
+                    rolesOpen ? "rotate-180" : ""
+                  }`}
+                  size={16}
+                />
+              </button>
+              {rolesOpen && (
+                <ul
+                  role="listbox"
+                  aria-multiselectable="true"
+                  className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
+                >
+                  {roleList?.map((role, i) => {
+                    const active = selectedRoles.includes(role);
+                    return (
+                      <li role="none" key={i}>
+                        <button
+                          ref={(element) => {
+                            roleOptionRefs.current[i] = element;
+                          }}
+                          type="button"
+                          role="option"
+                          tabIndex={-1}
+                          aria-selected={active}
+                          className={active ? "text-secondary" : "text-primary"}
+                          onClick={() => changeRole(role, !active)}
+                          onKeyDown={(event) => handleRoleKeyDown(event, i)}
+                        >
+                          {role}
+                          {active && <Check className="ml-auto" size={14} />}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
             </div>
             <label className="label cursor-pointer justify-start gap-3 mt-2">
               <input

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -1,5 +1,5 @@
-import { useContext, useState, useEffect, useRef } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { useContext, useState, useEffect } from "react";
+import { Check } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import { generateUniqueSceneName } from "../../../utils/sceneUtils";
@@ -34,10 +34,6 @@ export default function SceneSettings() {
   const [selectedRoles, setSelectedRoles] = useState(roles ?? []);
   const [sceneName, setSceneName] = useState(name ?? "");
   const [timerDuration, setTimerDuration] = useState(time ?? "");
-  const [rolesOpen, setRolesOpen] = useState(false);
-  const [activeRoleIndex, setActiveRoleIndex] = useState(0);
-  const rolesTriggerRef = useRef(null);
-  const roleOptionRefs = useRef([]);
 
   useEffect(() => {
     if (!name || name === sceneName) return;
@@ -55,10 +51,6 @@ export default function SceneSettings() {
     const selected = roleList.filter((role) => roles.includes(role));
     if (!shallow(selected, selectedRoles)) setSelectedRoles(selected);
   }, [roleList, roles]);
-
-  useEffect(() => {
-    if (rolesOpen) roleOptionRefs.current[activeRoleIndex]?.focus();
-  }, [activeRoleIndex, rolesOpen]);
 
   function saveSceneRoles() {
     modifySceneProp("roles", selectedRoles);
@@ -106,77 +98,6 @@ export default function SceneSettings() {
     else setSelectedRoles((prev) => prev.filter((r) => r !== role));
   }
 
-  function openRoles(index) {
-    if (!roleList?.length) return;
-    const selectedIndex = roleList.findIndex((role) =>
-      selectedRoles.includes(role)
-    );
-    setActiveRoleIndex(index ?? (selectedIndex >= 0 ? selectedIndex : 0));
-    setRolesOpen(true);
-  }
-
-  function closeRoles() {
-    setRolesOpen(false);
-    rolesTriggerRef.current?.focus();
-  }
-
-  function handleRolesBlur(event) {
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      setRolesOpen(false);
-      saveSceneRoles();
-    }
-  }
-
-  function handleRolesTriggerKeyDown(event) {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      if (rolesOpen) closeRoles();
-      else openRoles();
-      return;
-    }
-
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      openRoles(
-        event.key === "ArrowUp" ? (roleList?.length ?? 0) - 1 : undefined
-      );
-    }
-  }
-
-  function handleRoleKeyDown(event, index) {
-    const roleCount = roleList?.length ?? 0;
-    let nextIndex = index;
-
-    switch (event.key) {
-      case "Enter":
-      case " ":
-        event.preventDefault();
-        changeRole(roleList[index], !selectedRoles.includes(roleList[index]));
-        return;
-      case "ArrowDown":
-        nextIndex = (index + 1) % roleCount;
-        break;
-      case "ArrowUp":
-        nextIndex = (index - 1 + roleCount) % roleCount;
-        break;
-      case "Home":
-        nextIndex = 0;
-        break;
-      case "End":
-        nextIndex = roleCount - 1;
-        break;
-      case "Escape":
-        event.preventDefault();
-        closeRoles();
-        return;
-      default:
-        return;
-    }
-
-    event.preventDefault();
-    setActiveRoleIndex(nextIndex);
-  }
-
   return (
     <>
       <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
@@ -204,60 +125,33 @@ export default function SceneSettings() {
               placeholder="No timer"
             />
             <label className="label">Roles</label>
-            <div
-              className={`dropdown ${rolesOpen ? "dropdown-open" : ""}`}
-              onBlur={handleRolesBlur}
-            >
-              <button
-                ref={rolesTriggerRef}
-                type="button"
-                aria-haspopup="listbox"
-                aria-expanded={rolesOpen}
-                onClick={() => (rolesOpen ? closeRoles() : openRoles())}
-                onKeyDown={handleRolesTriggerKeyDown}
-                className="justify-between input mb-1 font-normal w-full"
+            <div className="dropdown" onBlur={saveSceneRoles}>
+              <div
+                tabIndex={0}
+                role="button"
+                className="justify-start input mb-1 font-normal"
               >
-                <span className="truncate">
-                  {selectedRoles?.join(", ") || "All"}
-                </span>
-                <ChevronDown
-                  aria-hidden="true"
-                  className={`shrink-0 transition-transform ${
-                    rolesOpen ? "rotate-180" : ""
-                  }`}
-                  size={16}
-                />
-              </button>
-              {rolesOpen && (
-                <ul
-                  role="listbox"
-                  aria-multiselectable="true"
-                  className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
-                >
-                  {roleList?.map((role, i) => {
-                    const active = selectedRoles.includes(role);
-                    return (
-                      <li role="none" key={i}>
-                        <button
-                          ref={(element) => {
-                            roleOptionRefs.current[i] = element;
-                          }}
-                          type="button"
-                          role="option"
-                          tabIndex={-1}
-                          aria-selected={active}
-                          className={active ? "text-secondary" : "text-primary"}
-                          onClick={() => changeRole(role, !active)}
-                          onKeyDown={(event) => handleRoleKeyDown(event, i)}
-                        >
-                          {role}
-                          {active && <Check className="ml-auto" size={14} />}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
+                {selectedRoles?.join(", ") || "All"}
+              </div>
+              <ul
+                tabIndex={0}
+                className="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
+              >
+                {roleList?.map((role, i) => {
+                  const active = selectedRoles.includes(role);
+                  return (
+                    <li
+                      className={active ? "text-secondary" : "text-primary"}
+                      key={i}
+                    >
+                      <a onClick={() => changeRole(role, !active)}>
+                        {role}
+                        {active && <Check className="ml-auto" size={14} />}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
             <label className="label cursor-pointer justify-start gap-3 mt-2">
               <input

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -11,6 +11,7 @@ import useDirectLink from "./useDirectLink";
 import shallow from "zustand/shallow";
 import toast from "react-hot-toast";
 import TimerStateOperationMenu from "../../../components/StateVariables/TimerStateOperationMenu";
+import SelectInput from "../components/Select";
 
 /**
  * This component displays the settings of a scene, such as the scene name
@@ -185,23 +186,23 @@ export default function SceneSettings() {
                 </span>
               )}
             </label>
-            <select
-              className="select select-bordered"
+            <SelectInput
+              nullable
               disabled={!directLink || directLinkDisabled}
-              value={directLink ?? ""}
-              onChange={(e) =>
-                modifySceneProp("directLink", e.target.value || null)
+              value={directLink}
+              values={
+                scenes
+                  ?.filter((scene) => scene._id !== sceneId)
+                  .map((scene) => scene._id) ?? []
               }
-            >
-              <option value="">No direct link target</option>
-              {scenes
-                ?.filter((scene) => scene._id !== sceneId)
-                .map((scene) => (
-                  <option key={scene._id} value={scene._id}>
-                    {scene.name}
-                  </option>
-                ))}
-            </select>
+              display={(targetId) =>
+                scenes?.find((scene) => scene._id === targetId)?.name ??
+                "Unknown scene"
+              }
+              onChange={(targetId) =>
+                modifySceneProp("directLink", targetId || null)
+              }
+            />
           </fieldset>
         </div>
       </div>

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -4,6 +4,7 @@ interface SelectInputProps<T> {
   display?: (v: T) => string;
   onChange: (v: T | null) => void;
   nullable?: boolean;
+  disabled?: boolean;
 }
 
 function SelectInput<T>({
@@ -11,44 +12,53 @@ function SelectInput<T>({
   value,
   display,
   nullable = false,
+  disabled = false,
   onChange,
 }: SelectInputProps<T>) {
   const render = display ?? ((v: T) => String(v));
 
   function handleClick(v: T) {
+    if (disabled) return;
     (document.activeElement as HTMLDivElement).blur();
     onChange(v);
   }
 
   return (
-    <div className="dropdown flex-1">
+    <div
+      className={`dropdown flex-1 ${
+        disabled ? "pointer-events-none opacity-50" : ""
+      }`}
+    >
       <div
-        tabIndex={0}
+        tabIndex={disabled ? -1 : 0}
         role="button"
+        aria-disabled={disabled}
         className="justify-start input mb-1 font-normal join-item w-full"
       >
         {value != null ? render(value) : "None"}
       </div>
-      <ul
-        tabIndex={0}
-        className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm"
-      >
-        {values.map((v, i) => (
-          <li key={i}>
-            <a
-              onClick={() => handleClick(v)}
-              className="block max-w-65 break-words overflow-hidden"
-            >
-              {render(v)}
-            </a>
-          </li>
-        ))}
-        {nullable ? (
-          <li>
-            <a onClick={() => onChange(null)}>None</a>
-          </li>
-        ) : null}
-      </ul>
+      {!disabled && (
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm"
+        >
+          {values.map((v, i) => (
+            <li key={i}>
+              <a
+                onClick={() => handleClick(v)}
+                className="block max-w-65 break-words overflow-hidden"
+              >
+                {render(v)}
+              </a>
+            </li>
+          ))}
+          {nullable ? (
+            <li>
+              <a onClick={() => onChange(null)}>None</a>
+            </li>
+          ) : null}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -1,10 +1,3 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type FocusEvent,
-  type KeyboardEvent,
-} from "react";
 import { ChevronDown } from "lucide-react";
 
 interface SelectInputProps<T> {
@@ -25,155 +18,43 @@ function SelectInput<T>({
   onChange,
 }: SelectInputProps<T>) {
   const render = display ?? ((v: T) => String(v));
-  const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const selectedIndex =
-    value == null ? (nullable ? values.length : -1) : values.indexOf(value);
-  const optionCount = values.length + (nullable ? 1 : 0);
 
-  useEffect(() => {
-    if (open) optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, open]);
-
-  function openMenu(index = selectedIndex >= 0 ? selectedIndex : 0) {
-    if (disabled || optionCount === 0) return;
-    setActiveIndex(index);
-    setOpen(true);
-  }
-
-  function selectOption(index: number) {
-    onChange(index < values.length ? values[index] : null);
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  function handleBlur(event: FocusEvent<HTMLDivElement>) {
-    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-      setOpen(false);
-    }
-  }
-
-  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      if (open) setOpen(false);
-      else openMenu();
-      return;
-    }
-
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      openMenu(
-        event.key === "ArrowUp" && selectedIndex < 0
-          ? optionCount - 1
-          : undefined
-      );
-    }
-  }
-
-  function handleOptionKeyDown(
-    event: KeyboardEvent<HTMLButtonElement>,
-    index: number
-  ) {
-    let nextIndex = index;
-
-    switch (event.key) {
-      case "Enter":
-      case " ":
-        event.preventDefault();
-        selectOption(index);
-        return;
-      case "ArrowDown":
-        nextIndex = (index + 1) % optionCount;
-        break;
-      case "ArrowUp":
-        nextIndex = (index - 1 + optionCount) % optionCount;
-        break;
-      case "Home":
-        nextIndex = 0;
-        break;
-      case "End":
-        nextIndex = optionCount - 1;
-        break;
-      case "Escape":
-        event.preventDefault();
-        setOpen(false);
-        triggerRef.current?.focus();
-        return;
-      default:
-        return;
-    }
-
-    event.preventDefault();
-    setActiveIndex(nextIndex);
+  function handleClick(v: T | null) {
+    (document.activeElement as HTMLDivElement).blur();
+    onChange(v);
   }
 
   return (
     <div
-      className={`dropdown flex-1 ${open ? "dropdown-open" : ""} ${
+      className={`dropdown flex-1 ${
         disabled ? "pointer-events-none opacity-50" : ""
       }`}
-      onBlur={handleBlur}
     >
-      <button
-        ref={triggerRef}
-        type="button"
-        disabled={disabled}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={() => (open ? setOpen(false) : openMenu())}
-        onKeyDown={handleTriggerKeyDown}
+      <div
+        tabIndex={0}
+        role="button"
         className="justify-between input mb-1 font-normal join-item w-full"
       >
         <span className="truncate">
           {value != null ? render(value) : "None"}
         </span>
-        <ChevronDown
-          aria-hidden="true"
-          className={`shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
-          size={16}
-        />
-      </button>
-      {!disabled && open && (
-        <ul
-          role="listbox"
-          className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm"
-        >
+        <ChevronDown className="shrink-0" size={16} />
+      </div>
+      {!disabled && (
+        <ul className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm">
           {values.map((v, i) => (
-            <li key={i} role="none">
-              <button
-                ref={(element) => {
-                  optionRefs.current[i] = element;
-                }}
-                type="button"
-                role="option"
-                tabIndex={-1}
-                aria-selected={value === v}
-                onClick={() => selectOption(i)}
-                onKeyDown={(event) => handleOptionKeyDown(event, i)}
+            <li key={i}>
+              <a
+                onClick={() => handleClick(v)}
                 className="block max-w-65 break-words overflow-hidden"
               >
                 {render(v)}
-              </button>
+              </a>
             </li>
           ))}
           {nullable ? (
-            <li role="none">
-              <button
-                ref={(element) => {
-                  optionRefs.current[values.length] = element;
-                }}
-                type="button"
-                role="option"
-                tabIndex={-1}
-                aria-selected={value == null}
-                onClick={() => selectOption(values.length)}
-                onKeyDown={(event) => handleOptionKeyDown(event, values.length)}
-              >
-                None
-              </button>
+            <li>
+              <a onClick={() => handleClick(null)}>None</a>
             </li>
           ) : null}
         </ul>

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -5,6 +5,7 @@ import {
   type FocusEvent,
   type KeyboardEvent,
 } from "react";
+import { ChevronDown } from "lucide-react";
 
 interface SelectInputProps<T> {
   values: T[];
@@ -55,6 +56,13 @@ function SelectInput<T>({
   }
 
   function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (open) setOpen(false);
+      else openMenu();
+      return;
+    }
+
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
       openMenu(
@@ -72,6 +80,11 @@ function SelectInput<T>({
     let nextIndex = index;
 
     switch (event.key) {
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        selectOption(index);
+        return;
       case "ArrowDown":
         nextIndex = (index + 1) % optionCount;
         break;
@@ -112,9 +125,16 @@ function SelectInput<T>({
         aria-expanded={open}
         onClick={() => (open ? setOpen(false) : openMenu())}
         onKeyDown={handleTriggerKeyDown}
-        className="justify-start input mb-1 font-normal join-item w-full"
+        className="justify-between input mb-1 font-normal join-item w-full"
       >
-        {value != null ? render(value) : "None"}
+        <span className="truncate">
+          {value != null ? render(value) : "None"}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+          size={16}
+        />
       </button>
       {!disabled && open && (
         <ul

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -1,3 +1,11 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type FocusEvent,
+  type KeyboardEvent,
+} from "react";
+
 interface SelectInputProps<T> {
   values: T[];
   value: T | null;
@@ -16,45 +24,136 @@ function SelectInput<T>({
   onChange,
 }: SelectInputProps<T>) {
   const render = display ?? ((v: T) => String(v));
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selectedIndex =
+    value == null ? (nullable ? values.length : -1) : values.indexOf(value);
+  const optionCount = values.length + (nullable ? 1 : 0);
 
-  function handleClick(v: T) {
-    if (disabled) return;
-    (document.activeElement as HTMLDivElement).blur();
-    onChange(v);
+  useEffect(() => {
+    if (open) optionRefs.current[activeIndex]?.focus();
+  }, [activeIndex, open]);
+
+  function openMenu(index = selectedIndex >= 0 ? selectedIndex : 0) {
+    if (disabled || optionCount === 0) return;
+    setActiveIndex(index);
+    setOpen(true);
+  }
+
+  function selectOption(index: number) {
+    onChange(index < values.length ? values[index] : null);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function handleBlur(event: FocusEvent<HTMLDivElement>) {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setOpen(false);
+    }
+  }
+
+  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      openMenu(
+        event.key === "ArrowUp" && selectedIndex < 0
+          ? optionCount - 1
+          : undefined
+      );
+    }
+  }
+
+  function handleOptionKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) {
+    let nextIndex = index;
+
+    switch (event.key) {
+      case "ArrowDown":
+        nextIndex = (index + 1) % optionCount;
+        break;
+      case "ArrowUp":
+        nextIndex = (index - 1 + optionCount) % optionCount;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = optionCount - 1;
+        break;
+      case "Escape":
+        event.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    setActiveIndex(nextIndex);
   }
 
   return (
     <div
-      className={`dropdown flex-1 ${
+      className={`dropdown flex-1 ${open ? "dropdown-open" : ""} ${
         disabled ? "pointer-events-none opacity-50" : ""
       }`}
+      onBlur={handleBlur}
     >
-      <div
-        tabIndex={disabled ? -1 : 0}
-        role="button"
-        aria-disabled={disabled}
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => (open ? setOpen(false) : openMenu())}
+        onKeyDown={handleTriggerKeyDown}
         className="justify-start input mb-1 font-normal join-item w-full"
       >
         {value != null ? render(value) : "None"}
-      </div>
-      {!disabled && (
+      </button>
+      {!disabled && open && (
         <ul
-          tabIndex={0}
+          role="listbox"
           className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm"
         >
           {values.map((v, i) => (
-            <li key={i}>
-              <a
-                onClick={() => handleClick(v)}
+            <li key={i} role="none">
+              <button
+                ref={(element) => {
+                  optionRefs.current[i] = element;
+                }}
+                type="button"
+                role="option"
+                tabIndex={-1}
+                aria-selected={value === v}
+                onClick={() => selectOption(i)}
+                onKeyDown={(event) => handleOptionKeyDown(event, i)}
                 className="block max-w-65 break-words overflow-hidden"
               >
                 {render(v)}
-              </a>
+              </button>
             </li>
           ))}
           {nullable ? (
-            <li>
-              <a onClick={() => onChange(null)}>None</a>
+            <li role="none">
+              <button
+                ref={(element) => {
+                  optionRefs.current[values.length] = element;
+                }}
+                type="button"
+                role="option"
+                tabIndex={-1}
+                aria-selected={value == null}
+                onClick={() => selectOption(values.length)}
+                onKeyDown={(event) => handleOptionKeyDown(event, values.length)}
+              >
+                None
+              </button>
             </li>
           ) : null}
         </ul>


### PR DESCRIPTION
## Issue

The direct-link scene selector used the browser’s native select styling, making it inconsistent with the themed selectors used throughout the authoring interface.

## Solution

Replaced the native selector with the shared themed `SelectInput` component and added disabled-state support to preserve the existing direct-link behavior.

## Risk

Low risk. The shared selector now supports a disabled state, which could affect other usages if they adopt this option incorrectly.

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Direct Link settings with a consistent scene-selection dropdown.
  * Added an option to remove a Direct Link target.
  * Added the ability to disable selection controls with improved visual feedback and non-interactive behavior.
  * Enhanced the dropdown trigger with a clearer chevron indicator, improved alignment, and truncated value display.
  * Added a fallback label for scenes without a recognized name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->