### PR TITLE
feat(authoring): canvas alignment guides and snapping

### DIFF
--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -27,6 +27,7 @@ function Overlay() {
   const selected = useEditorStore((state) => state.selected)!;
   const hovered = useEditorStore((state) => state.hovered)!;
   const bounds = useEditorStore((state) => state.mutationBounds);
+  const activeGuides = useEditorStore((state) => state.activeGuides);
   const scene = useVisualScene((scene) => scene.components);
   const mode = useEditorStore((scene) => scene.mode);
   const createType = useEditorStore((scene) => scene.createType);
@@ -74,6 +75,35 @@ function Overlay() {
       )}
       {mode.includes("mutation") &&
         resolve(component?.type ?? createType, bounds)}
+      {mode.includes("mutation") &&
+        activeGuides.map((guide, index) => {
+          const style = guide.isCanvasCenter
+            ? {
+                stroke: "var(--color-warning)",
+                strokeWidth: 3,
+                strokeDasharray: "6 4",
+              }
+            : { stroke: "var(--color-error)", strokeWidth: 2 };
+          return guide.orientation === "vertical" ? (
+            <line
+              key={index}
+              x1={guide.position}
+              y1={-50}
+              x2={guide.position}
+              y2={1130}
+              {...style}
+            />
+          ) : (
+            <line
+              key={index}
+              x1={-50}
+              y1={guide.position}
+              x2={1970}
+              y2={guide.position}
+              {...style}
+            />
+          );
+        })}
     </svg>
   );
 }

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -11,6 +11,7 @@ import type { VisualDocument } from "../../text/types";
 import { subtract, translate } from "../../util";
 import { handleCreateDrag, handleCreateEnd, handleCreateStart } from "./create";
 import { handleResizeDrag, handleResizeStart } from "./resize";
+import { snapTranslation } from "./snap";
 
 export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
   const target = e.target as HTMLElement;
@@ -105,21 +106,33 @@ function handleComponentClick(e: React.MouseEvent, position: Vec2) {
 }
 
 function handleComponentDrag(_: React.MouseEvent, position: Vec2) {
-  const { selected, setMutationBounds, offset, setMode } =
+  const { selected, setMutationBounds, offset, setMode, setActiveGuides } =
     useEditorStore.getState();
   if (!selected) return;
 
-  const component = useVisualScene.getState().components[selected];
+  const { components } = useVisualScene.getState();
+  const component = components[selected];
 
-  const verts = translate(component.bounds.verts, subtract(position, offset));
+  let verts = translate(component.bounds.verts, subtract(position, offset));
+  const { delta, guides } = snapTranslation(
+    verts,
+    component.bounds.rotation,
+    Object.values(components),
+    selected
+  );
+  verts = translate(verts, delta);
+
   setMutationBounds((prev) => ({ ...prev, verts }));
+  setActiveGuides(guides);
   setMode(["mutation"]);
 }
 
 function handleMutationEnd() {
-  const { selected, mutationBounds, setMode } = useEditorStore.getState();
+  const { selected, mutationBounds, setMode, setActiveGuides } =
+    useEditorStore.getState();
   modifyComponentBounds(selected!, mutationBounds);
   setMode(["normal"]);
+  setActiveGuides([]);
 }
 
 // document handlers

--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -1,5 +1,6 @@
 import { getComponent, getComponentProp } from "../../scene/scene";
 import useEditorStore from "../../stores/editor";
+import useVisualScene from "../../stores/visual";
 import type { Bounds, Vec2 } from "../../types";
 import {
   add,
@@ -13,6 +14,7 @@ import {
   scale,
   subtract,
 } from "../../util";
+import { snapResizePoint } from "./snap";
 
 type HandleType = "size" | "rotation";
 
@@ -30,7 +32,8 @@ export function handleResizeStart(e: React.MouseEvent) {
 }
 
 export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
-  const { addMode, setMutationBounds, selected } = useEditorStore.getState();
+  const { addMode, setMutationBounds, setActiveGuides, selected } =
+    useEditorStore.getState();
   addMode("mutation");
 
   const bounds = getComponentProp(selected!, "bounds") as Bounds;
@@ -38,11 +41,22 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
   const newBounds: Partial<Bounds> = {};
 
   if (type === "size") {
-    const relative = rotate(
+    let relative = rotate(
       position,
       getBoxCenter(bounds.verts),
       -bounds.rotation
     );
+
+    // alignment guides only make sense in global space, so only snap unrotated components
+    if (!bounds.rotation) {
+      const components = Object.values(useVisualScene.getState().components);
+      const snapped = snapResizePoint(relative, coords, components, selected!);
+      relative = snapped.position;
+      setActiveGuides(snapped.guides);
+    } else {
+      setActiveGuides([]);
+    }
+
     newBounds.verts = updateResize(relative, coords, e.ctrlKey, e.shiftKey);
   } else if (type === "rotation") {
     newBounds.rotation = getRotation(
@@ -50,6 +64,7 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
       getBoxCenter(bounds.verts),
       e.shiftKey
     );
+    setActiveGuides([]);
   }
 
   setMutationBounds((prev) => ({ ...prev, ...newBounds }));

--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -41,7 +41,7 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
   const newBounds: Partial<Bounds> = {};
 
   if (type === "size") {
-    let relative = rotate(
+    const relative = rotate(
       position,
       getBoxCenter(bounds.verts),
       -bounds.rotation
@@ -50,14 +50,40 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
     // alignment guides only make sense in global space, so only snap unrotated components
     if (!bounds.rotation) {
       const components = Object.values(useVisualScene.getState().components);
-      const snapped = snapResizePoint(relative, coords, components, selected!);
-      relative = snapped.position;
+
+      // resolve modifiers (shift/ctrl) against the raw point first so we snap the
+      // actual resize point, not the mouse position they'd otherwise overwrite
+      const unsnappedVerts = updateResize(
+        relative,
+        coords,
+        e.ctrlKey,
+        e.shiftKey
+      );
+      const draggedPoint = getVertPoint(unsnappedVerts, coords);
+      const originalOpposite = getVertPoint(bounds.verts, inverse(coords));
+      const pivot = getBoxCenter(bounds.verts);
+
+      const snapped = snapResizePoint(
+        draggedPoint,
+        originalOpposite,
+        pivot,
+        coords,
+        e.ctrlKey,
+        components,
+        selected!
+      );
       setActiveGuides(snapped.guides);
+
+      newBounds.verts = updateResize(
+        snapped.position,
+        coords,
+        e.ctrlKey,
+        e.shiftKey
+      );
     } else {
       setActiveGuides([]);
+      newBounds.verts = updateResize(relative, coords, e.ctrlKey, e.shiftKey);
     }
-
-    newBounds.verts = updateResize(relative, coords, e.ctrlKey, e.shiftKey);
   } else if (type === "rotation") {
     newBounds.rotation = getRotation(
       position,
@@ -168,6 +194,15 @@ function mirror(verts: Vec2[], center: Vec2, coords: number[]) {
   const point = { x: verts[coords[0]].x, y: verts[coords[1]].y };
   const inversePosition = add(scale(subtract(point, center), -1), center);
   return modifyVerts(verts, inverse(coords), inversePosition);
+}
+
+// extracts the position of the vertex being dragged, ignoring axes the
+// current handle doesn't control (coords entry of 0.5)
+function getVertPoint(verts: Vec2[], coords: number[]): Vec2 {
+  return {
+    x: coords[0] !== 0.5 ? verts[coords[0]].x : 0,
+    y: coords[1] !== 0.5 ? verts[coords[1]].y : 0,
+  };
 }
 
 function modifyVerts(verts: Vec2[], coords: number[], v: Vec2) {

--- a/frontend/src/features/authoring/handlers/pointer/snap.ts
+++ b/frontend/src/features/authoring/handlers/pointer/snap.ts
@@ -50,14 +50,21 @@ function collectSnapTargets(components: Component[], excludeId: string) {
   return { xs, ys };
 }
 
-function closestSnap(candidates: number[], targets: number[]) {
-  let best: { delta: number; position: number } | null = null;
+// a point on the shape that can be dragged into alignment, and how fast it
+// moves relative to the resize handle's input position (see snapResizePoint)
+interface Candidate {
+  value: number;
+  rate: number;
+}
+
+function closestSnap(candidates: Candidate[], targets: number[]) {
+  let best: { delta: number; position: number; rate: number } | null = null;
   for (const candidate of candidates) {
     for (const target of targets) {
-      const delta = target - candidate;
+      const delta = target - candidate.value;
       if (Math.abs(delta) > SNAP_THRESHOLD) continue;
       if (!best || Math.abs(delta) < Math.abs(best.delta)) {
-        best = { delta, position: target };
+        best = { delta, position: target, rate: candidate.rate };
       }
     }
   }
@@ -74,8 +81,18 @@ export function snapTranslation(
   const box = getAABB({ verts, rotation });
   const { xs, ys } = collectSnapTargets(components, excludeId);
 
-  const xSnap = closestSnap([box.minX, box.centerX, box.maxX], xs);
-  const ySnap = closestSnap([box.minY, box.centerY, box.maxY], ys);
+  // a plain translation moves every edge/center of the box at the same rate
+  const asCandidates = (values: number[]): Candidate[] =>
+    values.map((value) => ({ value, rate: 1 }));
+
+  const xSnap = closestSnap(
+    asCandidates([box.minX, box.centerX, box.maxX]),
+    xs
+  );
+  const ySnap = closestSnap(
+    asCandidates([box.minY, box.centerY, box.maxY]),
+    ys
+  );
 
   const guides: Guide[] = [];
   const delta: Vec2 = { x: 0, y: 0 };
@@ -100,22 +117,41 @@ export function snapTranslation(
   return { delta, guides };
 }
 
-// snaps a single resize handle point to nearby edges/centers; only meaningful for
-// unrotated components, since the point is expressed in the component's local space
+// snaps a resize handle to nearby edges/centers; only meaningful for unrotated
+// components, since points are expressed in the component's local space.
+//
+// A resize handle can move more than just the dragged corner: with ctrl held
+// the opposite corner mirrors it (moving at rate -1), and even a plain drag
+// shifts the box's center (rate 0.5, since only one of the two corners moves).
+// Each of those is a separate point that could be the one lining up with
+// another shape, so every one is checked, and the delta is converted back
+// into a position adjustment using that candidate's rate of movement.
 export function snapResizePoint(
-  position: Vec2,
+  draggedPoint: Vec2,
+  originalOpposite: Vec2,
+  pivot: Vec2,
   coords: number[],
+  anchorCenter: boolean,
   components: Component[],
   excludeId: string
 ): { position: Vec2; guides: Guide[] } {
   const { xs, ys } = collectSnapTargets(components, excludeId);
   const guides: Guide[] = [];
-  const snapped = { ...position };
+  const snapped = { ...draggedPoint };
 
   if (coords[0] !== 0.5) {
-    const snap = closestSnap([position.x], xs);
+    const candidates: Candidate[] = anchorCenter
+      ? [
+          { value: draggedPoint.x, rate: 1 },
+          { value: 2 * pivot.x - draggedPoint.x, rate: -1 },
+        ]
+      : [
+          { value: draggedPoint.x, rate: 1 },
+          { value: (draggedPoint.x + originalOpposite.x) / 2, rate: 0.5 },
+        ];
+    const snap = closestSnap(candidates, xs);
     if (snap) {
-      snapped.x = snap.position;
+      snapped.x = draggedPoint.x + snap.delta / snap.rate;
       guides.push({
         orientation: "vertical",
         position: snap.position,
@@ -125,9 +161,18 @@ export function snapResizePoint(
   }
 
   if (coords[1] !== 0.5) {
-    const snap = closestSnap([position.y], ys);
+    const candidates: Candidate[] = anchorCenter
+      ? [
+          { value: draggedPoint.y, rate: 1 },
+          { value: 2 * pivot.y - draggedPoint.y, rate: -1 },
+        ]
+      : [
+          { value: draggedPoint.y, rate: 1 },
+          { value: (draggedPoint.y + originalOpposite.y) / 2, rate: 0.5 },
+        ];
+    const snap = closestSnap(candidates, ys);
     if (snap) {
-      snapped.y = snap.position;
+      snapped.y = draggedPoint.y + snap.delta / snap.rate;
       guides.push({
         orientation: "horizontal",
         position: snap.position,

--- a/frontend/src/features/authoring/handlers/pointer/snap.ts
+++ b/frontend/src/features/authoring/handlers/pointer/snap.ts
@@ -1,0 +1,140 @@
+import type { Bounds, Component, Guide, Vec2 } from "../../types";
+import { expandBoxVerts, getBoxCenter, rotateMany } from "../../util";
+
+export const SNAP_THRESHOLD = 10;
+export const CANVAS_WIDTH = 1920;
+export const CANVAS_HEIGHT = 1080;
+
+interface AABB {
+  minX: number;
+  maxX: number;
+  centerX: number;
+  minY: number;
+  maxY: number;
+  centerY: number;
+}
+
+function getAABB(bounds: Bounds): AABB {
+  const corners = rotateMany(
+    expandBoxVerts(bounds.verts),
+    getBoxCenter(bounds.verts),
+    bounds.rotation
+  );
+  const xs = corners.map((v) => v.x);
+  const ys = corners.map((v) => v.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  return {
+    minX,
+    maxX,
+    centerX: (minX + maxX) / 2,
+    minY,
+    maxY,
+    centerY: (minY + maxY) / 2,
+  };
+}
+
+function collectSnapTargets(components: Component[], excludeId: string) {
+  const xs = [0, CANVAS_WIDTH / 2, CANVAS_WIDTH];
+  const ys = [0, CANVAS_HEIGHT / 2, CANVAS_HEIGHT];
+
+  for (const component of components) {
+    if (component.id === excludeId) continue;
+    const box = getAABB(component.bounds);
+    xs.push(box.minX, box.centerX, box.maxX);
+    ys.push(box.minY, box.centerY, box.maxY);
+  }
+
+  return { xs, ys };
+}
+
+function closestSnap(candidates: number[], targets: number[]) {
+  let best: { delta: number; position: number } | null = null;
+  for (const candidate of candidates) {
+    for (const target of targets) {
+      const delta = target - candidate;
+      if (Math.abs(delta) > SNAP_THRESHOLD) continue;
+      if (!best || Math.abs(delta) < Math.abs(best.delta)) {
+        best = { delta, position: target };
+      }
+    }
+  }
+  return best;
+}
+
+// snaps a translated (dragged) bounding box to nearby edges/centers, independently per axis
+export function snapTranslation(
+  verts: Vec2[],
+  rotation: number,
+  components: Component[],
+  excludeId: string
+): { delta: Vec2; guides: Guide[] } {
+  const box = getAABB({ verts, rotation });
+  const { xs, ys } = collectSnapTargets(components, excludeId);
+
+  const xSnap = closestSnap([box.minX, box.centerX, box.maxX], xs);
+  const ySnap = closestSnap([box.minY, box.centerY, box.maxY], ys);
+
+  const guides: Guide[] = [];
+  const delta: Vec2 = { x: 0, y: 0 };
+
+  if (xSnap) {
+    delta.x = xSnap.delta;
+    guides.push({
+      orientation: "vertical",
+      position: xSnap.position,
+      isCanvasCenter: xSnap.position === CANVAS_WIDTH / 2,
+    });
+  }
+  if (ySnap) {
+    delta.y = ySnap.delta;
+    guides.push({
+      orientation: "horizontal",
+      position: ySnap.position,
+      isCanvasCenter: ySnap.position === CANVAS_HEIGHT / 2,
+    });
+  }
+
+  return { delta, guides };
+}
+
+// snaps a single resize handle point to nearby edges/centers; only meaningful for
+// unrotated components, since the point is expressed in the component's local space
+export function snapResizePoint(
+  position: Vec2,
+  coords: number[],
+  components: Component[],
+  excludeId: string
+): { position: Vec2; guides: Guide[] } {
+  const { xs, ys } = collectSnapTargets(components, excludeId);
+  const guides: Guide[] = [];
+  const snapped = { ...position };
+
+  if (coords[0] !== 0.5) {
+    const snap = closestSnap([position.x], xs);
+    if (snap) {
+      snapped.x = snap.position;
+      guides.push({
+        orientation: "vertical",
+        position: snap.position,
+        isCanvasCenter: snap.position === CANVAS_WIDTH / 2,
+      });
+    }
+  }
+
+  if (coords[1] !== 0.5) {
+    const snap = closestSnap([position.y], ys);
+    if (snap) {
+      snapped.y = snap.position;
+      guides.push({
+        orientation: "horizontal",
+        position: snap.position,
+        isCanvasCenter: snap.position === CANVAS_HEIGHT / 2,
+      });
+    }
+  }
+
+  return { position: snapped, guides };
+}

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -1,6 +1,6 @@
 import create from "zustand";
 import type { ModelSelection, VisualSelection } from "../text/types";
-import type { BaseTextStyle, Bounds, Vec2 } from "../types";
+import type { BaseTextStyle, Bounds, Guide, Vec2 } from "../types";
 import { getComponent } from "../scene/scene";
 import { getStyleForSelection } from "../scene/operations/text";
 
@@ -14,6 +14,7 @@ interface EditorState {
   mouseDown: boolean;
   mutationBounds: Bounds;
   offset: Vec2;
+  activeGuides: Guide[];
 
   setSelected: (id: string | null) => void;
   setHovered: (id: string | null) => void;
@@ -21,6 +22,7 @@ interface EditorState {
   setMouseDown: (mouseDown: boolean) => void;
   setMutationBounds: Dynamic<Bounds>;
   setOffset: (offset: Vec2) => void;
+  setActiveGuides: (guides: Guide[]) => void;
 
   // text editing
   selection: ModelSelection;
@@ -67,6 +69,7 @@ const useEditorStore = create<EditorState>((set) => ({
   mouseDown: false,
   mutationBounds: { verts: [], rotation: 0 },
   offset: { x: 0, y: 0 },
+  activeGuides: [],
 
   setLoading: (value: boolean) => set({ loading: value }),
   setSelected: (id) => set({ selected: id }),
@@ -75,6 +78,7 @@ const useEditorStore = create<EditorState>((set) => ({
   setMouseDown: (mouseDown) => set({ mouseDown }),
   setMutationBounds: setter(set, "mutationBounds"),
   setOffset: (offset) => set({ offset }),
+  setActiveGuides: (guides) => set({ activeGuides: guides }),
 
   selection: { start: null, end: null },
   visualSelection: { start: null, end: null },
@@ -105,6 +109,7 @@ const useEditorStore = create<EditorState>((set) => ({
       selection: { start: null, end: null },
       visualSelection: { start: null, end: null },
       mode: ["normal"],
+      activeGuides: [],
     }),
 }));
 

--- a/frontend/src/features/authoring/types.ts
+++ b/frontend/src/features/authoring/types.ts
@@ -34,6 +34,12 @@ export interface RelativeBounds {
   rotation: number;
 }
 
+export interface Guide {
+  orientation: "vertical" | "horizontal";
+  position: number;
+  isCanvasCenter?: boolean;
+}
+
 interface GenericComponent {
   id: string;
   bounds: Bounds;

--- a/frontend/src/features/authoring/types.ts
+++ b/frontend/src/features/authoring/types.ts
@@ -35,6 +35,12 @@ export interface RelativeBounds {
   rotation: number;
 }
 
+export interface Guide {
+  orientation: "vertical" | "horizontal";
+  position: number;
+  isCanvasCenter?: boolean;
+}
+
 interface GenericComponent {
   id: string;
   bounds: Bounds;


### PR DESCRIPTION
## Issue

It's difficult to create visually compelling scenes when there's no alignment snapping, forcing tedious micro movements to achieve the alignment you want.

## Solution

Snap dragged and resized components to nearby edges/centers of other components and the canvas, rendering live guide lines on the overlay so authors can align elements precisely. Canvas-center guides are dashed lines and regular alignment guides are solid lines.

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smart snapping when moving and resizing canvas components.
  * Components now align automatically with nearby edges, centers, and canvas boundaries.
  * Added visual guide lines to show active alignments during editing.
  * Guides use distinct styling for canvas-center and component alignments.
  * Alignment guides clear automatically when editing ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->