### PR TITLE
VPS-143/Duplicate scene index fix

### DIFF
--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -240,7 +240,6 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const dbScene = new Scene(newScene);
   await dbScene.save();
 
- 
   //find where scene originally sits in scenes array
   const { scenes: sceneIds = [] } =
     (await Scenario.findById(scenarioId, { scenes: 1 }).lean()) ?? {};

--- a/backend/src/db/daos/sceneDao.js
+++ b/backend/src/db/daos/sceneDao.js
@@ -240,9 +240,17 @@ const duplicateScene = async (scenarioId, sceneId) => {
   const dbScene = new Scene(newScene);
   await dbScene.save();
 
+ 
+  //find where scene originally sits in scenes array
+  const { scenes: sceneIds = [] } =
+    (await Scenario.findById(scenarioId, { scenes: 1 }).lean()) ?? {};
+  //positions duplicate either right after original or at end of array
+  const position =
+    sceneIds.findIndex((id) => id.equals(sceneId)) + 1 || sceneIds.length;
+
   await Scenario.updateOne(
     { _id: scenarioId },
-    { $push: { scenes: dbScene._id } }
+    { $push: { scenes: { $each: [dbScene._id], $position: position } } }
   );
 
   const fileRefDeltas = computeCreateFileRefDeltas(dbScene.components);

--- a/backend/src/routes/api/__tests__/sceneApi.test.js
+++ b/backend/src/routes/api/__tests__/sceneApi.test.js
@@ -359,8 +359,8 @@ describe("Scene API tests", () => {
     });
     expect(scenarioScenes).toEqual([
       scene1._id.toString(),
-      scene2._id.toString(),
       responseScene._id,
+      scene2._id.toString(),
     ]);
 
     // check scene is not added to unrelated scenario


### PR DESCRIPTION
## Issue

Duplicate scene would create duplicates at the end of scenes array, which is frustrating for authoring w high number of existing scenes.

## Solution
Duplicate scene gets original scenes position in array, duplicate is given position i+1

## Risk
Hopefully none

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicated scenes now appear immediately after the original scene in the scenario order.
  - If the original scene’s position cannot be determined, the duplicate is added to the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->