### PR TITLE
VPS-138/Removed system check for dark mode on browser/OS

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,7 +109,7 @@
 @plugin "daisyui/theme" {
   name: "vps-dark";
   default: true;
-  prefersdark: true;
+  prefersdark: false;
   color-scheme: dark;
 
   --color-base-100: var(--color-black);


### PR DESCRIPTION
## Issue

The dark/light mode toggle didn't reliably stick on some browsers. When a user's OS/browser had system dark mode enabled, daisyUI emitted an extra `@media (prefers-color-scheme: dark)` CSS rule with the same specificity as our `[data-theme="vps-light"]` rule. Because it came later in the compiled stylesheet, it silently overrode the user's explicit light mode selection.

## Solution

Set `prefersdark: false` on the `vps-dark` theme in `index.css` so daisyUI no longer generates the competing system-preference rule. Theme selection is now controlled entirely by the `data-theme` attribute (set via the toggle + localStorage), with no system override fighting it. Default stays dark mode, unchanged.

One-line change.

Note: this only fixes the override bug. Light mode itself still needs a lot of visual polish, since it hasn't been a focus and looks rough in a lot of places.

## Risk

Low. Single-line CSS config change, no logic changes. Verified dark mode still applies by default and the toggle correctly persists light/dark across reloads regardless of system theme setting.

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing
