### PR TITLE
fix: medium severity authorisation gaps

### DIFF
--- a/backend/src/db/daos/noteDao.js
+++ b/backend/src/db/daos/noteDao.js
@@ -2,6 +2,17 @@ import Note from "../models/note.js";
 import Group from "../models/group.js";
 import { HttpError } from "../../util/error.js";
 
+export const hasNoteInGroup = (group, noteId) => {
+  if (!group?.notes) return false;
+
+  const groupedNotes =
+    group.notes instanceof Map
+      ? Array.from(group.notes.values())
+      : Object.values(group.notes);
+
+  return groupedNotes.flat().some((id) => id === noteId);
+};
+
 /**
  * Creates a empty note in the database
  * @param {String} groupId group ID the note belongs to
@@ -76,7 +87,7 @@ const retrieveNoteList = async (groupId) => {
  * @returns database note object
  */
 const retrieveNote = async (noteId) => {
-  const note = await Note.findById(noteId);
+  const note = await Note.findOne({ _id: noteId });
   return note;
 };
 

--- a/backend/src/db/daos/noteDao.js
+++ b/backend/src/db/daos/noteDao.js
@@ -3,35 +3,13 @@ import Group from "../models/group.js";
 import { HttpError } from "../../util/error.js";
 
 /**
- * Checks if a user is in a group
- * @param {String} groupId group ID
- * @param {String} email email of the user
- * @returns role of the user in the group
- * @returns null if user is not in group
- */
-const checkRole = async (groupId, email) => {
-  const group = await Group.findById(groupId);
-  let role = null;
-  group.users.forEach((userToCheck) => {
-    if (userToCheck.email === email) {
-      role = userToCheck.role;
-    }
-  });
-  return role;
-};
-
-/**
  * Creates a empty note in the database
  * @param {String} groupId group ID the note belongs to
  * @param {String} title  title of the note
  * @param {String} role role of the note
  * @returns
  */
-const createNote = async (groupId, title, email, text = "") => {
-  const role = await checkRole(groupId, email);
-  if (role === null) {
-    return null;
-  }
+const createNote = async (groupId, title, role, text = "") => {
   const dbNote = new Note({ title, role, text, date: new Date() });
   await dbNote.save();
   const updateQuery = {};
@@ -47,10 +25,9 @@ const createNote = async (groupId, title, email, text = "") => {
  * @param {String} email email of the user
  * @returns
  */
-const deleteNote = async (noteId, groupId, email) => {
-  const role = await checkRole(groupId, email);
+const deleteNote = async (noteId, groupId, role) => {
   const note = await Note.findById(noteId, { role: 1 }).lean();
-  if (note?.role !== role) throw new HttpError(403, "Forbidden");
+  if (note?.role !== role) throw new HttpError("forbidden", 403);
 
   const updateQuery = { $pull: { [`notes.${note.role}`]: noteId } };
   await Promise.all([
@@ -71,15 +48,9 @@ const deleteNote = async (noteId, groupId, email) => {
  * @param {String} email email of the user
  * @returns
  */
-const updateNote = async (noteId, updatedNote, groupId, email) => {
-  const role = await checkRole(groupId, email);
-  if (role === null) {
-    return;
-  }
+const updateNote = async (noteId, updatedNote, role) => {
   const note = await Note.findById(noteId);
-  if (note.role !== role) {
-    return;
-  }
+  if (note?.role !== role) throw new HttpError("forbidden", 403);
   note.title = updatedNote.title;
   note.text = updatedNote.text;
   note.date = updatedNote.date;
@@ -92,13 +63,10 @@ const updateNote = async (noteId, updatedNote, groupId, email) => {
  * @param {String} email email of the user
  * @returns list of database note objects
  */
-//  I know the group is fetched for twice but this is currently not used anywhere
 const retrieveNoteList = async (groupId) => {
   const { notes } = await Group.findById(groupId, { notes: 1 }).lean();
-
   const noteIds = Object.values(notes).flat();
   const dbNotes = await Note.find({ _id: { $in: noteIds } }, { __v: 0 });
-
   return dbNotes;
 };
 

--- a/backend/src/middleware/__tests__/groupAuth.test.js
+++ b/backend/src/middleware/__tests__/groupAuth.test.js
@@ -8,6 +8,7 @@ import { useMongoMemoryServer } from "../../test/testSetup.js";
 describe("Group Auth Middleware tests", () => {
   const HTTP_NOT_FOUND = 404;
   const HTTP_FORBIDDEN = 403;
+  const HTTP_UNAUTHORIZED = 401;
 
   useMongoMemoryServer();
 
@@ -90,6 +91,28 @@ describe("Group Auth Middleware tests", () => {
 
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining({ status: HTTP_NOT_FOUND })
+    );
+  });
+
+  it("rejects when the authenticated user cannot be found", async () => {
+    const group = await Group.create({
+      users: [{ email: "doctor@example.com", name: "Doctor", role: "doctor" }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-003",
+      currentFlags: [],
+    });
+
+    const req = mockRequest(group._id.toString(), { uid: "missing-user" });
+    const next = jest.fn();
+
+    await groupAuth(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: HTTP_UNAUTHORIZED,
+        message: "user not found",
+      })
     );
   });
 });

--- a/backend/src/middleware/__tests__/groupAuth.test.js
+++ b/backend/src/middleware/__tests__/groupAuth.test.js
@@ -1,0 +1,95 @@
+import { jest, describe, beforeEach, it, expect } from "@jest/globals";
+
+import Group from "../../db/models/group.js";
+import User from "../../db/models/user.js";
+import groupAuth from "../groupAuth.js";
+import { useMongoMemoryServer } from "../../test/testSetup.js";
+
+describe("Group Auth Middleware tests", () => {
+  const HTTP_NOT_FOUND = 404;
+  const HTTP_FORBIDDEN = 403;
+
+  useMongoMemoryServer();
+
+  const mockRequest = (groupId, bodyContent = {}) => ({
+    params: { groupId },
+    body: bodyContent,
+  });
+
+  const nextFunction = jest.fn();
+
+  beforeEach(async () => {
+    nextFunction.mockClear();
+    await User.create({
+      uid: "user1",
+      name: "Doctor",
+      email: "doctor@example.com",
+      pictureURL: "http://example.com/doctor.png",
+    });
+    await User.create({
+      uid: "outsider",
+      name: "Outsider",
+      email: "outsider@example.com",
+      pictureURL: "http://example.com/outsider.png",
+    });
+  });
+
+  it("authorises a member of the group", async () => {
+    const group = await Group.create({
+      users: [{ email: "doctor@example.com", name: "Doctor", role: "doctor" }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-001",
+      currentFlags: [],
+    });
+
+    const req = mockRequest(group._id.toString(), { uid: "user1" });
+    const next = jest.fn();
+
+    await groupAuth(req, {}, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.body.membership).toMatchObject({ email: "doctor@example.com" });
+  });
+
+  it("rejects a non-member of the group", async () => {
+    const group = await Group.create({
+      users: [{ email: "doctor@example.com", name: "Doctor", role: "doctor" }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-002",
+      currentFlags: [],
+    });
+
+    const req = mockRequest(group._id.toString(), { uid: "outsider" });
+    const next = jest.fn();
+
+    await groupAuth(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: HTTP_FORBIDDEN })
+    );
+  });
+
+  it("rejects an invalid group id", async () => {
+    const req = mockRequest("not-a-valid-id", { uid: "user1" });
+    const next = jest.fn();
+
+    await groupAuth(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: HTTP_NOT_FOUND })
+    );
+  });
+
+  it("rejects an non-existent group id", async () => {
+    const req = mockRequest("000000000000000000000002", { uid: "user1" });
+    const next = jest.fn();
+
+    await groupAuth(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: HTTP_NOT_FOUND })
+    );
+  });
+});

--- a/backend/src/middleware/groupAuth.js
+++ b/backend/src/middleware/groupAuth.js
@@ -6,7 +6,6 @@ import { isValidObjectId } from "../util/validation.js";
 
 async function getEmailByUid(uid) {
   const user = await User.findOne({ uid }, { email: 1 }).lean();
-  if (!user) throw new HttpError("user not found", HttpStatusCode.Unauthorized);
   return user.email;
 }
 

--- a/backend/src/middleware/groupAuth.js
+++ b/backend/src/middleware/groupAuth.js
@@ -1,0 +1,36 @@
+import { HttpStatusCode } from "axios";
+import { HttpError } from "../util/error.js";
+import Group from "../db/models/group.js";
+import User from "../db/models/user.js";
+import { isValidObjectId } from "../util/validation.js";
+
+async function getEmailByUid(uid) {
+  const user = await User.findOne({ uid }, { email: 1 }).lean();
+  if (!user) throw new HttpError("user not found", HttpStatusCode.Unauthorized);
+  return user.email;
+}
+
+export default async function groupAuth(req, _res, next) {
+  try {
+    const { groupId } = req.params;
+    if (!isValidObjectId(groupId))
+      throw new HttpError("group not found", HttpStatusCode.NotFound);
+    const group = await Group.findById(groupId);
+    if (!group) throw new HttpError("group not found", HttpStatusCode.NotFound);
+
+    const email = await getEmailByUid(req.body.uid);
+
+    const membership = group.users.find((member) => member.email === email);
+    if (!membership)
+      throw new HttpError(
+        "not a member of this group",
+        HttpStatusCode.Forbidden
+      );
+
+    req.body.membership = membership;
+
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+}

--- a/backend/src/middleware/groupAuth.js
+++ b/backend/src/middleware/groupAuth.js
@@ -6,6 +6,7 @@ import { isValidObjectId } from "../util/validation.js";
 
 async function getEmailByUid(uid) {
   const user = await User.findOne({ uid }, { email: 1 }).lean();
+  if (!user) throw new HttpError("user not found", HttpStatusCode.Unauthorized);
   return user.email;
 }
 
@@ -27,6 +28,7 @@ export default async function groupAuth(req, _res, next) {
       );
 
     req.body.membership = membership;
+    req.body.group = group;
 
     return next();
   } catch (err) {

--- a/backend/src/middleware/scenarioAuth.js
+++ b/backend/src/middleware/scenarioAuth.js
@@ -1,6 +1,8 @@
 import { HttpStatusCode } from "axios";
 import { retrieveScenario } from "../db/daos/scenarioDao.js";
 import { hasAccess } from "../db/daos/accessDao.js";
+import { isValidObjectId } from "../util/validation.js";
+import { HttpError } from "../util/error.js";
 
 /**
  * Checks if the scenario is accessable by the user
@@ -8,7 +10,11 @@ import { hasAccess } from "../db/daos/accessDao.js";
  */
 export default async function scenarioAuth(req, res, next) {
   try {
-    const scenario = await retrieveScenario(req.params.scenarioId);
+    const { scenarioId } = req.params;
+    if (!isValidObjectId(scenarioId))
+      throw new HttpError("invalid scenario id", HttpStatusCode.BadRequest);
+
+    const scenario = await retrieveScenario(scenarioId);
     if (!scenario) return res.sendStatus(HttpStatusCode.NotFound);
 
     // is direct owner or has been given access
@@ -35,7 +41,11 @@ export async function isAuthor(scenarioId, uid) {
  */
 export async function scenarioOwnerAuth(req, res, next) {
   try {
-    const scenario = await retrieveScenario(req.params.scenarioId);
+    const { scenarioId } = req.params;
+    if (!isValidObjectId(scenarioId))
+      throw new HttpError("invalid scenario id", HttpStatusCode.BadRequest);
+
+    const scenario = await retrieveScenario(scenarioId);
     if (!scenario) return res.sendStatus(HttpStatusCode.NotFound);
 
     if (req.body.uid === scenario.uid) return next();

--- a/backend/src/routes/api/__tests__/groupApi.test.js
+++ b/backend/src/routes/api/__tests__/groupApi.test.js
@@ -80,60 +80,6 @@ describe("Group API tests", () => {
     expect(response.data).toHaveLength(0);
   });
 
-  it("GET /group/path/:groupId returns current scene when path is non-empty", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/group/path/${group._id}`,
-      authHeaders("user1")
-    );
-    expect(response.status).toBe(200);
-    expect(response.data._id).toBe(scene._id.toString());
-  });
-
-  it("GET /group/path/:groupId returns null when path is empty", async () => {
-    const emptyGroup = await Group.create({
-      users: [],
-      notes: {},
-      path: [],
-      scenarioId: scenario._id.toString(),
-      currentFlags: [],
-    });
-
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/group/path/${emptyGroup._id}`,
-      authHeaders("user1")
-    );
-    expect(response.status).toBe(200);
-    expect(response.data).toBeNull();
-  });
-
-  it("GET /group/retrieve/:groupId returns a group by id", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/group/retrieve/${group._id}`,
-      authHeaders("user1")
-    );
-    expect(response.status).toBe(200);
-    expect(response.data._id).toBe(group._id.toString());
-    expect(response.data.users).toHaveLength(2);
-  });
-
-  it("GET /group/retrieve/:groupId returns 404 for unknown group", async () => {
-    await expect(
-      axios.get(
-        `http://localhost:${ctx.port}/api/group/retrieve/000000000000000000000099`,
-        authHeaders("user1")
-      )
-    ).rejects.toMatchObject({ response: { status: 404 } });
-  });
-
-  it("GET /group/:scenarioId/roleList returns the role list for a scenario", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/group/${scenario._id}/roleList`,
-      authHeaders("user1")
-    );
-    expect(response.status).toBe(200);
-    expect(response.data).toEqual(["doctor", "nurse"]);
-  });
-
   it("POST /group/:scenarioId creates groups for a scenario", async () => {
     const groupList = [
       [

--- a/backend/src/routes/api/__tests__/noteApi.test.js
+++ b/backend/src/routes/api/__tests__/noteApi.test.js
@@ -7,6 +7,7 @@ import Note from "../../../db/models/note.js";
 import Group from "../../../db/models/group.js";
 import User from "../../../db/models/user.js";
 import auth from "../../../middleware/firebaseAuth.js";
+import errorHandler from "../../../middleware/errorHandler.js";
 import { authHeaders } from "./testHelpers.js";
 import {
   useMongoMemoryServer,
@@ -27,6 +28,7 @@ describe("Note API tests", () => {
     const app = express();
     app.use(express.json());
     app.use("/", routes);
+    app.use(errorHandler);
     return app;
   });
 
@@ -108,6 +110,31 @@ describe("Note API tests", () => {
     expect(response.data.title).toBe("Note 1");
   });
 
+  it("GET /group/:groupId/notes/:noteId returns not found for cross-group note access", async () => {
+    const otherGroup = await Group.create({
+      users: [{ email: userEmail, name: "Doctor", role: userRole }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-cross-group-get",
+      currentFlags: [],
+    });
+
+    await expect(
+      axios.get(
+        `http://localhost:${ctx.port}/api/group/${otherGroup._id}/notes/${note1._id}`,
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({
+      response: {
+        status: 404,
+        data: {
+          status: 404,
+          error: "note not found",
+        },
+      },
+    });
+  });
+
   it("POST /group/:groupId/notes creates a note for a user in the group", async () => {
     const response = await axios.post(
       `http://localhost:${ctx.port}/api/group/${group._id}/notes`,
@@ -159,6 +186,39 @@ describe("Note API tests", () => {
     expect(dbNote.text).toBe("Updated text");
   });
 
+  it("PUT /group/:groupId/notes/:noteId returns not found for cross-group note access", async () => {
+    const otherGroup = await Group.create({
+      users: [{ email: userEmail, name: "Doctor", role: userRole }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-cross-group-put",
+      currentFlags: [],
+    });
+
+    await expect(
+      axios.put(
+        `http://localhost:${ctx.port}/api/group/${otherGroup._id}/notes/${note1._id}`,
+        {
+          title: "Should Not Update",
+          text: "Should Not Update",
+        },
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({
+      response: {
+        status: 404,
+        data: {
+          status: 404,
+          error: "note not found",
+        },
+      },
+    });
+
+    const dbNote = await Note.findById(note1._id).lean();
+    expect(dbNote.title).toBe("Note 1");
+    expect(dbNote.text).toBe("Some text");
+  });
+
   it("DELETE /group/:groupId/notes/:noteId removes the note and its reference from the group", async () => {
     const response = await axios.delete(
       `http://localhost:${ctx.port}/api/group/${group._id}/notes/${note1._id}`,
@@ -174,5 +234,35 @@ describe("Note API tests", () => {
 
     const dbGroup = await Group.findById(group._id).lean();
     expect(dbGroup.notes[userRole] ?? []).not.toContain(note1._id.toString());
+  });
+
+  it("DELETE /group/:groupId/notes/:noteId returns not found for cross-group note access", async () => {
+    const otherGroup = await Group.create({
+      users: [{ email: userEmail, name: "Doctor", role: userRole }],
+      notes: {},
+      path: [],
+      scenarioId: "scenario-cross-group-delete",
+      currentFlags: [],
+    });
+
+    await expect(
+      axios.delete(
+        `http://localhost:${ctx.port}/api/group/${otherGroup._id}/notes/${note1._id}`,
+        {
+          ...authHeaders("user1"),
+        }
+      )
+    ).rejects.toMatchObject({
+      response: {
+        status: 404,
+        data: {
+          status: 404,
+          error: "note not found",
+        },
+      },
+    });
+
+    const dbNote = await Note.findById(note1._id).lean();
+    expect(dbNote).not.toBeNull();
   });
 });

--- a/backend/src/routes/api/__tests__/noteApi.test.js
+++ b/backend/src/routes/api/__tests__/noteApi.test.js
@@ -70,9 +70,9 @@ describe("Note API tests", () => {
     });
   });
 
-  it("GET /note/retrieveAll/:groupId returns all notes for a group", async () => {
+  it("GET /group/:groupId/notes returns all notes for a group", async () => {
     const response = await axios.get(
-      `http://localhost:${ctx.port}/api/note/retrieveAll/${group._id}`,
+      `http://localhost:${ctx.port}/api/group/${group._id}/notes`,
       authHeaders("user1")
     );
     expect(response.status).toBe(200);
@@ -81,9 +81,9 @@ describe("Note API tests", () => {
     expect(response.data[0].text).toBe("Some text");
   });
 
-  it("GET /note/retrieveAll/:groupId returns empty array for group with no notes", async () => {
+  it("GET /group/:groupId/notes returns empty array for group with no notes", async () => {
     const emptyGroup = await Group.create({
-      users: [],
+      users: [{ email: userEmail, name: "Doctor", role: userRole }],
       notes: {},
       path: [],
       scenarioId: "scenario-002",
@@ -91,16 +91,16 @@ describe("Note API tests", () => {
     });
 
     const response = await axios.get(
-      `http://localhost:${ctx.port}/api/note/retrieveAll/${emptyGroup._id}`,
+      `http://localhost:${ctx.port}/api/group/${emptyGroup._id}/notes`,
       authHeaders("user1")
     );
     expect(response.status).toBe(200);
     expect(response.data).toHaveLength(0);
   });
 
-  it("GET /note/retrieve/:noteId returns a specific note", async () => {
+  it("GET /group/:groupId/notes/:noteId returns a specific note", async () => {
     const response = await axios.get(
-      `http://localhost:${ctx.port}/api/note/retrieve/${note1._id}`,
+      `http://localhost:${ctx.port}/api/group/${group._id}/notes/${note1._id}`,
       authHeaders("user1")
     );
     expect(response.status).toBe(200);
@@ -108,11 +108,10 @@ describe("Note API tests", () => {
     expect(response.data.title).toBe("Note 1");
   });
 
-  it("POST /note/ creates a note for a user in the group", async () => {
+  it("POST /group/:groupId/notes creates a note for a user in the group", async () => {
     const response = await axios.post(
-      `http://localhost:${ctx.port}/api/note/`,
+      `http://localhost:${ctx.port}/api/group/${group._id}/notes`,
       {
-        groupId: group._id.toString(),
         title: "New Note",
       },
       authHeaders("user1")
@@ -126,32 +125,29 @@ describe("Note API tests", () => {
     expect(notes[0].role).toBe(userRole);
   });
 
-  it("POST /note/ does nothing silently when user is not in group", async () => {
+  it("POST /group/:groupId/notes returns forbidden when user is not in group", async () => {
     // Authenticated as "outsider", whose email is not a group member —
-    // createNote returns null but the route still responds 200.
-    const response = await axios.post(
-      `http://localhost:${ctx.port}/api/note/`,
-      {
-        groupId: group._id.toString(),
-        title: "Ghost Note",
-      },
-      authHeaders("outsider")
-    );
-    expect(response.status).toBe(200);
-    expect(response.data).toBe("note created");
+    // the middleware rejects the request before any note is created.
+    await expect(
+      axios.post(
+        `http://localhost:${ctx.port}/api/group/${group._id}/notes`,
+        {
+          title: "Ghost Note",
+        },
+        authHeaders("outsider")
+      )
+    ).rejects.toMatchObject({ response: { status: 403 } });
 
     const notes = await Note.find({ title: "Ghost Note" });
     expect(notes).toHaveLength(0);
   });
 
-  it("PUT /note/update updates a note's title and text", async () => {
+  it("PUT /group/:groupId/notes/:noteId updates a note's title and text", async () => {
     const response = await axios.put(
-      `http://localhost:${ctx.port}/api/note/update`,
+      `http://localhost:${ctx.port}/api/group/${group._id}/notes/${note1._id}`,
       {
-        noteId: note1._id.toString(),
         title: "Updated Title",
         text: "Updated text",
-        groupId: group._id.toString(),
       },
       authHeaders("user1")
     );
@@ -163,15 +159,11 @@ describe("Note API tests", () => {
     expect(dbNote.text).toBe("Updated text");
   });
 
-  it("DELETE /note/delete removes the note and its reference from the group", async () => {
+  it("DELETE /group/:groupId/notes/:noteId removes the note and its reference from the group", async () => {
     const response = await axios.delete(
-      `http://localhost:${ctx.port}/api/note/delete`,
+      `http://localhost:${ctx.port}/api/group/${group._id}/notes/${note1._id}`,
       {
         ...authHeaders("user1"),
-        data: {
-          noteId: note1._id.toString(),
-          groupId: group._id.toString(),
-        },
       }
     );
     expect(response.status).toBe(200);

--- a/backend/src/routes/api/__tests__/noteApi.test.js
+++ b/backend/src/routes/api/__tests__/noteApi.test.js
@@ -264,5 +264,8 @@ describe("Note API tests", () => {
 
     const dbNote = await Note.findById(note1._id).lean();
     expect(dbNote).not.toBeNull();
+
+    const sourceGroup = await Group.findById(group._id).lean();
+    expect(sourceGroup.notes[userRole] ?? []).toContain(note1._id.toString());
   });
 });

--- a/backend/src/routes/api/__tests__/userApi.test.js
+++ b/backend/src/routes/api/__tests__/userApi.test.js
@@ -6,7 +6,6 @@ import routes from "../../index.js";
 import User from "../../../db/models/user.js";
 import Group from "../../../db/models/group.js";
 import Scenario from "../../../db/models/scenario.js";
-import Scene from "../../../db/models/scene.js";
 import auth from "../../../middleware/firebaseAuth.js";
 import { authHeaders } from "./testHelpers.js";
 import {
@@ -55,73 +54,6 @@ describe("User API tests", () => {
       users: ["uid-1", "uid-2"],
     });
   });
-
-  // --- GET / ---
-
-  it("GET /user/ returns all users", async () => {
-    const response = await axios.get(`http://localhost:${ctx.port}/api/user/`);
-    expect(response.status).toBe(200);
-    expect(response.data).toHaveLength(2);
-    const uids = response.data.map((u) => u.uid);
-    expect(uids).toContain("uid-1");
-    expect(uids).toContain("uid-2");
-  });
-
-  // --- GET /min ---
-
-  it("GET /user/min returns minimal user fields sorted by name", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/user/min`
-    );
-    expect(response.status).toBe(200);
-    expect(response.data).toHaveLength(2);
-    // Should be sorted by name ascending: Alice, Bob
-    expect(response.data[0].name).toBe("Alice");
-    expect(response.data[1].name).toBe("Bob");
-    // Only uid, name, email fields
-    expect(response.data[0].uid).toBe("uid-1");
-    expect(response.data[0].pictureURL).toBeUndefined();
-  });
-
-  // --- GET /:uid ---
-
-  it("GET /user/:uid returns a user by uid", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/user/${user1.uid}`
-    );
-    expect(response.status).toBe(200);
-    expect(Array.isArray(response.data)).toBe(true);
-    expect(response.data[0].name).toBe("Alice");
-  });
-
-  it("GET /user/:uid returns empty array for unknown uid", async () => {
-    const response = await axios.get(
-      `http://localhost:${ctx.port}/api/user/unknown-uid`
-    );
-    expect(response.status).toBe(200);
-    expect(response.data).toHaveLength(0);
-  });
-
-  // --- GET /played/:scenarioId ---
-
-  // NOTE: retrievePlayedUsers reads Scenario.users, but the Scenario schema does
-  // not define a 'users' field, so it is stripped on write and the query returns
-  // nothing. The scenario in beforeEach is seeded with users uid-1 and uid-2, so
-  // this asserts the CORRECT behaviour and is marked `it.failing`: it stays green
-  // while the bug exists and turns red once the schema defines 'users' — signalling
-  // that it should be un-marked.
-  it.failing(
-    "GET /user/played/:scenarioId returns users who played the scenario",
-    async () => {
-      const response = await axios.get(
-        `http://localhost:${ctx.port}/api/user/played/${scenario._id}`
-      );
-      expect(response.status).toBe(200);
-      const uids = response.data.map((u) => u.uid);
-      expect(uids).toContain("uid-1");
-      expect(uids).toContain("uid-2");
-    }
-  );
 
   // --- POST / (sign-in) ---
 
@@ -181,44 +113,6 @@ describe("User API tests", () => {
       }
     );
     expect(response.status).toBe(200);
-  });
-
-  // --- DELETE /:uid ---
-
-  it("DELETE /user/:uid returns 404 for unknown uid", async () => {
-    // deleteUser catches errors and returns false → sendStatus(404)
-    await expect(
-      axios.delete(`http://localhost:${ctx.port}/api/user/unknown-uid`)
-    ).rejects.toMatchObject({ response: { status: 404 } });
-  });
-
-  // --- PUT /:uid ---
-
-  it("PUT /user/:uid updates the user's played array", async () => {
-    const response = await axios.put(
-      `http://localhost:${ctx.port}/api/user/${user1.uid}`,
-      { scenarioId: scenario._id.toString() }
-    );
-    expect(response.status).toBe(200);
-    // addPlayed returns true on success, route responds with the return value
-    expect(response.data).toBe(true);
-  });
-
-  // --- POST /:uid/:scenarioId/path ---
-
-  it("POST /user/:uid/:scenarioId/path adds a scene to the user path", async () => {
-    const scene = await Scene.create({ name: "S1", components: [] });
-
-    const response = await axios.post(
-      `http://localhost:${ctx.port}/api/user/${user1.uid}/${scenario._id}/path`,
-      { nextSceneId: scene._id.toString() }
-    );
-    expect(response.status).toBe(200);
-
-    const dbUser = await User.findOne({ uid: user1.uid });
-    expect(dbUser.paths.get(scenario._id.toString())).toContain(
-      scene._id.toString()
-    );
   });
 
   // --- GET /group/:scenarioId (requires auth) ---

--- a/backend/src/routes/api/group.js
+++ b/backend/src/routes/api/group.js
@@ -1,17 +1,11 @@
 import { Router } from "express";
-import {
-  createGroup,
-  getCurrentScene,
-  getGroup,
-  getGroupByScenarioId,
-} from "../../db/daos/groupDao.js";
+import { createGroup, getGroupByScenarioId } from "../../db/daos/groupDao.js";
 
-import { retrieveRoleList, updateRoleList } from "../../db/daos/scenarioDao.js";
+import { updateRoleList } from "../../db/daos/scenarioDao.js";
 import Group from "../../db/models/group.js";
 
 import auth from "../../middleware/firebaseAuth.js";
 import scenarioAuth from "../../middleware/scenarioAuth.js";
-import validScenarioId from "../../middleware/validScenarioId.js";
 
 const router = Router();
 
@@ -22,7 +16,7 @@ const HTTP_NOT_FOUND = 404;
 router.use(auth);
 
 // get the groups assigned to a scenario
-router.get("/scenario/:scenarioId", async (req, res) => {
+router.get("/scenario/:scenarioId", scenarioAuth, async (req, res) => {
   try {
     const { scenarioId } = req.params;
     const groups = await getGroupByScenarioId(scenarioId);
@@ -32,29 +26,7 @@ router.get("/scenario/:scenarioId", async (req, res) => {
   }
 });
 
-// get the current scene of the group
-router.get("/path/:groupId", async (req, res) => {
-  try {
-    const { groupId } = req.params;
-    const currentScene = await getCurrentScene(groupId);
-    return res.status(HTTP_OK).json(currentScene);
-  } catch (error) {
-    return res.status(HTTP_NOT_FOUND).json({ error: error.message });
-  }
-});
-
-// get a group by its id
-router.get("/retrieve/:groupId", async (req, res) => {
-  const { groupId } = req.params;
-  const group = await getGroup(groupId);
-  if (!group) {
-    return res.status(HTTP_NOT_FOUND).json({ error: "Group not found" });
-  }
-  return res.status(HTTP_OK).json(group);
-});
-
-router.use("/:scenarioId", validScenarioId);
-// create a new group — restricted to scenario owner
+// create a new group — restricted to scenario editor
 router.post("/:scenarioId", scenarioAuth, async (req, res) => {
   const { groupList, roleList } = req.body;
   const { scenarioId } = req.params;
@@ -102,14 +74,6 @@ router.post("/:scenarioId", scenarioAuth, async (req, res) => {
   await Promise.all(promises);
 
   return res.status(HTTP_OK).json(output);
-});
-
-// Kept for backward compatibility; superseded by GET /api/scenario/:scenarioId/roles
-router.get("/:scenarioId/roleList", async (req, res) => {
-  const { scenarioId } = req.params;
-  const roleList = await retrieveRoleList(scenarioId);
-
-  res.status(HTTP_OK).json(roleList);
 });
 
 export default router;

--- a/backend/src/routes/api/index.js
+++ b/backend/src/routes/api/index.js
@@ -16,7 +16,7 @@ const router = Router();
 router.use("/scenario", scenario);
 router.use("/staff", staff);
 router.use("/user", user);
-router.use("/note", note);
+router.use("/group/:groupId/notes", note);
 router.use("/group", group);
 router.use("/navigate", navigate);
 router.use("/resources", resource);

--- a/backend/src/routes/api/note.js
+++ b/backend/src/routes/api/note.js
@@ -6,67 +6,63 @@ import {
   deleteNote,
   retrieveNote,
 } from "../../db/daos/noteDao.js";
-import auth from "../../middleware/firebaseAuth.js";
-import { handle, HttpError } from "../../util/error.js";
-import STATUS from "../../util/status.js";
-import User from "../../db/models/user.js";
+import firebaseAuth from "../../middleware/firebaseAuth.js";
+import groupAuth from "../../middleware/groupAuth.js";
+import { handle } from "../../util/error.js";
 
-const router = Router();
-const HTTP_OK = 200;
+const router = Router({ mergeParams: true });
 
-router.use(auth);
-
-async function getEmailByUid(uid) {
-  const user = await User.findOne({ uid }, { email: 1 }).lean();
-  if (!user) throw new HttpError("User not found", STATUS.UNAUTHORIZED);
-  return user.email;
-}
+router.use(firebaseAuth);
+router.use(groupAuth);
 
 // Retrieve note list
-router.get("/retrieveAll/:groupId", async (req, res) => {
+router.get("/", async (req, res) => {
   const { groupId } = req.params;
   const notes = await retrieveNoteList(groupId);
-  res.status(HTTP_OK).json(notes);
+  res.json(notes);
 });
 
 // Retrieve a note
-router.get("/retrieve/:noteId", async (req, res) => {
+router.get("/:noteId", async (req, res) => {
   const { noteId } = req.params;
   const note = await retrieveNote(noteId);
-  res.status(HTTP_OK).json(note);
+  res.json(note);
 });
 
 // Create an empty note
 router.post(
   "/",
   handle(async (req, res) => {
-    const { groupId, title } = req.body;
-    const email = await getEmailByUid(req.body.uid);
-    await createNote(groupId, title, email);
-    res.status(HTTP_OK).json("note created");
+    const { title, membership } = req.body;
+    const { groupId } = req.params;
+    await createNote(groupId, title, membership.role);
+    res.json("note created");
   })
 );
 
 // Update a note
 router.put(
-  "/update",
+  "/:noteId",
   handle(async (req, res) => {
-    const { noteId, text, title, groupId } = req.body;
-    const email = await getEmailByUid(req.body.uid);
-    const date = new Date();
-    await updateNote(noteId, { text, title, date }, groupId, email);
-    res.status(HTTP_OK).json("note updated");
+    const { noteId } = req.params;
+    const { membership, text, title } = req.body;
+    await updateNote(
+      noteId,
+      { text, title, date: new Date() },
+      membership.role
+    );
+    res.json("note updated");
   })
 );
 
 // Delete a note
 router.delete(
-  "/delete",
+  "/:noteId",
   handle(async (req, res) => {
-    const { noteId, groupId } = req.body;
-    const email = await getEmailByUid(req.body.uid);
-    await deleteNote(noteId, groupId, email);
-    res.status(STATUS.OK).json("note deleted");
+    const { noteId, groupId } = req.params;
+    const { membership } = req.body;
+    await deleteNote(noteId, groupId, membership.role);
+    res.json("note deleted");
   })
 );
 

--- a/backend/src/routes/api/note.js
+++ b/backend/src/routes/api/note.js
@@ -5,10 +5,12 @@ import {
   retrieveNoteList,
   deleteNote,
   retrieveNote,
+  hasNoteInGroup,
 } from "../../db/daos/noteDao.js";
 import firebaseAuth from "../../middleware/firebaseAuth.js";
 import groupAuth from "../../middleware/groupAuth.js";
-import { handle } from "../../util/error.js";
+import { handle, HttpError } from "../../util/error.js";
+import { HttpStatusCode } from "axios";
 
 const router = Router({ mergeParams: true });
 
@@ -16,18 +18,26 @@ router.use(firebaseAuth);
 router.use(groupAuth);
 
 // Retrieve note list
-router.get("/", async (req, res) => {
-  const { groupId } = req.params;
-  const notes = await retrieveNoteList(groupId);
-  res.json(notes);
-});
+router.get(
+  "/",
+  handle(async (req, res) => {
+    const { groupId } = req.params;
+    const notes = await retrieveNoteList(groupId);
+    res.json(notes);
+  })
+);
 
 // Retrieve a note
-router.get("/:noteId", async (req, res) => {
-  const { noteId } = req.params;
-  const note = await retrieveNote(noteId);
-  res.json(note);
-});
+router.get(
+  "/:noteId",
+  handle(async (req, res) => {
+    const { noteId } = req.params;
+    if (!hasNoteInGroup(req.body.group, noteId))
+      throw new HttpError("note not found", HttpStatusCode.NotFound);
+    const note = await retrieveNote(noteId);
+    res.json(note);
+  })
+);
 
 // Create an empty note
 router.post(
@@ -45,7 +55,9 @@ router.put(
   "/:noteId",
   handle(async (req, res) => {
     const { noteId } = req.params;
-    const { membership, text, title } = req.body;
+    const { membership, group, text, title } = req.body;
+    if (!hasNoteInGroup(group, noteId))
+      throw new HttpError("note not found", HttpStatusCode.NotFound);
     await updateNote(
       noteId,
       { text, title, date: new Date() },
@@ -60,7 +72,9 @@ router.delete(
   "/:noteId",
   handle(async (req, res) => {
     const { noteId, groupId } = req.params;
-    const { membership } = req.body;
+    const { membership, group } = req.body;
+    if (!hasNoteInGroup(group, noteId))
+      throw new HttpError("note not found", HttpStatusCode.NotFound);
     await deleteNote(noteId, groupId, membership.role);
     res.json("note deleted");
   })

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -14,7 +14,6 @@ import UploadedFile from "../../db/models/uploadedFile.js";
 const router = Router();
 
 router.use(auth);
-router.use("/:scenarioId", scenarioAuth);
 
 /**
  * @route GET /api/resources/:scenarioId
@@ -33,6 +32,8 @@ router.get(
     return res.json(resources);
   })
 );
+
+router.use("/:scenarioId", scenarioAuth);
 
 /**
  * @route POST /api/resources/:scenarioId

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -18,6 +18,7 @@ router.use(auth);
 /**
  * @route GET /api/resources/:scenarioId
  * @desc Get all resources for a scenario
+ * NOTE: this route is unprotected currently, will be addressed with assignment refactor
  */
 router.get(
   "/:scenarioId",

--- a/backend/src/routes/api/user.js
+++ b/backend/src/routes/api/user.js
@@ -1,13 +1,9 @@
 import { Router } from "express";
 import {
-  retrieveAllUser,
   retrieveUserByEmail,
   createUser,
-  retrieveUser,
-  addPlayed,
   retrievePlayedUsers,
   assignScenarioToUsers,
-  retrieveAllUserMinAsc,
 } from "../../db/daos/userDao.js";
 import User from "../../db/models/user.js";
 import Group from "../../db/models/group.js";
@@ -15,6 +11,7 @@ import auth from "../../middleware/firebaseAuth.js";
 
 import STATUS from "../../util/status.js";
 import { handle, HttpError } from "../../util/error.js";
+import scenarioAuth from "../../middleware/scenarioAuth.js";
 
 const router = Router();
 
@@ -52,18 +49,6 @@ router.post(
 // All routes below require Firebase authentication
 router.use(auth);
 
-// gets all users
-router.get("/", async (req, res) => {
-  const dashboard = await retrieveAllUser();
-  res.json(dashboard);
-});
-
-// Only gets the uid, name and email.
-router.get("/min", async (req, res) => {
-  const users = await retrieveAllUserMinAsc();
-  res.json(users);
-});
-
 // fetch the user's group needed for a scenario upfront
 router.get(
   "/group/:scenarioId",
@@ -80,14 +65,16 @@ router.get(
   })
 );
 
+// NOTE: not currently used, but associated ui functionality will be added
+
 // get users that played scenario
-router.get("/played/:scenarioId", async (req, res) => {
+router.get("/played/:scenarioId", scenarioAuth, async (req, res) => {
   const users = await retrievePlayedUsers(req.params.scenarioId);
   return res.json(users);
 });
 
 // assign scenario to users
-router.patch("/assigned/:scenarioId", async (req, res) => {
+router.patch("/assigned/:scenarioId", scenarioAuth, async (req, res) => {
   const { userEmails } = req.body;
   const newAssigneeIds = Object.entries(
     await User.find({ email: { $in: userEmails } }, "_id")
@@ -96,40 +83,6 @@ router.patch("/assigned/:scenarioId", async (req, res) => {
   await assignScenarioToUsers(req.params.scenarioId, newAssigneeIds);
 
   res.status(STATUS.OK).send();
-});
-
-// get user by uid
-router.get("/:uid", async (req, res) => {
-  const user = await retrieveUser(req.params.uid);
-  res.json(user);
-});
-
-// update user's played array
-router.put("/:uid", async (req, res) => {
-  const scenarioID = Object.values(req.body)[0];
-  const added = await addPlayed(req.params.uid, req.body, scenarioID);
-  if (added) {
-    res.status(STATUS.OK).json(added);
-  } else {
-    res.sendStatus(STATUS.NOT_FOUND);
-  }
-});
-
-// add a scene to the user's path
-router.post("/:uid/:scenarioId/path", async (req, res) => {
-  const { nextSceneId } = req.body;
-  const { uid, scenarioId } = req.params;
-
-  await User.findOneAndUpdate(
-    { uid },
-    {
-      $push: {
-        [`paths.${scenarioId}`]: { $each: [nextSceneId], $position: 0 },
-      },
-    }
-  );
-
-  res.sendStatus(STATUS.OK);
 });
 
 export default router;

--- a/frontend/src/features/playScenario/components/NoteDetail.jsx
+++ b/frontend/src/features/playScenario/components/NoteDetail.jsx
@@ -41,13 +41,8 @@ export default function NoteDetail({
     try {
       const token = await getAuth().currentUser.getIdToken();
       await axios.put(
-        "/api/note/update",
-        {
-          noteId: note._id,
-          title,
-          text,
-          groupId: group._id,
-        },
+        `/api/group/${group._id}/notes/${note._id}`,
+        { title, text },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setEditing(false);
@@ -62,8 +57,7 @@ export default function NoteDetail({
   async function handleDelete() {
     try {
       const token = await getAuth().currentUser.getIdToken();
-      await axios.delete("/api/note/delete", {
-        data: { noteId: note._id, groupId: group._id },
+      await axios.delete(`/api/group/${group._id}/notes/${note._id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       onDeleted?.(note._id);

--- a/frontend/src/features/playScenario/components/NotesPanel.jsx
+++ b/frontend/src/features/playScenario/components/NotesPanel.jsx
@@ -50,7 +50,7 @@ export default function NotesPanel({ group, open, onClose }) {
     setError(null);
     try {
       const token = await getToken();
-      const { data } = await axios.get(`/api/note/retrieveAll/${group._id}`, {
+      const { data } = await axios.get(`/api/group/${group._id}/notes`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const fetched = data || [];
@@ -93,12 +93,12 @@ export default function NotesPanel({ group, open, onClose }) {
       const token = await getToken();
       const prevIds = new Set(notes.map((n) => n._id));
       await axios.post(
-        "/api/note/",
-        { groupId: group._id, title: "New Note" },
+        `/api/group/${group._id}/notes`,
+        { title: "New Note" },
         { headers: { Authorization: `Bearer ${token}` } }
       );
 
-      const { data } = await axios.get(`/api/note/retrieveAll/${group._id}`, {
+      const { data } = await axios.get(`/api/group/${group._id}/notes`, {
         headers: { Authorization: `Bearer ${await getToken()}` },
       });
       const fetched = data || [];


### PR DESCRIPTION
## Issue

There are authorisation gaps in our api that allow users to access things they shouldn't be able to see. 

## Solution

Some gaps were associated with old routes, which have been removed outright. The others have been fixed by adding relevant middleware. For notes, this included creating a new groupAuth middleware that checks for group existence and membership.

## Risk

Resources api is unprotected, to be addressed later. https://github.com/UoaWDCC/VPS/pull/477/changes#diff-7e27e9df0e533725118bb2f3c209183d69f2c8b757c611efb071cb7f3711fbb2R21

## Checklist

- [x] Acceptance criteria met
- [x] Unit tests written and passing
- [x] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes are now managed within their associated groups, including viewing, creating, updating, and deleting notes.
  * Group membership and roles are checked automatically when accessing group notes.
* **Bug Fixes**
  * Unauthorized note changes now return a clear forbidden error.
  * Invalid scenario and group identifiers now receive appropriate validation errors.
* **Changes**
  * Scenario resources and played-user actions now enforce scenario authorization.
  * Obsolete group and user-management endpoints were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->