### PR TITLE
fix: make resource collection popup work in Safari

### DIFF
--- a/frontend/src/features/resources/components/AddGroup.jsx
+++ b/frontend/src/features/resources/components/AddGroup.jsx
@@ -40,11 +40,7 @@ function AddGroup({ onAdd }) {
   };
 
   return (
-    <div
-      className={`dropdown dropdown-end ${
-        open ? "dropdown-open" : ""
-      }`}
-    >
+    <div className={`dropdown dropdown-end ${open ? "dropdown-open" : ""}`}>
       <button
         type="button"
         className="btn btn-phantom btn-sm"

--- a/frontend/src/features/resources/components/AddGroup.jsx
+++ b/frontend/src/features/resources/components/AddGroup.jsx
@@ -5,6 +5,7 @@ function AddGroup({ onAdd }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const inputRef = useRef(null);
+  const dropdownRef = useRef(null);
 
   useEffect(() => {
     if (open) {
@@ -16,6 +17,25 @@ function AddGroup({ onAdd }) {
     setOpen(false);
     setName("");
   };
+  useEffect(() => {
+  if (!open) return;
+
+  const handleClickOutside = (event) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target)
+    ) {
+      setOpen(false);
+      setName("");
+    }
+  };
+
+  document.addEventListener("pointerdown", handleClickOutside);
+
+  return () => {
+    document.removeEventListener("pointerdown", handleClickOutside);
+  };
+}, [open]);
 
   const addCollection = () => {
     const trimmedName = name.trim();
@@ -40,7 +60,7 @@ function AddGroup({ onAdd }) {
   };
 
   return (
-    <div className={`dropdown dropdown-end ${open ? "dropdown-open" : ""}`}>
+    <div ref={dropdownRef} className={`dropdown dropdown-end ${open ? "dropdown-open" : ""}`} >
       <button
         type="button"
         className="btn btn-phantom btn-sm"

--- a/frontend/src/features/resources/components/AddGroup.jsx
+++ b/frontend/src/features/resources/components/AddGroup.jsx
@@ -1,45 +1,93 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 
 function AddGroup({ onAdd }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  const closeDropdown = () => {
+    setOpen(false);
+    setName("");
+  };
+
+  const addCollection = () => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      return;
+    }
+
+    onAdd(trimmedName);
+    closeDropdown();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      addCollection();
+    }
+
+    if (event.key === "Escape") {
+      closeDropdown();
+    }
+  };
 
   return (
-    <div className="dropdown dropdown-end">
+    <div
+      className={`dropdown dropdown-end ${
+        open ? "dropdown-open" : ""
+      }`}
+    >
       <button
+        type="button"
         className="btn btn-phantom btn-sm"
-        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="create-collection-dropdown"
+        onClick={() => setOpen((value) => !value)}
       >
-        Create
+        Create collection
       </button>
+
       {open && (
-        <div className="dropdown-content z-[1] bg-base-200 rounded-box p-3 w-64 shadow">
+        <div
+          id="create-collection-dropdown"
+          className="dropdown-content z-[1] bg-base-200 rounded-box p-3 w-64 shadow"
+        >
           <label className="form-control w-full">
-            <span className="label-text">Group name</span>
+            <span className="label-text">Collection name</span>
+
             <input
+              ref={inputRef}
               className="input input-bordered input-sm"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={handleKeyDown}
             />
           </label>
+
           <div className="mt-3 flex justify-end gap-2">
             <button
+              type="button"
               className="btn btn-ghost btn-sm"
-              onClick={() => setOpen(false)}
+              onClick={closeDropdown}
             >
               Cancel
             </button>
+
             <button
+              type="button"
               className="btn btn-primary btn-sm"
-              onClick={() => {
-                if (!name.trim()) return;
-                onAdd(name.trim());
-                setName("");
-                setOpen(false);
-              }}
+              disabled={!name.trim()}
+              onClick={addCollection}
             >
-              Add
+              Add collection
             </button>
           </div>
         </div>

--- a/frontend/src/features/resources/components/AddGroup.jsx
+++ b/frontend/src/features/resources/components/AddGroup.jsx
@@ -18,24 +18,21 @@ function AddGroup({ onAdd }) {
     setName("");
   };
   useEffect(() => {
-  if (!open) return;
+    if (!open) return;
 
-  const handleClickOutside = (event) => {
-    if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(event.target)
-    ) {
-      setOpen(false);
-      setName("");
-    }
-  };
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setOpen(false);
+        setName("");
+      }
+    };
 
-  document.addEventListener("pointerdown", handleClickOutside);
+    document.addEventListener("pointerdown", handleClickOutside);
 
-  return () => {
-    document.removeEventListener("pointerdown", handleClickOutside);
-  };
-}, [open]);
+    return () => {
+      document.removeEventListener("pointerdown", handleClickOutside);
+    };
+  }, [open]);
 
   const addCollection = () => {
     const trimmedName = name.trim();
@@ -60,7 +57,10 @@ function AddGroup({ onAdd }) {
   };
 
   return (
-    <div ref={dropdownRef} className={`dropdown dropdown-end ${open ? "dropdown-open" : ""}`} >
+    <div
+      ref={dropdownRef}
+      className={`dropdown dropdown-end ${open ? "dropdown-open" : ""}`}
+    >
       <button
         type="button"
         className="btn btn-phantom btn-sm"


### PR DESCRIPTION
## Issue

The resource collection creation popup did not appear when clicking Create in Safari, although it worked correctly in other browsers.

The interface also used inconsistent terminology, referring to the same feature as both Collections and Groups.

## Solution

Updated the dropdown so its open state is controlled explicitly using React state and DaisyUI’s dropdown-open class, rather than relying on browser focus behaviour. This ensures the popup displays consistently in Safari and other supported browsers.

Also updated the popup wording to consistently use Collection instead of Group.

## Risk

Low risk apart from Hartej's colouring books.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically focuses the collection name field when opened.
  * Added Enter and Escape keyboard controls.
  * Supports closing when clicking outside the dialog.
  * Improved dropdown accessibility with appropriate attributes.
* **Bug Fixes**
  * Collection names are trimmed and validated consistently.
  * Empty-name submissions are disabled.
  * Form state resets when the dialog closes.
* **Style**
  * Updated labels and button text to use “collection” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->