### PR TITLE
VPS-117: Prevent empty scene settings from expanding

### DIFF
--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -11,21 +11,30 @@ import { useState } from "react";
 const StateOperationMenu = ({ component }) => {
   const [createOpen, setCreateOpen] = useState(false);
 
+  const stateOperations = component?.stateOperations ?? [];
+  const hasStateOperations = stateOperations.length > 0;
+
   function createNew() {
     setCreateOpen(true);
   }
 
   return (
     <>
-      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
-        <input type="checkbox" />
-        <div className="collapse-title flex items-center justify-between">
-          State Operations
-          <PlusIcon size={18} onClick={createNew} className="z-1" />
-        </div>
+    <div
+      className={`collapse overflow-visible ${
+        hasStateOperations ? "collapse-arrow" : ""
+      } bg-base-300 rounded-sm text-s`}
+    >
+      {hasStateOperations && <input type="checkbox" />}
+
+      <div className="collapse-title flex items-center justify-between">
+        State Operations
+        <PlusIcon size={18} onClick={createNew} className="z-1" />
+      </div>
+
+      {hasStateOperations && (
         <div className="collapse-content text--1 bg-base-200 px-0">
-          {/* <CreateStateOperation component={component} /> */}
-          {component?.stateOperations?.map((operation, i) => (
+          {stateOperations.map((operation, i) => (
             <EditStateOperation
               component={component}
               operationIndex={i}
@@ -34,7 +43,8 @@ const StateOperationMenu = ({ component }) => {
             />
           ))}
         </div>
-      </div>
+      )}
+    </div>
       <CreateStateOperation
         component={component}
         open={createOpen}

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -20,31 +20,31 @@ const StateOperationMenu = ({ component }) => {
 
   return (
     <>
-    <div
-      className={`collapse overflow-visible ${
-        hasStateOperations ? "collapse-arrow" : ""
-      } bg-base-300 rounded-sm text-s`}
-    >
-      {hasStateOperations && <input type="checkbox" />}
+      <div
+        className={`collapse overflow-visible ${
+          hasStateOperations ? "collapse-arrow" : ""
+        } bg-base-300 rounded-sm text-s`}
+      >
+        {hasStateOperations && <input type="checkbox" />}
 
-      <div className="collapse-title flex items-center justify-between">
-        State Operations
-        <PlusIcon size={18} onClick={createNew} className="z-1" />
-      </div>
-
-      {hasStateOperations && (
-        <div className="collapse-content text--1 bg-base-200 px-0">
-          {stateOperations.map((operation, i) => (
-            <EditStateOperation
-              component={component}
-              operationIndex={i}
-              stateOperation={operation}
-              key={i}
-            />
-          ))}
+        <div className="collapse-title flex items-center justify-between">
+          State Operations
+          <PlusIcon size={18} onClick={createNew} className="z-1" />
         </div>
-      )}
-    </div>
+
+        {hasStateOperations && (
+          <div className="collapse-content text--1 bg-base-200 px-0">
+            {stateOperations.map((operation, i) => (
+              <EditStateOperation
+                component={component}
+                operationIndex={i}
+                stateOperation={operation}
+                key={i}
+              />
+            ))}
+          </div>
+        )}
+      </div>
       <CreateStateOperation
         component={component}
         open={createOpen}

--- a/frontend/src/components/StateVariables/StateOperationMenu.jsx
+++ b/frontend/src/components/StateVariables/StateOperationMenu.jsx
@@ -27,7 +27,11 @@ const StateOperationMenu = ({ component }) => {
       >
         {hasStateOperations && <input type="checkbox" />}
 
-        <div className="collapse-title flex items-center justify-between">
+        <div
+          className={`collapse-title flex items-center justify-between ${
+            hasStateOperations ? "" : "pe-4"
+          }`}
+        >
           State Operations
           <PlusIcon size={18} onClick={createNew} className="z-1" />
         </div>

--- a/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
@@ -25,6 +25,7 @@ function AudioManager() {
   const inputRef = useRef(null);
 
   const audios = Object.values(components).filter((c) => c.type === "audio");
+  const hasAudios = audios.length > 0;
 
   async function handleFileInput(e) {
     addAudio(e.target.files[0]);
@@ -37,18 +38,26 @@ function AudioManager() {
 
   return (
     <>
-      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
-        <input type="checkbox" />
-        <div className="collapse-title flex items-center justify-between">
-          Audio Elements
-          <PlusIcon size={18} onClick={createNew} className="z-1" />
-        </div>
+    <div
+      className={`collapse overflow-visible ${
+        hasAudios ? "collapse-arrow" : ""
+      } bg-base-300 rounded-sm text-s`}
+    >
+      {hasAudios && <input type="checkbox" />}
+
+      <div className="collapse-title flex items-center justify-between">
+        Audio Elements
+        <PlusIcon size={18} onClick={createNew} className="z-1" />
+      </div>
+
+      {hasAudios && (
         <div className="collapse-content text--1 bg-base-200 px-0">
-          {audios.map((audio, i) => (
-            <EditAudioComponent component={audio} key={i} />
+          {audios.map((audio) => (
+            <EditAudioComponent component={audio} key={audio.id} />
           ))}
         </div>
-      </div>
+      )}
+    </div>
       <input
         type="file"
         accept=".mp3"

--- a/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
@@ -45,7 +45,11 @@ function AudioManager() {
       >
         {hasAudios && <input type="checkbox" />}
 
-        <div className="collapse-title flex items-center justify-between">
+        <div
+          className={`collapse-title flex items-center justify-between ${
+            hasAudios ? "" : "pe-4"
+          }`}
+        >
           Audio Elements
           <PlusIcon size={18} onClick={createNew} className="z-1" />
         </div>

--- a/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/AudioManager.jsx
@@ -38,26 +38,26 @@ function AudioManager() {
 
   return (
     <>
-    <div
-      className={`collapse overflow-visible ${
-        hasAudios ? "collapse-arrow" : ""
-      } bg-base-300 rounded-sm text-s`}
-    >
-      {hasAudios && <input type="checkbox" />}
+      <div
+        className={`collapse overflow-visible ${
+          hasAudios ? "collapse-arrow" : ""
+        } bg-base-300 rounded-sm text-s`}
+      >
+        {hasAudios && <input type="checkbox" />}
 
-      <div className="collapse-title flex items-center justify-between">
-        Audio Elements
-        <PlusIcon size={18} onClick={createNew} className="z-1" />
-      </div>
-
-      {hasAudios && (
-        <div className="collapse-content text--1 bg-base-200 px-0">
-          {audios.map((audio) => (
-            <EditAudioComponent component={audio} key={audio.id} />
-          ))}
+        <div className="collapse-title flex items-center justify-between">
+          Audio Elements
+          <PlusIcon size={18} onClick={createNew} className="z-1" />
         </div>
-      )}
-    </div>
+
+        {hasAudios && (
+          <div className="collapse-content text--1 bg-base-200 px-0">
+            {audios.map((audio) => (
+              <EditAudioComponent component={audio} key={audio.id} />
+            ))}
+          </div>
+        )}
+      </div>
       <input
         type="file"
         accept=".mp3"


### PR DESCRIPTION
## Issue

VPS-117: Empty list based scene settings behave unexpectedly

Linear issue: https://linear.app/projectsvps/issue/VPS-117/empty-list-based-scene-settings-behave-unexpectedly

## Solution

- Prevented the Audio Elements section from being expandable when it is empty.
- Prevented the State Operations section from being expandable when it is empty.
- Kept the add buttons available for creating the first item.
- Restored the expansion arrow and collapse behaviour when items exist.

## Risk

Low. But Hartej is the big risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar behavior by hiding “State Operations” and “Audio” sections when there’s nothing to show.
  * Disabled related empty UI elements (checkboxes, collapse headers, and arrow styling) unless corresponding items exist.
  * Improved audio list rendering reliability by using stable item identifiers for list keys instead of array indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->