### PR TITLE
fix(authoring): default to aspect-locked resize for images

### DIFF
--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -173,8 +173,10 @@ function updateResize(
 
   if (!coords.includes(2)) {
     // none of these apply to the speech triangle
-    // shift modifier
-    if (fixed && !coords.includes(0.5)) {
+    // hold shift to lock aspect ratio while resizing, except for images,
+    // which lock aspect ratio by default and can be unlocked with shift
+    const shouldLockAspect = type === "image" ? !fixed : fixed;
+    if (shouldLockAspect && !coords.includes(0.5)) {
       lockAspect(bounds.verts, verts, coords);
     }
 


### PR DESCRIPTION
## Issue

The user will almost always want to proportionally resize images.

## Solution

Default to aspect-locked resize and holding SHIFT switches to free-form resize

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Image resizing now preserves the original aspect ratio by default.
  * Hold **Shift** while resizing an image to adjust its width and height independently.
  * Other component types retain their existing resizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->