### PR TITLE
VPS-166/Fixed incorrect cursor hover on textboxes in play page

### DIFF
--- a/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioCanvas.jsx
@@ -196,7 +196,7 @@ export default function PlayScenarioCanvas({
 
   return (
     <div className="bg-black" style={{ width: "100vw", height: "100vh" }}>
-      <svg id="main" className="w-full h-full" viewBox="0 0 1920 1080">
+      <svg id="play-main" className="w-full h-full" viewBox="0 0 1920 1080">
         <rect x="0" y="0" width="1920" height="1080" fill="white" />
         {components}
       </svg>


### PR DESCRIPTION
## Issue

Hovering over a textbox/shape while playing a scenario showed a "move" cursor (drag-to-reposition), which is authoring-only behavior. It happened because the play canvas's root `<svg>` shared the same `id="main"` as the authoring canvas, so the authoring cursor CSS rules matched it too.

## Solution

Gave the play canvas's `<svg>` its own id (`play-main`) so the `svg#main` cursor rules no longer match it.

## Risk

Low - single id rename, no other code references `#main`/`#play-main`.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the scenario canvas element identifier for improved rendering reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->