### PR TITLE
fix(authoring): proportional resize axis lock

### DIFF
--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -135,7 +135,12 @@ function lockAspect(verts: Vec2[], newVerts: Vec2[], coords: number[]) {
 
   const { x: dx, y: dy } = subtract(newPoint, inversePoint);
   const aspect = getAspect(verts);
-  if (Math.abs(dx) >= Math.abs(dy)) {
+  const width = Math.abs(verts[1].x - verts[0].x);
+  const height = Math.abs(verts[1].y - verts[0].y);
+
+  // compare movement relative to each axis's own size, not raw magnitude,
+  // otherwise the axis with the larger original dimension always "wins"
+  if (Math.abs(dx) * height >= Math.abs(dy) * width) {
     newVerts[coords[1]].y =
       inversePoint.y + Math.sign(dy) * (Math.abs(dx) / aspect);
   } else {


### PR DESCRIPTION
## Issue

Corner resize with shift/ctrl compared raw dx/dy against the fixed opposite corner instead of each axis's own dimension, so the larger original axis (e.g. width on a wide shape) almost always "won", leaving the shorter axis effectively locked during drag.

## Solution

Compare movement relative to each axis's own original size

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Wiki documentation is written and up to date
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aspect-ratio locking during resizing, producing more consistent results when dragging horizontally or vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->