### PR TITLE
feat: show scenario name on edit button

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -145,7 +145,8 @@ export default function AuthoringToolPage() {
     }
   }
 
-  const isScenarioOwner = allScenarios?.owned.find((s) => s._id === scenarioId);
+  const ownedScenario = allScenarios?.owned.find((s) => s._id === scenarioId);
+  const isOwner = Boolean(ownedScenario);
 
   return (
     <>
@@ -155,13 +156,13 @@ export default function AuthoringToolPage() {
             <ArrowLeftIcon size={20} />
             Back
           </button>
-          {isScenarioOwner && (
+          {isOwner && (
             <button
               onClick={() => setShowEditModal(true)}
               className="btn btn-phantom text-m"
             >
               <PencilIcon size={20} />
-              {isScenarioOwner.name}
+              {ownedScenario.name}
             </button>
           )}
           <button
@@ -175,7 +176,7 @@ export default function AuthoringToolPage() {
             <UsersIcon size={20} />
             Groups
           </button>
-          {isScenarioOwner && (
+          {isOwner && (
             <button
               onClick={() => setShareModalOpen(true)}
               className="btn btn-phantom text-m"
@@ -198,17 +199,17 @@ export default function AuthoringToolPage() {
           </div>
         </div>
       </div>
-      {isScenarioOwner && (
+      {isOwner && (
         <ShareModal open={shareModalOpen} setOpen={setShareModalOpen} />
       )}
-      {isScenarioOwner && (
+      {isOwner && (
         <ModalDialog
           title="Edit Scenario Details"
           open={showEditModal}
           onClose={() => setShowEditModal(false)}
         >
           <DetailEditModal
-            scenario={isScenarioOwner}
+            scenario={ownedScenario}
             onSave={(details) =>
               updateScenarioDetails({ id: scenarioId, details })
             }

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -161,7 +161,7 @@ export default function AuthoringToolPage() {
               className="btn btn-phantom text-m"
             >
               <PencilIcon size={20} />
-              Details
+              {isScenarioOwner.name}
             </button>
           )}
           <button

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -157,13 +157,15 @@ export default function AuthoringToolPage() {
             Back
           </button>
           {isOwner && (
-            <button
-              onClick={() => setShowEditModal(true)}
-              className="btn btn-phantom text-m"
-            >
-              <PencilIcon size={20} />
-              {ownedScenario.name}
-            </button>
+            <div className="flex flex-1 min-w-0">
+              <button
+                onClick={() => setShowEditModal(true)}
+                className="btn btn-phantom text-m max-w-full min-w-0"
+              >
+                <PencilIcon size={20} className="shrink-0" />
+                <span className="min-w-0 truncate">{ownedScenario.name}</span>
+              </button>
+            </div>
           )}
           <button
             onClick={goToResources}


### PR DESCRIPTION
## Issue

<img width="260" height="57" alt="image" src="https://github.com/user-attachments/assets/3c69077f-3edf-433e-8759-9980e3e6201e" />

## Solution

<img width="322" height="60" alt="image" src="https://github.com/user-attachments/assets/2e37beb8-38f6-438b-8695-0adb122194ba" />

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved ownership handling for authoring scenarios.
  * Owner-only controls now display the relevant scenario name.
  * Sharing and editing controls use updated ownership information.
  * Edit dialogs now show details for the selected owned scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->