### PR TITLE
fix: move timout settings into scene details

### DIFF
--- a/frontend/src/components/Properties/TimerPropertyOperationMenu.jsx
+++ b/frontend/src/components/Properties/TimerPropertyOperationMenu.jsx
@@ -84,7 +84,7 @@ export default function TimerPropertyOperationMenu() {
 
   return (
     <>
-      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
+      <div className="collapse overflow-visible collapse-arrow bg-base-200 border-base-300 rounded-sm text-s">
         <input type="checkbox" />
         <div className="collapse-title flex items-center justify-between">
           On Timeout

--- a/frontend/src/components/Properties/TimerPropertyOperationMenu.jsx
+++ b/frontend/src/components/Properties/TimerPropertyOperationMenu.jsx
@@ -84,14 +84,15 @@ export default function TimerPropertyOperationMenu() {
 
   return (
     <>
-      <div className="collapse overflow-visible collapse-arrow bg-base-200 border-base-300 rounded-sm text-s">
+      <div className="collapse overflow-visible collapse-arrow bg-base-200 rounded-sm text-s">
         <input type="checkbox" />
-        <div className="collapse-title flex items-center justify-between">
-          On Timeout
+        <div className="collapse-title !pl-0 flex items-center justify-between text-xs after:text-base-content/50">
+          <label className="label">On Timeout</label>
           <PlusIcon
             size={18}
             onClick={() => setCreateOpen(true)}
             className="z-1"
+            opacity={0.5}
           />
         </div>
         <div className="collapse-content text--1 bg-base-200 px-0">

--- a/frontend/src/features/authoring/CanvasSideBar/ObjectPropertyEditor.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/ObjectPropertyEditor.jsx
@@ -1,10 +1,7 @@
 import { getBoxCenter, translate, correct } from "../../authoring/util";
 import { useEffect, useState, useRef } from "react";
 import { modifyComponentProp } from "../scene/operations/component";
-import {
-  SquareCenterlineDashedHorizontal,
-  SquareCenterlineDashedVertical,
-} from "lucide-react";
+import { FlipHorizontal2, FlipVertical2 } from "lucide-react";
 
 export function ObjectPropertyEditor({ component }) {
   // x and y vals used for setting and current
@@ -249,7 +246,7 @@ export function ObjectPropertyEditor({ component }) {
                   className="hover:bg-stone-800 cursor-pointer rounded-sm"
                   onClick={() => flipComponent("x")}
                 >
-                  <SquareCenterlineDashedHorizontal className="m-2" />
+                  <FlipHorizontal2 className="m-2" />
                 </button>
                 <button
                   type="button"
@@ -258,7 +255,7 @@ export function ObjectPropertyEditor({ component }) {
                   className="hover:bg-stone-800 cursor-pointer rounded-sm"
                   onClick={() => flipComponent("y")}
                 >
-                  <SquareCenterlineDashedVertical className="m-2" />
+                  <FlipVertical2 className="m-2" />
                 </button>
               </div>
             </div>

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -100,7 +100,7 @@ export default function SceneSettings() {
 
   return (
     <>
-      <div className="collapse overflow-visible collapse-arrow bg-base-300 rounded-sm text-s">
+      <div className="collapse collapse-arrow bg-base-300 rounded-sm text-s">
         <input type="checkbox" />
         <div className="collapse-title">Scene Details</div>
         <div className="collapse-content text--1 bg-base-200">
@@ -124,6 +124,7 @@ export default function SceneSettings() {
               className="input"
               placeholder="No timer"
             />
+            {time > 0 && <TimerStateOperationMenu />}
             <label className="label">Roles</label>
             <div className="dropdown" onBlur={saveSceneRoles}>
               <div

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -124,7 +124,7 @@ export default function SceneSettings() {
               className="input"
               placeholder="No timer"
             />
-            {time > 0 && <TimerStateOperationMenu />}
+            {time > 0 && <TimerPropertyOperationMenu />}
             <label className="label">Roles</label>
             <div className="dropdown" onBlur={saveSceneRoles}>
               <div
@@ -217,7 +217,6 @@ export default function SceneSettings() {
           </fieldset>
         </div>
       </div>
-      {time > 0 && <TimerPropertyOperationMenu />}
     </>
   );
 }

--- a/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
+++ b/frontend/src/features/authoring/CanvasSideBar/SceneSettings.jsx
@@ -100,7 +100,7 @@ export default function SceneSettings() {
 
   return (
     <>
-      <div className="collapse collapse-arrow bg-base-300 rounded-sm text-s">
+      <div className="collapse collapse-arrow bg-base-300 rounded-sm text-s has-[>input:checked]:overflow-visible">
         <input type="checkbox" />
         <div className="collapse-title">Scene Details</div>
         <div className="collapse-content text--1 bg-base-200">


### PR DESCRIPTION
## Issue

"Timer duration" is inside the "Scene Details," while "On timeout" is a separate section that appears after setting the timer duration, which shows a disconnect between the related timeout settings.

## Solution

Transfer the "On timeout" inside the "Scene Details" section by moving the conditional rendering of "On timeout" inside the "Scene Details" just after Scene Detail inputs


## Risk

- I have removed the overflow-visible CSS of scene settings to hide the "On timeout" section when the "Scene Details" section is folded. That might affect later updates.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved the timer timeout menu layout and styling for clearer visibility.
  * The timeout menu now appears within scene details only when a timer is active.
  * Updated horizontal and vertical flip controls with clearer icons.
  * Scene details scrolling is enabled appropriately while the section is expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->