### PR TITLE
Fix themed dropdown selection

### DIFF
--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect } from "react";
-import { Check } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import ScenarioContext from "context/ScenarioContext";
 import SceneContext from "context/SceneContext";
 import { generateUniqueSceneName } from "../../../utils/sceneUtils";
@@ -129,9 +129,12 @@ export default function SceneSettings() {
               <div
                 tabIndex={0}
                 role="button"
-                className="justify-start input mb-1 font-normal"
+                className="justify-between input mb-1 font-normal w-full"
               >
-                {selectedRoles?.join(", ") || "All"}
+                <span className="truncate">
+                  {selectedRoles?.join(", ") || "All"}
+                </span>
+                <ChevronDown className="shrink-0" size={16} />
               </div>
               <ul
                 tabIndex={0}

--- a/frontend/src/features/authoring/components/Select.tsx
+++ b/frontend/src/features/authoring/components/Select.tsx
@@ -41,7 +41,10 @@ function SelectInput<T>({
         <ChevronDown className="shrink-0" size={16} />
       </div>
       {!disabled && (
-        <ul className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm">
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu bg-base-300 rounded-box z-1 w-70 p-2 shadow-sm"
+        >
           {values.map((v, i) => (
             <li key={i}>
               <a


### PR DESCRIPTION
## Issue

Dropdown options could not be selected after the keyboard handling was removed.

## Solution

Restored mouse selection and made the Roles dropdown styling consistent with the other themed selectors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the roles dropdown appearance with clearer spacing, truncation for long selections, and a visible expand indicator.
  - Reformatted dropdown markup for improved readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->