### PR TITLE
feat: change "creating [element]" to signal user to do something rather than wait for loading

### DIFF
--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -106,7 +106,7 @@ function Canvas() {
               opacity-75
             "
           >
-            Creating {createType}
+            Click or drag to create {createType}
           </div>
         )}
         <Overlay />


### PR DESCRIPTION
## Issue

Testers thought the creation indicator e.g. "Creating Textbox" signalled loading rather than indicating that the user had to perform some action on the canvas.

## Solution

The text has now been changed to "Click or drag to create [element]" to prompt the user to click on the canvas and also to tell the user that they can drag when creating the element too.

<img width="1312" height="731" alt="image" src="https://github.com/user-attachments/assets/733ad127-b639-4864-8ea5-186947284430" />
<img width="273" height="75" alt="image" src="https://github.com/user-attachments/assets/fe18af77-f816-4902-b441-065bc17b0efd" />
<img width="325" height="77" alt="image" src="https://github.com/user-attachments/assets/b1452ea5-191f-4c60-8f96-4c72530646ce" />


## Risk

N/A

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated the canvas creation prompt to clearly indicate that users can click or drag to create a component, while preserving the selected component type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->