### PR TITLE
refactor: extract canvas dimensions into shared constants

### DIFF
--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -17,6 +17,7 @@ import {
 import { handleContextGlobal } from "../handlers/pointer/context";
 import LoadingOverlay from "./LoadingOverlay.tsx";
 import useEditorStore from "../stores/editor.ts";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 
 const componentMap: Record<string, React.FC<Record<string, unknown>>> = {
   textbox: (props) => <TextBox {...props} editable={true} />,
@@ -47,8 +48,8 @@ function Canvas() {
     const boundingRect = canvasRef.current?.children[0];
     if (!boundingRect) return { x: 0, y: 0 };
     const { top, left, width, height } = boundingRect.getBoundingClientRect();
-    const x = ((cx - left) / width) * 1920;
-    const y = ((cy - top) / height) * 1080;
+    const x = ((cx - left) / width) * CANVAS_WIDTH;
+    const y = ((cy - top) / height) * CANVAS_HEIGHT;
     return { x, y };
   }
 
@@ -115,14 +116,14 @@ function Canvas() {
         <svg
           id="outline"
           className="w-full h-full absolute pointer-events-none"
-          viewBox={`-50 -50 ${1920 + 50 * 2} ${1080 + 50 * 2}`}
+          viewBox={`-50 -50 ${CANVAS_WIDTH + 50 * 2} ${CANVAS_HEIGHT + 50 * 2}`}
           style={{ mixBlendMode: "difference" }}
         >
           <rect
             x="0"
             y="0"
-            width="1920"
-            height="1080"
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
             fill="none"
             stroke="white"
             strokeWidth="1"
@@ -132,10 +133,16 @@ function Canvas() {
         <svg
           id="main"
           className="w-full h-full"
-          viewBox={`-50 -50 ${1920 + 50 * 2} ${1080 + 50 * 2}`}
+          viewBox={`-50 -50 ${CANVAS_WIDTH + 50 * 2} ${CANVAS_HEIGHT + 50 * 2}`}
           ref={canvasRef}
         >
-          <rect x="0" y="0" width="1920" height="1080" fill="white" />
+          <rect
+            x="0"
+            y="0"
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            fill="white"
+          />
           {components}
         </svg>
       </div>

--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -10,6 +10,7 @@ import SpeechHandles from "./handles/SpeechHandles";
 import Rectangle from "./Rectangle";
 import useEditorStore from "../stores/editor";
 import useVisualScene from "../stores/visual";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 
 const componentMap: Record<string, React.FC<Record<string, unknown>>> = {
   speech: Speech,
@@ -50,7 +51,7 @@ function Overlay() {
     <svg
       id="overlay"
       className="w-full h-full absolute pointer-events-none"
-      viewBox={`-50 -50 ${1920 + 50 * 2} ${1080 + 50 * 2}`}
+      viewBox={`-50 -50 ${CANVAS_WIDTH + 50 * 2} ${CANVAS_HEIGHT + 50 * 2}`}
     >
       {component && (
         <>
@@ -90,7 +91,7 @@ function Overlay() {
               x1={guide.position}
               y1={-50}
               x2={guide.position}
-              y2={1130}
+              y2={CANVAS_HEIGHT + 50}
               {...style}
             />
           ) : (
@@ -98,7 +99,7 @@ function Overlay() {
               key={index}
               x1={-50}
               y1={guide.position}
-              x2={1970}
+              x2={CANVAS_WIDTH + 50}
               y2={guide.position}
               {...style}
             />

--- a/frontend/src/features/authoring/components/Thumbnail.jsx
+++ b/frontend/src/features/authoring/components/Thumbnail.jsx
@@ -5,6 +5,7 @@ import Line from "../elements/Line";
 import Speech from "../elements/Speech";
 import TextBox from "../elements/TextBox";
 import { buildVisualComponents } from "../pipeline";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 
 const componentMap = {
   textbox: TextBox,
@@ -28,8 +29,14 @@ const Thumbnail = ({ components }) => {
     .map(resolve);
 
   return (
-    <svg viewBox="0 0 1920 1080">
-      <rect x="0" y="0" width="1920" height="1080" fill="white" />
+    <svg viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}>
+      <rect
+        x="0"
+        y="0"
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        fill="white"
+      />
       {visualComponents}
     </svg>
   );

--- a/frontend/src/features/authoring/handlers/pointer/snap.ts
+++ b/frontend/src/features/authoring/handlers/pointer/snap.ts
@@ -1,9 +1,8 @@
 import type { Bounds, Component, Guide, Vec2 } from "../../types";
 import { expandBoxVerts, getBoxCenter, rotateMany } from "../../util";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../../util/canvas";
 
 export const SNAP_THRESHOLD = 10;
-export const CANVAS_WIDTH = 1920;
-export const CANVAS_HEIGHT = 1080;
 
 interface AABB {
   minX: number;

--- a/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
@@ -1,4 +1,5 @@
 import { buildVisualScene } from "../authoring/pipeline";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../util/canvas";
 import TextBox from "../authoring/elements/TextBox";
 import Speech from "../authoring/elements/Speech";
 import Ellipse from "../authoring/elements/Ellipse";
@@ -196,8 +197,18 @@ export default function PlayScenarioCanvas({
 
   return (
     <div className="bg-black" style={{ width: "100vw", height: "100vh" }}>
-      <svg id="main" className="w-full h-full" viewBox="0 0 1920 1080">
-        <rect x="0" y="0" width="1920" height="1080" fill="white" />
+      <svg
+        id="main"
+        className="w-full h-full"
+        viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}
+      >
+        <rect
+          x="0"
+          y="0"
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
+          fill="white"
+        />
         {components}
       </svg>
     </div>

--- a/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
@@ -1,4 +1,5 @@
 import { buildVisualScene } from "../authoring/pipeline";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../util/canvas";
 import TextBox from "../authoring/elements/TextBox";
 import Speech from "../authoring/elements/Speech";
 import Ellipse from "../authoring/elements/Ellipse";
@@ -201,8 +202,18 @@ export default function PlayScenarioCanvas({
 
   return (
     <div className="bg-black" style={{ width: "100vw", height: "100vh" }}>
-      <svg id="play-main" className="w-full h-full" viewBox="0 0 1920 1080">
-        <rect x="0" y="0" width="1920" height="1080" fill="white" />
+      <svg
+        id="play-main"
+        className="w-full h-full"
+        viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}
+      >
+        <rect
+          x="0"
+          y="0"
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
+          fill="white"
+        />
         {components}
       </svg>
     </div>

--- a/frontend/src/util/canvas.ts
+++ b/frontend/src/util/canvas.ts
@@ -1,0 +1,2 @@
+export const CANVAS_WIDTH = 1920;
+export const CANVAS_HEIGHT = 1080;


### PR DESCRIPTION
## Issue

_A clear and concise description of what the issue is_

## Solution

_A clear and concise description of what the solution is_

## Risk

_Potential risks that this PR might bring_

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized canvas sizing across authoring, previews, playback, overlays, and thumbnails.
  - Improved consistency of coordinate conversion, alignment guides, SVG view boxes, and background rendering.
  - Maintained the existing 1920×1080 canvas dimensions while ensuring all views remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->