### PR TITLE
VPS-150/Restricted file types of uploaded images

### DIFF
--- a/frontend/src/features/authoring/images.tsx
+++ b/frontend/src/features/authoring/images.tsx
@@ -19,6 +19,13 @@ import { v4 } from "uuid";
 
 type ModifyScene = (scene: Scene) => Promise<unknown> | undefined;
 
+const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+];
+
 async function addImageToScene(
   image: UploadedFile,
   originScene: Scene,
@@ -117,14 +124,20 @@ function ImageCreateMenu() {
 
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
+    event.target.value = "";
 
-    if (file) {
-      const originScene = getScene();
+    if (!file) return;
 
-      addNewImage(file, scenarioId, user, originScene, modifyScene).catch(
-        handleGeneric
-      );
+    if (!ACCEPTED_IMAGE_MIME_TYPES.includes(file.type)) {
+      toast.error("Unsupported file type");
+      return;
     }
+
+    const originScene = getScene();
+
+    addNewImage(file, scenarioId, user, originScene, modifyScene).catch(
+      handleGeneric
+    );
   }
 
   const showFilePicker = () => {
@@ -176,6 +189,7 @@ function ImageCreateMenu() {
       <input
         ref={fileInputRef}
         type="file"
+        accept={ACCEPTED_IMAGE_MIME_TYPES.join(",")}
         className="hidden"
         onChange={handleFileChange}
       />


### PR DESCRIPTION
## Issue

The "Upload New Image" file picker in the scene authoring sidebar accepted any file type (PDFs, docx, markdown, etc.), since the native `<input type="file">` had no restriction. Selecting a non-image file would only fail after a round trip to the backend, with a generic "Image upload failed" toast.

## Solution

Restricted the file input to image types only:
- Added an `accept` attribute (`image/png,image/jpeg,image/webp,image/gif`) so the OS file picker filters to image files by default, matching the image MIME types the backend already accepts (`backend/src/routes/api/files.js`).
- Added client-side MIME type validation in `handleFileChange` since `accept` is only a picker hint (users can still choose "All Files" or drag-and-drop a non-image file). Invalid files now show a `toast.error("Unsupported file type")` instead of silently attempting an upload.
- Reset the input value after each selection so re-selecting the same rejected file re-triggers `onChange`.

## Risk

Low risk - change is scoped to a single input in `frontend/src/features/authoring/images.tsx` and only tightens client-side validation ahead of an existing backend check. No changes to upload/storage behavior for valid image files.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload validation by accepting only PNG, JPEG, WebP, and GIF files.
  * Unsupported image formats are now rejected with a clear error notification.
  * Updated file selection controls to show supported image formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->