### PR TITLE
fix(authoring): context menu flickers at previous position

### DIFF
--- a/frontend/src/components/ContextMenu/portal.jsx
+++ b/frontend/src/components/ContextMenu/portal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 
 const OFFSET = -5;
 
@@ -45,8 +45,13 @@ export const ContextMenuPortal = () => {
     return () => (listener = null);
   }, [setCurrent]);
 
-  useEffect(() => {
-    if (!current.menu || !menuRef.current) return;
+  // runs before paint so the menu is never shown at an unadjusted position,
+  // and clears the previous menu's position so a reopen can't flash there
+  useLayoutEffect(() => {
+    if (!current.menu || !menuRef.current) {
+      setAdjustedPosition(null);
+      return;
+    }
 
     const { innerWidth: vw, innerHeight: vh } = window;
     const rect = menuRef.current.getBoundingClientRect();

--- a/frontend/src/components/ContextMenu/portal.jsx
+++ b/frontend/src/components/ContextMenu/portal.jsx
@@ -28,10 +28,10 @@ const attachClickAwayListener = () => {
     const menu = document.getElementById("context-menu-wrapper");
     if (menu?.contains(event.target)) return;
     unrender();
-    document.removeEventListener("mouseup", clickAwayListener);
+    document.removeEventListener("mousedown", clickAwayListener);
   };
 
-  document.addEventListener("mouseup", clickAwayListener, { passive: true });
+  document.addEventListener("mousedown", clickAwayListener, { passive: true });
 };
 
 export const ContextMenuPortal = () => {


### PR DESCRIPTION
## Issue

~~The main cause for the flicker is that, the current function which create the context menu check onmouseup if your cursor is on a piece of html which is apart of the context menu. This bug happens when you are holding right click and move your cursor off the context menu and release right click.~~

`adjustedPosition` is never cleared when the menu closes so the next open paints one frame at the previous menu's coordinates before the effect corrects it

## Solution

~~Change from mouseup to mousedown because it is guaranteed that the mouse will start on top of the context menu due to negative offset~~

`useLayoutEffect` to adjust first before paint

## Risk

NONE

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context menu click-away handling by responding when the mouse button is pressed, providing more consistent dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->