### PR TITLE
fix(authoring): spawn new elements at mouse position

### DIFF
--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -132,12 +132,19 @@ export function createComponentFromBounds(
   bounds: Bounds
 ) {
   const component = structuredClone(defaults[type]);
+
   const dims = mutate(subtract(bounds.verts[1], bounds.verts[0]), Math.abs);
-  if (dims.x > 50 && dims.y > 50) component.bounds = bounds;
+
+  if (dims.x > 50 && dims.y > 50) {
+    component.bounds = bounds;
+  } else {
+    component.bounds.verts = translate(component.bounds.verts, bounds.verts[0]);
+  }
 
   // Set zIndex to the current number of components on the canvas
   const componentsCount = Object.keys(getScene().components).length;
   component.zIndex = componentsCount;
+
   return add(component);
 }
 


### PR DESCRIPTION
## Issue

When a new canvas element was created by clicking instead of dragging, it appeared in the top left corner of the canvas rather than at the user's mouse position.

## Solution

Updated `createComponentFromBounds` so that elements created with a click or small drag keep their default dimensions but are translated to the initial mouse position.

Elements created by dragging more than the minimum size continue to use the dimensions defined by the drag action.

## Risk

Low risk. But harbassan is the big risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected component placement when creating components with small dimensions.
  * Components now appear at the requested origin while retaining appropriate default sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->