### PR TITLE
VPS-96/change name of uploaded resources

### DIFF
--- a/backend/src/db/models/resource.js
+++ b/backend/src/db/models/resource.js
@@ -1,5 +1,7 @@
 import { model, Schema } from "mongoose";
 
+export const RESOURCE_NAME_MAX_LENGTH = 255;
+
 const resourceSchema = new Schema(
   {
     scenarioId: {
@@ -19,7 +21,12 @@ const resourceSchema = new Schema(
       enum: ["file", "collection"],
       required: true,
     },
-    name: { type: String, required: true, trim: true, maxlength: 255 },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: RESOURCE_NAME_MAX_LENGTH,
+    },
     fileId: {
       type: Schema.Types.ObjectId,
       ref: "UploadedFile",

--- a/backend/src/db/models/resource.js
+++ b/backend/src/db/models/resource.js
@@ -19,7 +19,7 @@ const resourceSchema = new Schema(
       enum: ["file", "collection"],
       required: true,
     },
-    name: { type: String, required: true },
+    name: { type: String, required: true, trim: true, maxlength: 255 },
     fileId: {
       type: Schema.Types.ObjectId,
       ref: "UploadedFile",

--- a/backend/src/routes/api/__tests__/resourcesApi.test.js
+++ b/backend/src/routes/api/__tests__/resourcesApi.test.js
@@ -211,38 +211,43 @@ describe("Resources API tests", () => {
     expect(response.data.name).toBe("padded.png");
   });
 
-  it("PATCH /resources/:scenarioId/:resourceId returns 400 when the file extension is changed", async () => {
-    await expect(
-      axios.patch(
-        `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
-        { name: "renamed.txt" },
-        authHeaders("user1")
-      )
-    ).rejects.toMatchObject({ response: { status: 400 } });
-
-    const dbResource = await Resource.findById(resource._id);
-    expect(dbResource.name).toBe("image.png");
-  });
-
-  it("PATCH /resources/:scenarioId/:resourceId allows renaming a legacy resource with untrimmed whitespace in its stored name", async () => {
-    // Bypass the schema's trim:true setter to simulate a resource that was
-    // written before that option existed, with whitespace still in `name`.
-    await Resource.collection.updateOne(
-      { _id: resource._id },
-      { $set: { name: "image.png " } }
-    );
-
+  it("PATCH /resources/:scenarioId/:resourceId allows a name that no longer matches the file's real extension", async () => {
     const response = await axios.patch(
       `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
-      { name: "vacation.png" },
+      { name: "renamed.txt" },
       authHeaders("user1")
     );
 
     expect(response.status).toBe(200);
-    expect(response.data.name).toBe("vacation.png");
+    expect(response.data.name).toBe("renamed.txt");
   });
 
-  it("PATCH /resources/:scenarioId/:resourceId allows renaming a collection without an extension restriction", async () => {
+  it("PATCH /resources/:scenarioId/:resourceId allows removing the file extension entirely", async () => {
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+      { name: "Patient Info Sheet" },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("Patient Info Sheet");
+
+    const dbResource = await Resource.findById(resource._id);
+    expect(dbResource.name).toBe("Patient Info Sheet");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId allows a name containing a period, such as a trailing full stop", async () => {
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+      { name: "image." },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("image.");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId renames a collection", async () => {
     const response = await axios.patch(
       `http://localhost:${ctx.port}/api/resources/${scenarioId}/${collection._id}`,
       { name: "Renamed Group" },

--- a/backend/src/routes/api/__tests__/resourcesApi.test.js
+++ b/backend/src/routes/api/__tests__/resourcesApi.test.js
@@ -224,6 +224,24 @@ describe("Resources API tests", () => {
     expect(dbResource.name).toBe("image.png");
   });
 
+  it("PATCH /resources/:scenarioId/:resourceId allows renaming a legacy resource with untrimmed whitespace in its stored name", async () => {
+    // Bypass the schema's trim:true setter to simulate a resource that was
+    // written before that option existed, with whitespace still in `name`.
+    await Resource.collection.updateOne(
+      { _id: resource._id },
+      { $set: { name: "image.png " } }
+    );
+
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+      { name: "vacation.png" },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("vacation.png");
+  });
+
   it("PATCH /resources/:scenarioId/:resourceId allows renaming a collection without an extension restriction", async () => {
     const response = await axios.patch(
       `http://localhost:${ctx.port}/api/resources/${scenarioId}/${collection._id}`,

--- a/backend/src/routes/api/__tests__/resourcesApi.test.js
+++ b/backend/src/routes/api/__tests__/resourcesApi.test.js
@@ -184,6 +184,87 @@ describe("Resources API tests", () => {
     expect(dbResource).not.toBeNull();
   });
 
+  // --- Rename resource ---
+
+  it("PATCH /resources/:scenarioId/:resourceId renames a resource", async () => {
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+      { name: "renamed.png" },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("renamed.png");
+
+    const dbResource = await Resource.findById(resource._id);
+    expect(dbResource.name).toBe("renamed.png");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId trims whitespace from the name", async () => {
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+      { name: "  padded.png  " },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("padded.png");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId returns 400 when the file extension is changed", async () => {
+    await expect(
+      axios.patch(
+        `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+        { name: "renamed.txt" },
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    const dbResource = await Resource.findById(resource._id);
+    expect(dbResource.name).toBe("image.png");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId allows renaming a collection without an extension restriction", async () => {
+    const response = await axios.patch(
+      `http://localhost:${ctx.port}/api/resources/${scenarioId}/${collection._id}`,
+      { name: "Renamed Group" },
+      authHeaders("user1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data.name).toBe("Renamed Group");
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId returns 400 for a blank name", async () => {
+    await expect(
+      axios.patch(
+        `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+        { name: "   " },
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId returns 400 for a name over 255 characters", async () => {
+    await expect(
+      axios.patch(
+        `http://localhost:${ctx.port}/api/resources/${scenarioId}/${resource._id}`,
+        { name: "a".repeat(256) },
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  it("PATCH /resources/:scenarioId/:resourceId returns 404 when resource not found", async () => {
+    await expect(
+      axios.patch(
+        `http://localhost:${ctx.port}/api/resources/${scenarioId}/000000000000000000000099`,
+        { name: "renamed.png" },
+        authHeaders("user1")
+      )
+    ).rejects.toMatchObject({ response: { status: 404 } });
+  });
+
   // --- Delete resource ---
 
   it("DELETE /resources/:scenarioId/:resourceId deletes the Resource and decrements the file reference count", async () => {

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -17,12 +17,6 @@ const router = Router();
 
 router.use(auth);
 
-function getExtension(name) {
-  const trimmed = name.trim();
-  const dotIndex = trimmed.lastIndexOf(".");
-  return dotIndex <= 0 ? "" : trimmed.slice(dotIndex).toLowerCase();
-}
-
 /**
  * @route GET /api/resources/:scenarioId
  * @desc Get all resources for a scenario
@@ -34,7 +28,7 @@ router.get(
     const { scenarioId } = req.params;
 
     const resources = await Resource.find({ scenarioId })
-      .populate("fileId", "url type contentType size")
+      .populate("fileId", "name url type contentType size")
       .sort({ parentId: 1, createdAt: -1 })
       .lean();
 
@@ -88,7 +82,7 @@ router.post(
       name,
       fileId,
     });
-    await resource.populate("fileId", "url type contentType size");
+    await resource.populate("fileId", "name url type contentType size");
 
     await applyReferenceDelta(fileId, 1);
 
@@ -188,24 +182,16 @@ router.patch(
         HttpStatusCode.BadRequest
       );
 
-    const existing = await Resource.findOne({ _id: resourceId, scenarioId });
-    if (!existing)
+    const resource = await Resource.findOneAndUpdate(
+      { _id: resourceId, scenarioId },
+      { name: trimmedName },
+      { new: true, runValidators: true }
+    ).populate("fileId", "name url type contentType size");
+
+    if (!resource)
       throw new HttpError("resource not found", HttpStatusCode.NotFound);
 
-    if (
-      existing.type === "file" &&
-      getExtension(trimmedName) !== getExtension(existing.name)
-    )
-      throw new HttpError(
-        "file extension cannot be changed",
-        HttpStatusCode.BadRequest
-      );
-
-    existing.name = trimmedName;
-    await existing.save();
-    await existing.populate("fileId", "url type contentType size");
-
-    return res.json(existing);
+    return res.json(resource);
   })
 );
 
@@ -224,7 +210,7 @@ router.post(
       { $push: { stateConditionals: stateConditional } },
       { new: true, runValidators: true }
     )
-      .populate("fileId", "url type contentType size")
+      .populate("fileId", "name url type contentType size")
       .lean();
 
     if (!resource)
@@ -253,7 +239,7 @@ router.put(
       { $set: { "stateConditionals.$": stateConditional } },
       { new: true, runValidators: true }
     )
-      .populate("fileId", "url type contentType size")
+      .populate("fileId", "name url type contentType size")
       .lean();
 
     if (!resource)
@@ -277,7 +263,7 @@ router.delete(
       { $pull: { stateConditionals: { _id: conditionalId } } },
       { new: true }
     )
-      .populate("fileId", "url type contentType size")
+      .populate("fileId", "name url type contentType size")
       .lean();
 
     if (!resource)

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -7,7 +7,9 @@ import {
   applyReferenceDelta,
   applyReferenceDeltas,
 } from "../../db/daos/fileDao.js";
-import Resource from "../../db/models/resource.js";
+import Resource, {
+  RESOURCE_NAME_MAX_LENGTH,
+} from "../../db/models/resource.js";
 import { isValidObjectId } from "../../util/validation.js";
 import UploadedFile from "../../db/models/uploadedFile.js";
 
@@ -16,8 +18,9 @@ const router = Router();
 router.use(auth);
 
 function getExtension(name) {
-  const dotIndex = name.lastIndexOf(".");
-  return dotIndex <= 0 ? "" : name.slice(dotIndex).toLowerCase();
+  const trimmed = name.trim();
+  const dotIndex = trimmed.lastIndexOf(".");
+  return dotIndex <= 0 ? "" : trimmed.slice(dotIndex).toLowerCase();
 }
 
 /**
@@ -179,9 +182,9 @@ router.patch(
     if (!trimmedName)
       throw new HttpError("name is required", HttpStatusCode.BadRequest);
 
-    if (trimmedName.length > 255)
+    if (trimmedName.length > RESOURCE_NAME_MAX_LENGTH)
       throw new HttpError(
-        "name must be 255 characters or fewer",
+        `name must be ${RESOURCE_NAME_MAX_LENGTH} characters or fewer`,
         HttpStatusCode.BadRequest
       );
 

--- a/backend/src/routes/api/resources.js
+++ b/backend/src/routes/api/resources.js
@@ -15,6 +15,11 @@ const router = Router();
 
 router.use(auth);
 
+function getExtension(name) {
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex <= 0 ? "" : name.slice(dotIndex).toLowerCase();
+}
+
 /**
  * @route GET /api/resources/:scenarioId
  * @desc Get all resources for a scenario
@@ -153,6 +158,51 @@ router.delete(
     await applyReferenceDeltas(fileRefDeltas);
 
     return res.status(HttpStatusCode.NoContent).send();
+  })
+);
+
+/**
+ * @route PATCH /api/resources/:scenarioId/:resourceId
+ * @desc Rename a resource
+ */
+router.patch(
+  "/:scenarioId/:resourceId",
+  handle(async (req, res) => {
+    const { scenarioId, resourceId } = req.params;
+    const { name } = req.body;
+
+    if (!isValidObjectId(resourceId))
+      throw new HttpError("invalid resource id", HttpStatusCode.BadRequest);
+
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+
+    if (!trimmedName)
+      throw new HttpError("name is required", HttpStatusCode.BadRequest);
+
+    if (trimmedName.length > 255)
+      throw new HttpError(
+        "name must be 255 characters or fewer",
+        HttpStatusCode.BadRequest
+      );
+
+    const existing = await Resource.findOne({ _id: resourceId, scenarioId });
+    if (!existing)
+      throw new HttpError("resource not found", HttpStatusCode.NotFound);
+
+    if (
+      existing.type === "file" &&
+      getExtension(trimmedName) !== getExtension(existing.name)
+    )
+      throw new HttpError(
+        "file extension cannot be changed",
+        HttpStatusCode.BadRequest
+      );
+
+    existing.name = trimmedName;
+    await existing.save();
+    await existing.populate("fileId", "url type contentType size");
+
+    return res.json(existing);
   })
 );
 

--- a/frontend/src/features/resources/ManageResourcesPage.jsx
+++ b/frontend/src/features/resources/ManageResourcesPage.jsx
@@ -1,29 +1,18 @@
-import React, { useEffect, useRef, useState, useContext } from "react";
+import React, { useRef, useState, useContext } from "react";
 import toast from "react-hot-toast";
 import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
-import {
-  ArrowLeftIcon,
-  CheckIcon,
-  PencilIcon,
-  PlusIcon,
-  XIcon,
-} from "lucide-react";
+import { ArrowLeftIcon, PlusIcon, XIcon } from "lucide-react";
 import AddGroup from "./components/AddGroup";
+import ResourceNameField from "./components/ResourceNameField";
 import StateConditionalMenu from "../../components/StateVariables/StateConditionalMenu";
 import { api } from "../../util/api";
 import AuthenticationContext from "../../context/AuthenticationContext";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { filterTreeBySearch, normaliseFile } from "./util";
+import { filterTreeBySearch, isTemp, normaliseFile } from "./util";
 import { v4 as uuid } from "uuid";
 import ResourcePreview from "./ResourcePreview";
 import SkeletonBody from "./ResourcesSkeleton";
-
-const RESOURCE_NAME_MAX_LENGTH = 255;
-
-function isTemp(resource) {
-  return resource._id.startsWith("temp.");
-}
 
 async function uploadFileResource(user, scenarioId, parentId, file) {
   const formData = new FormData();
@@ -392,121 +381,6 @@ export default function ManageResourcesPage() {
 }
 
 // Helper components
-function ResourceNameField({
-  resource,
-  disabled,
-  onSelect,
-  onRename,
-  actions,
-}) {
-  const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(resource.name);
-  const inputRef = useRef(null);
-
-  useEffect(() => {
-    if (editing) {
-      inputRef.current?.focus();
-    }
-  }, [editing]);
-
-  function startEditing(e) {
-    e.stopPropagation();
-    if (disabled) return;
-    setValue(resource.name);
-    setEditing(true);
-  }
-
-  function commitEdit() {
-    setEditing(false);
-    const trimmedName = value.trim();
-    if (!trimmedName || trimmedName === resource.name) return;
-    onRename(trimmedName);
-  }
-
-  function handleKeyDown(e) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      inputRef.current?.blur();
-    } else if (e.key === "Escape") {
-      setValue(resource.name);
-      setEditing(false);
-    }
-  }
-
-  const rowStyle = editing
-    ? {
-        gridTemplateColumns: "minmax(0, 1fr) auto",
-        backgroundColor: "transparent",
-        boxShadow: "none",
-        color: "var(--color-base-content)",
-        cursor: "auto",
-      }
-    : { gridTemplateColumns: "minmax(0, 1fr) auto auto" };
-
-  return (
-    <div className="grid items-center gap-1 overflow-hidden" style={rowStyle}>
-      {editing ? (
-        <input
-          ref={inputRef}
-          type="text"
-          className="input input-xs input-bordered min-w-0"
-          style={{
-            "--input-color":
-              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
-            backgroundColor: "var(--color-base-100)",
-            borderColor:
-              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
-            color: "var(--color-base-content)",
-            boxShadow: "none",
-            outline: "none",
-            userSelect: "text",
-            WebkitUserSelect: "text",
-          }}
-          value={value}
-          maxLength={RESOURCE_NAME_MAX_LENGTH}
-          onChange={(e) => setValue(e.target.value)}
-          onBlur={commitEdit}
-          onKeyDown={handleKeyDown}
-          onClick={(e) => e.stopPropagation()}
-        />
-      ) : (
-        <>
-          <button
-            type="button"
-            className={`min-w-0 truncate bg-transparent px-0 text-left text--1 border-none cursor-pointer disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${isTemp(resource) ? "text-primary" : ""}`}
-            title={resource.name}
-            onClick={onSelect}
-            disabled={disabled}
-          >
-            {resource.name}
-          </button>
-          <button
-            type="button"
-            className="btn btn-phantom btn-xs px-0"
-            onClick={startEditing}
-            title="Rename"
-            disabled={disabled}
-          >
-            <PencilIcon size={14} />
-          </button>
-        </>
-      )}
-      {editing ? (
-        <button
-          type="button"
-          className="btn btn-phantom btn-xs px-0"
-          onClick={() => inputRef.current?.blur()}
-          title="Confirm rename"
-        >
-          <CheckIcon size={14} />
-        </button>
-      ) : (
-        actions
-      )}
-    </div>
-  );
-}
-
 function UploadButton({
   onFiles,
   multiple = true,

--- a/frontend/src/features/resources/ManageResourcesPage.jsx
+++ b/frontend/src/features/resources/ManageResourcesPage.jsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState, useContext } from "react";
+import React, { useEffect, useRef, useState, useContext } from "react";
 import toast from "react-hot-toast";
 import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
-import { ArrowLeftIcon, PlusIcon, XIcon } from "lucide-react";
+import { ArrowLeftIcon, PencilIcon, PlusIcon, XIcon } from "lucide-react";
 import AddGroup from "./components/AddGroup";
 import StateConditionalMenu from "../../components/StateVariables/StateConditionalMenu";
 import { api } from "../../util/api";
@@ -12,6 +12,8 @@ import { filterTreeBySearch, normaliseFile } from "./util";
 import { v4 as uuid } from "uuid";
 import ResourcePreview from "./ResourcePreview";
 import SkeletonBody from "./ResourcesSkeleton";
+
+const RESOURCE_NAME_MAX_LENGTH = 255;
 
 function isTemp(resource) {
   return resource._id.startsWith("temp.");
@@ -44,6 +46,15 @@ async function createResourceCollection(user, scenarioId, name) {
 
 async function removeResource(user, scenarioId, resourceId) {
   await api.delete(user, `/api/resources/${scenarioId}/${resourceId}`);
+}
+
+async function renameResource(user, scenarioId, resourceId, name) {
+  const res = await api.patch(
+    user,
+    `/api/resources/${scenarioId}/${resourceId}`,
+    { name }
+  );
+  return res.data;
 }
 
 function buildResourceTree(resources) {
@@ -153,6 +164,27 @@ export default function ManageResourcesPage() {
     onSettled: () => queryClient.invalidateQueries(["resources", scenarioId]),
   });
 
+  const renameResourceMutation = useMutation({
+    mutationFn: ({ resourceId, name }) =>
+      renameResource(user, scenarioId, resourceId, name),
+    onMutate: async ({ resourceId, name }) => {
+      await queryClient.cancelQueries(["resources", scenarioId]);
+      const previous = queryClient.getQueryData(["resources", scenarioId]);
+      queryClient.setQueryData(["resources", scenarioId], (prev) =>
+        (prev ?? []).map((r) => (r._id === resourceId ? { ...r, name } : r))
+      );
+      return { previous };
+    },
+    onError: (e, _, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["resources", scenarioId], context.previous);
+      }
+      console.error(e);
+      toast.error("Something went wrong renaming the resource");
+    },
+    onSettled: () => queryClient.invalidateQueries(["resources", scenarioId]),
+  });
+
   function goBack() {
     history.push(`/scenario/${scenarioId}`);
   }
@@ -187,7 +219,7 @@ export default function ManageResourcesPage() {
           ) : (
             <div className="grid grid-cols-1 gap-4 lg:h-full lg:min-h-0 lg:grid-cols-3">
               {/* LEFT: Groups and files */}
-              <div className="card min-h-[35dvh] bg-base-100 shadow-md lg:h-full lg:min-h-0">
+              <div className="card min-h-[35dvh] min-w-0 overflow-hidden bg-base-100 shadow-md lg:h-full lg:min-h-0">
                 <div className="card-body flex min-h-0 flex-col gap-4 px-0">
                   <h1 className="flex-none text-xl">Uploaded Resources</h1>
 
@@ -217,9 +249,9 @@ export default function ManageResourcesPage() {
                       </li>
                     )}
                     {filteredTree.map((resource) => (
-                      <li key={resource._id}>
+                      <li key={resource._id} className="overflow-hidden">
                         {resource.type === "collection" ? (
-                          <details>
+                          <details className="overflow-hidden">
                             <summary
                               className={`flex items-center ${isTemp(resource) ? "text-primary" : ""} ${selectedResource?._id === resource._id ? "bg-base-200" : ""}`}
                               onClick={() =>
@@ -227,7 +259,10 @@ export default function ManageResourcesPage() {
                                 setSelectedResourceId(resource._id)
                               }
                             >
-                              <span className="text--1 truncate">
+                              <span
+                                className="text--1 truncate"
+                                title={resource.name}
+                              >
                                 {resource.name}
                               </span>
                               <div className="flex items-center ml-auto">
@@ -255,22 +290,32 @@ export default function ManageResourcesPage() {
                               </div>
                             </summary>
 
-                            <ul>
+                            <ul className="overflow-hidden">
                               {resource.children.length === 0 && (
                                 <li className="opacity-60 p-2">No files yet</li>
                               )}
                               {resource.children.map((child) => (
-                                <li key={child._id}>
-                                  <div className="flex items-center justify-between">
-                                    <a
-                                      className={`min-w-0 flex-1 text--1 truncate ${isTemp(child) ? "text-primary" : ""}`}
-                                      onClick={() => {
-                                        if (!child._id.startsWith("temp."))
-                                          setSelectedResourceId(child._id);
-                                      }}
-                                    >
-                                      {child.name}
-                                    </a>
+                                <li key={child._id} className="overflow-hidden">
+                                  <div
+                                    className="grid items-center gap-1 overflow-hidden"
+                                    style={{
+                                      gridTemplateColumns:
+                                        "minmax(0, 1fr) auto",
+                                    }}
+                                  >
+                                    <ResourceNameField
+                                      resource={child}
+                                      disabled={isTemp(child)}
+                                      onSelect={() =>
+                                        setSelectedResourceId(child._id)
+                                      }
+                                      onRename={(name) =>
+                                        renameResourceMutation.mutate({
+                                          resourceId: child._id,
+                                          name,
+                                        })
+                                      }
+                                    />
                                     <button
                                       className="btn btn-phantom btn-xs px-0"
                                       onClick={(e) => {
@@ -290,16 +335,25 @@ export default function ManageResourcesPage() {
                             </ul>
                           </details>
                         ) : (
-                          <div className="flex items-center justify-between">
-                            <a
-                              className={`min-w-0 flex-1 text--1 truncate ${isTemp(resource) ? "text-primary" : ""}`}
-                              onClick={() => {
-                                if (!resource._id.startsWith("temp."))
-                                  setSelectedResourceId(resource._id);
-                              }}
-                            >
-                              {resource.name}
-                            </a>
+                          <div
+                            className="grid items-center gap-1 overflow-hidden"
+                            style={{
+                              gridTemplateColumns: "minmax(0, 1fr) auto",
+                            }}
+                          >
+                            <ResourceNameField
+                              resource={resource}
+                              disabled={isTemp(resource)}
+                              onSelect={() =>
+                                setSelectedResourceId(resource._id)
+                              }
+                              onRename={(name) =>
+                                renameResourceMutation.mutate({
+                                  resourceId: resource._id,
+                                  name,
+                                })
+                              }
+                            />
                             <button
                               className="btn btn-phantom btn-xs px-0"
                               onClick={(e) => {
@@ -345,6 +399,103 @@ export default function ManageResourcesPage() {
 }
 
 // Helper components
+function splitFileName(name) {
+  const dotIndex = name.lastIndexOf(".");
+  if (dotIndex <= 0) return { base: name, ext: "" };
+  return { base: name.slice(0, dotIndex), ext: name.slice(dotIndex) };
+}
+
+function ResourceNameField({ resource, disabled, onSelect, onRename }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(() => splitFileName(resource.name).base);
+  const inputRef = useRef(null);
+
+  const { ext } = splitFileName(resource.name);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  function startEditing(e) {
+    e.stopPropagation();
+    if (disabled) return;
+    setValue(splitFileName(resource.name).base);
+    setEditing(true);
+  }
+
+  function commitEdit() {
+    setEditing(false);
+    const trimmedBase = value.trim();
+    if (!trimmedBase) return;
+    const newName = `${trimmedBase}${ext}`;
+    if (newName === resource.name) return;
+    onRename(newName);
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      inputRef.current?.blur();
+    } else if (e.key === "Escape") {
+      setValue(splitFileName(resource.name).base);
+      setEditing(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex min-w-0 items-center gap-1">
+        <input
+          ref={inputRef}
+          type="text"
+          className="input input-xs input-bordered min-w-0 flex-1"
+          value={value}
+          maxLength={Math.max(RESOURCE_NAME_MAX_LENGTH - ext.length, 1)}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+        />
+        {ext && (
+          <span
+            className="shrink-0 text--1 opacity-60"
+            title="File type can't be changed"
+          >
+            {ext}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid items-center gap-1 overflow-hidden"
+      style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
+    >
+      <a
+        className={`text--1 truncate ${isTemp(resource) ? "text-primary" : ""}`}
+        title={resource.name}
+        onClick={() => !disabled && onSelect()}
+      >
+        {resource.name}
+      </a>
+      <button
+        type="button"
+        className="btn btn-phantom btn-xs px-0"
+        onClick={startEditing}
+        title="Rename"
+        disabled={disabled}
+      >
+        <PencilIcon size={14} />
+      </button>
+    </div>
+  );
+}
+
 function UploadButton({
   onFiles,
   multiple = true,

--- a/frontend/src/features/resources/ManageResourcesPage.jsx
+++ b/frontend/src/features/resources/ManageResourcesPage.jsx
@@ -392,12 +392,6 @@ export default function ManageResourcesPage() {
 }
 
 // Helper components
-function splitFileName(name) {
-  const dotIndex = name.lastIndexOf(".");
-  if (dotIndex <= 0) return { base: name, ext: "" };
-  return { base: name.slice(0, dotIndex), ext: name.slice(dotIndex) };
-}
-
 function ResourceNameField({
   resource,
   disabled,
@@ -406,10 +400,8 @@ function ResourceNameField({
   actions,
 }) {
   const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(() => splitFileName(resource.name).base);
+  const [value, setValue] = useState(resource.name);
   const inputRef = useRef(null);
-
-  const { ext } = splitFileName(resource.name);
 
   useEffect(() => {
     if (editing) {
@@ -420,17 +412,15 @@ function ResourceNameField({
   function startEditing(e) {
     e.stopPropagation();
     if (disabled) return;
-    setValue(splitFileName(resource.name).base);
+    setValue(resource.name);
     setEditing(true);
   }
 
   function commitEdit() {
     setEditing(false);
-    const trimmedBase = value.trim();
-    if (!trimmedBase) return;
-    const newName = `${trimmedBase}${ext}`;
-    if (newName === resource.name) return;
-    onRename(newName);
+    const trimmedName = value.trim();
+    if (!trimmedName || trimmedName === resource.name) return;
+    onRename(trimmedName);
   }
 
   function handleKeyDown(e) {
@@ -438,7 +428,7 @@ function ResourceNameField({
       e.preventDefault();
       inputRef.current?.blur();
     } else if (e.key === "Escape") {
-      setValue(splitFileName(resource.name).base);
+      setValue(resource.name);
       setEditing(false);
     }
   }
@@ -456,44 +446,34 @@ function ResourceNameField({
   return (
     <div className="grid items-center gap-1 overflow-hidden" style={rowStyle}>
       {editing ? (
-        <div className="flex min-w-0 items-center gap-1">
-          <input
-            ref={inputRef}
-            type="text"
-            className="input input-xs input-bordered min-w-0 flex-1"
-            style={{
-              "--input-color":
-                "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
-              backgroundColor: "var(--color-base-100)",
-              borderColor:
-                "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
-              color: "var(--color-base-content)",
-              boxShadow: "none",
-              outline: "none",
-              userSelect: "text",
-              WebkitUserSelect: "text",
-            }}
-            value={value}
-            maxLength={Math.max(RESOURCE_NAME_MAX_LENGTH - ext.length, 1)}
-            onChange={(e) => setValue(e.target.value)}
-            onBlur={commitEdit}
-            onKeyDown={handleKeyDown}
-            onClick={(e) => e.stopPropagation()}
-          />
-          {ext && (
-            <span
-              className="shrink-0 text--1 opacity-60"
-              title="File type can't be changed"
-            >
-              {ext}
-            </span>
-          )}
-        </div>
+        <input
+          ref={inputRef}
+          type="text"
+          className="input input-xs input-bordered min-w-0"
+          style={{
+            "--input-color":
+              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+            backgroundColor: "var(--color-base-100)",
+            borderColor:
+              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+            color: "var(--color-base-content)",
+            boxShadow: "none",
+            outline: "none",
+            userSelect: "text",
+            WebkitUserSelect: "text",
+          }}
+          value={value}
+          maxLength={RESOURCE_NAME_MAX_LENGTH}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+        />
       ) : (
         <>
           <button
             type="button"
-            className={`btn btn-phantom btn-xs min-w-0 justify-start truncate px-0 text--1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${isTemp(resource) ? "text-primary" : ""}`}
+            className={`min-w-0 truncate bg-transparent px-0 text-left text--1 border-none cursor-pointer disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${isTemp(resource) ? "text-primary" : ""}`}
             title={resource.name}
             onClick={onSelect}
             disabled={disabled}

--- a/frontend/src/features/resources/ManageResourcesPage.jsx
+++ b/frontend/src/features/resources/ManageResourcesPage.jsx
@@ -491,13 +491,15 @@ function ResourceNameField({
         </div>
       ) : (
         <>
-          <a
-            className={`text--1 truncate ${isTemp(resource) ? "text-primary" : ""}`}
+          <button
+            type="button"
+            className={`btn btn-phantom btn-xs min-w-0 justify-start truncate px-0 text--1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${isTemp(resource) ? "text-primary" : ""}`}
             title={resource.name}
-            onClick={() => !disabled && onSelect()}
+            onClick={onSelect}
+            disabled={disabled}
           >
             {resource.name}
-          </a>
+          </button>
           <button
             type="button"
             className="btn btn-phantom btn-xs px-0"

--- a/frontend/src/features/resources/ManageResourcesPage.jsx
+++ b/frontend/src/features/resources/ManageResourcesPage.jsx
@@ -2,7 +2,13 @@ import React, { useEffect, useRef, useState, useContext } from "react";
 import toast from "react-hot-toast";
 import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
-import { ArrowLeftIcon, PencilIcon, PlusIcon, XIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  CheckIcon,
+  PencilIcon,
+  PlusIcon,
+  XIcon,
+} from "lucide-react";
 import AddGroup from "./components/AddGroup";
 import StateConditionalMenu from "../../components/StateVariables/StateConditionalMenu";
 import { api } from "../../util/api";
@@ -296,76 +302,63 @@ export default function ManageResourcesPage() {
                               )}
                               {resource.children.map((child) => (
                                 <li key={child._id} className="overflow-hidden">
-                                  <div
-                                    className="grid items-center gap-1 overflow-hidden"
-                                    style={{
-                                      gridTemplateColumns:
-                                        "minmax(0, 1fr) auto",
-                                    }}
-                                  >
-                                    <ResourceNameField
-                                      resource={child}
-                                      disabled={isTemp(child)}
-                                      onSelect={() =>
-                                        setSelectedResourceId(child._id)
-                                      }
-                                      onRename={(name) =>
-                                        renameResourceMutation.mutate({
-                                          resourceId: child._id,
-                                          name,
-                                        })
-                                      }
-                                    />
-                                    <button
-                                      className="btn btn-phantom btn-xs px-0"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        deleteResourceMutation.mutate(
-                                          child._id
-                                        );
-                                      }}
-                                      title="Delete file"
-                                      disabled={isTemp(child)}
-                                    >
-                                      <XIcon size={16} />
-                                    </button>
-                                  </div>
+                                  <ResourceNameField
+                                    resource={child}
+                                    disabled={isTemp(child)}
+                                    onSelect={() =>
+                                      setSelectedResourceId(child._id)
+                                    }
+                                    onRename={(name) =>
+                                      renameResourceMutation.mutate({
+                                        resourceId: child._id,
+                                        name,
+                                      })
+                                    }
+                                    actions={
+                                      <button
+                                        className="btn btn-phantom btn-xs px-0"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          deleteResourceMutation.mutate(
+                                            child._id
+                                          );
+                                        }}
+                                        title="Delete file"
+                                        disabled={isTemp(child)}
+                                      >
+                                        <XIcon size={16} />
+                                      </button>
+                                    }
+                                  />
                                 </li>
                               ))}
                             </ul>
                           </details>
                         ) : (
-                          <div
-                            className="grid items-center gap-1 overflow-hidden"
-                            style={{
-                              gridTemplateColumns: "minmax(0, 1fr) auto",
-                            }}
-                          >
-                            <ResourceNameField
-                              resource={resource}
-                              disabled={isTemp(resource)}
-                              onSelect={() =>
-                                setSelectedResourceId(resource._id)
-                              }
-                              onRename={(name) =>
-                                renameResourceMutation.mutate({
-                                  resourceId: resource._id,
-                                  name,
-                                })
-                              }
-                            />
-                            <button
-                              className="btn btn-phantom btn-xs px-0"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                deleteResourceMutation.mutate(resource._id);
-                              }}
-                              title="Delete file"
-                              disabled={isTemp(resource)}
-                            >
-                              <XIcon size={16} />
-                            </button>
-                          </div>
+                          <ResourceNameField
+                            resource={resource}
+                            disabled={isTemp(resource)}
+                            onSelect={() => setSelectedResourceId(resource._id)}
+                            onRename={(name) =>
+                              renameResourceMutation.mutate({
+                                resourceId: resource._id,
+                                name,
+                              })
+                            }
+                            actions={
+                              <button
+                                className="btn btn-phantom btn-xs px-0"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  deleteResourceMutation.mutate(resource._id);
+                                }}
+                                title="Delete file"
+                                disabled={isTemp(resource)}
+                              >
+                                <XIcon size={16} />
+                              </button>
+                            }
+                          />
                         )}
                       </li>
                     ))}
@@ -405,7 +398,13 @@ function splitFileName(name) {
   return { base: name.slice(0, dotIndex), ext: name.slice(dotIndex) };
 }
 
-function ResourceNameField({ resource, disabled, onSelect, onRename }) {
+function ResourceNameField({
+  resource,
+  disabled,
+  onSelect,
+  onRename,
+  actions,
+}) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(() => splitFileName(resource.name).base);
   const inputRef = useRef(null);
@@ -415,7 +414,6 @@ function ResourceNameField({ resource, disabled, onSelect, onRename }) {
   useEffect(() => {
     if (editing) {
       inputRef.current?.focus();
-      inputRef.current?.select();
     }
   }, [editing]);
 
@@ -445,53 +443,84 @@ function ResourceNameField({ resource, disabled, onSelect, onRename }) {
     }
   }
 
-  if (editing) {
-    return (
-      <div className="flex min-w-0 items-center gap-1">
-        <input
-          ref={inputRef}
-          type="text"
-          className="input input-xs input-bordered min-w-0 flex-1"
-          value={value}
-          maxLength={Math.max(RESOURCE_NAME_MAX_LENGTH - ext.length, 1)}
-          onChange={(e) => setValue(e.target.value)}
-          onBlur={commitEdit}
-          onKeyDown={handleKeyDown}
-          onClick={(e) => e.stopPropagation()}
-        />
-        {ext && (
-          <span
-            className="shrink-0 text--1 opacity-60"
-            title="File type can't be changed"
-          >
-            {ext}
-          </span>
-        )}
-      </div>
-    );
-  }
+  const rowStyle = editing
+    ? {
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        backgroundColor: "transparent",
+        boxShadow: "none",
+        color: "var(--color-base-content)",
+        cursor: "auto",
+      }
+    : { gridTemplateColumns: "minmax(0, 1fr) auto auto" };
 
   return (
-    <div
-      className="grid items-center gap-1 overflow-hidden"
-      style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
-    >
-      <a
-        className={`text--1 truncate ${isTemp(resource) ? "text-primary" : ""}`}
-        title={resource.name}
-        onClick={() => !disabled && onSelect()}
-      >
-        {resource.name}
-      </a>
-      <button
-        type="button"
-        className="btn btn-phantom btn-xs px-0"
-        onClick={startEditing}
-        title="Rename"
-        disabled={disabled}
-      >
-        <PencilIcon size={14} />
-      </button>
+    <div className="grid items-center gap-1 overflow-hidden" style={rowStyle}>
+      {editing ? (
+        <div className="flex min-w-0 items-center gap-1">
+          <input
+            ref={inputRef}
+            type="text"
+            className="input input-xs input-bordered min-w-0 flex-1"
+            style={{
+              "--input-color":
+                "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+              backgroundColor: "var(--color-base-100)",
+              borderColor:
+                "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+              color: "var(--color-base-content)",
+              boxShadow: "none",
+              outline: "none",
+              userSelect: "text",
+              WebkitUserSelect: "text",
+            }}
+            value={value}
+            maxLength={Math.max(RESOURCE_NAME_MAX_LENGTH - ext.length, 1)}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={commitEdit}
+            onKeyDown={handleKeyDown}
+            onClick={(e) => e.stopPropagation()}
+          />
+          {ext && (
+            <span
+              className="shrink-0 text--1 opacity-60"
+              title="File type can't be changed"
+            >
+              {ext}
+            </span>
+          )}
+        </div>
+      ) : (
+        <>
+          <a
+            className={`text--1 truncate ${isTemp(resource) ? "text-primary" : ""}`}
+            title={resource.name}
+            onClick={() => !disabled && onSelect()}
+          >
+            {resource.name}
+          </a>
+          <button
+            type="button"
+            className="btn btn-phantom btn-xs px-0"
+            onClick={startEditing}
+            title="Rename"
+            disabled={disabled}
+          >
+            <PencilIcon size={14} />
+          </button>
+        </>
+      )}
+      {editing ? (
+        <button
+          type="button"
+          className="btn btn-phantom btn-xs px-0"
+          onClick={() => inputRef.current?.blur()}
+          title="Confirm rename"
+        >
+          <CheckIcon size={14} />
+        </button>
+      ) : (
+        actions
+      )}
     </div>
   );
 }

--- a/frontend/src/features/resources/ResourcePreview.jsx
+++ b/frontend/src/features/resources/ResourcePreview.jsx
@@ -9,7 +9,19 @@ async function loadText(url) {
   });
 }
 
-async function downloadFile(url, name) {
+function fileTypeLabel(file) {
+  if (file.extension) return file.extension.slice(1).toUpperCase();
+  const subtype = file.contentType?.split("/")[1];
+  return subtype ? subtype.toUpperCase() : null;
+}
+
+function downloadFilename(name, extension) {
+  const trimmed = name?.trim() || "";
+  if (!extension || trimmed.toLowerCase().endsWith(extension)) return trimmed;
+  return `${trimmed}${extension}`;
+}
+
+async function downloadFile(url, name, extension) {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`failed to load file (${res.status})`);
   const blob = await res.blob();
@@ -17,7 +29,7 @@ async function downloadFile(url, name) {
 
   const link = document.createElement("a");
   link.href = blobUrl;
-  link.download = name || "";
+  link.download = downloadFilename(name, extension);
   document.body.appendChild(link);
   link.click();
 
@@ -52,16 +64,27 @@ function ResourcePreview({ file }) {
   const isImage = file.fileType === "image";
   const isText = canPreviewText;
   const isPDF = file.contentType === "application/pdf";
+  const typeLabel = fileTypeLabel(file);
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 p-3 font-ibm">
       <div className="flex items-start justify-between gap-2">
-        <h3 className="text-m min-w-0 break-all">{file.name}</h3>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <h3 className="text-m min-w-0 break-all">{file.name}</h3>
+          {typeLabel && (
+            <span
+              className="badge badge-ghost badge-sm shrink-0"
+              title={`File type: ${typeLabel}`}
+            >
+              {typeLabel}
+            </span>
+          )}
+        </div>
         <button
           type="button"
           className="btn btn-phantom btn-xs shrink-0"
           onClick={() =>
-            downloadFile(file.url, file.name).catch((err) => {
+            downloadFile(file.url, file.name, file.extension).catch((err) => {
               console.error("Failed to download file:", err);
               toast.error("Failed to download file. Please try again.");
             })

--- a/frontend/src/features/resources/ResourcePreview.jsx
+++ b/frontend/src/features/resources/ResourcePreview.jsx
@@ -38,9 +38,9 @@ function ResourcePreview({ file }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 p-3 font-ibm">
-      <div className="flex items-center justify-between gap-2">
-        <h3 className="text-m truncate">{file.name}</h3>
-        <a className="btn btn-phantom btn-xs" href={file.url} download>
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-m min-w-0 break-all">{file.name}</h3>
+        <a className="btn btn-phantom btn-xs shrink-0" href={file.url} download>
           Download
         </a>
       </div>

--- a/frontend/src/features/resources/ResourcePreview.jsx
+++ b/frontend/src/features/resources/ResourcePreview.jsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import toast from "react-hot-toast";
 import MDTextViewer from "../playScenario/components/MDTextViewer";
 
 async function loadText(url) {
@@ -60,9 +61,10 @@ function ResourcePreview({ file }) {
           type="button"
           className="btn btn-phantom btn-xs shrink-0"
           onClick={() =>
-            downloadFile(file.url, file.name).catch((err) =>
-              console.error("Failed to download file:", err)
-            )
+            downloadFile(file.url, file.name).catch((err) => {
+              console.error("Failed to download file:", err);
+              toast.error("Failed to download file. Please try again.");
+            })
           }
         >
           Download

--- a/frontend/src/features/resources/ResourcePreview.jsx
+++ b/frontend/src/features/resources/ResourcePreview.jsx
@@ -8,6 +8,22 @@ async function loadText(url) {
   });
 }
 
+async function downloadFile(url, name) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`failed to load file (${res.status})`);
+  const blob = await res.blob();
+  const blobUrl = window.URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = name || "";
+  document.body.appendChild(link);
+  link.click();
+
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(blobUrl);
+}
+
 function ResourcePreview({ file }) {
   const canPreviewText = !!(
     file?.fileType === "document" &&
@@ -40,9 +56,17 @@ function ResourcePreview({ file }) {
     <div className="flex h-full min-h-0 flex-col gap-3 p-3 font-ibm">
       <div className="flex items-start justify-between gap-2">
         <h3 className="text-m min-w-0 break-all">{file.name}</h3>
-        <a className="btn btn-phantom btn-xs shrink-0" href={file.url} download>
+        <button
+          type="button"
+          className="btn btn-phantom btn-xs shrink-0"
+          onClick={() =>
+            downloadFile(file.url, file.name).catch((err) =>
+              console.error("Failed to download file:", err)
+            )
+          }
+        >
           Download
-        </a>
+        </button>
       </div>
 
       <div className="min-h-0 flex-1">

--- a/frontend/src/features/resources/components/ResourceNameField.jsx
+++ b/frontend/src/features/resources/components/ResourceNameField.jsx
@@ -61,6 +61,7 @@ export default function ResourceNameField({
         <input
           ref={inputRef}
           type="text"
+          aria-label={`Rename ${resource.name}`}
           className="input input-xs input-bordered min-w-0"
           style={{
             "--input-color":

--- a/frontend/src/features/resources/components/ResourceNameField.jsx
+++ b/frontend/src/features/resources/components/ResourceNameField.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { CheckIcon, PencilIcon } from "lucide-react";
+import { isTemp } from "../util";
+
+const RESOURCE_NAME_MAX_LENGTH = 255;
+
+export default function ResourceNameField({
+  resource,
+  disabled,
+  onSelect,
+  onRename,
+  actions,
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(resource.name);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+    }
+  }, [editing]);
+
+  function startEditing(e) {
+    e.stopPropagation();
+    if (disabled) return;
+    setValue(resource.name);
+    setEditing(true);
+  }
+
+  function commitEdit() {
+    setEditing(false);
+    const trimmedName = value.trim();
+    if (!trimmedName || trimmedName === resource.name) return;
+    onRename(trimmedName);
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      inputRef.current?.blur();
+    } else if (e.key === "Escape") {
+      setValue(resource.name);
+      setEditing(false);
+    }
+  }
+
+  const rowStyle = editing
+    ? {
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        backgroundColor: "transparent",
+        boxShadow: "none",
+        color: "var(--color-base-content)",
+        cursor: "auto",
+      }
+    : { gridTemplateColumns: "minmax(0, 1fr) auto auto" };
+
+  return (
+    <div className="grid items-center gap-1 overflow-hidden" style={rowStyle}>
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          className="input input-xs input-bordered min-w-0"
+          style={{
+            "--input-color":
+              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+            backgroundColor: "var(--color-base-100)",
+            borderColor:
+              "color-mix(in oklab, var(--color-base-content) 20%, transparent)",
+            color: "var(--color-base-content)",
+            boxShadow: "none",
+            outline: "none",
+            userSelect: "text",
+            WebkitUserSelect: "text",
+          }}
+          value={value}
+          maxLength={RESOURCE_NAME_MAX_LENGTH}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <>
+          <button
+            type="button"
+            className={`min-w-0 truncate bg-transparent px-0 text-left text--1 border-none cursor-pointer disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${isTemp(resource) ? "text-primary" : ""}`}
+            title={resource.name}
+            onClick={onSelect}
+            disabled={disabled}
+          >
+            {resource.name}
+          </button>
+          <button
+            type="button"
+            className="btn btn-phantom btn-xs px-0"
+            onClick={startEditing}
+            title="Rename"
+            disabled={disabled}
+          >
+            <PencilIcon size={14} />
+          </button>
+        </>
+      )}
+      {editing ? (
+        <button
+          type="button"
+          className="btn btn-phantom btn-xs px-0"
+          onClick={() => inputRef.current?.blur()}
+          title="Confirm rename"
+        >
+          <CheckIcon size={14} />
+        </button>
+      ) : (
+        actions
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/resources/util.js
+++ b/frontend/src/features/resources/util.js
@@ -1,3 +1,7 @@
+export function isTemp(resource) {
+  return resource._id.startsWith("temp.");
+}
+
 export function getExtension(name) {
   if (!name) return "";
   const dotIndex = name.lastIndexOf(".");

--- a/frontend/src/features/resources/util.js
+++ b/frontend/src/features/resources/util.js
@@ -5,7 +5,9 @@ export function isTemp(resource) {
 export function getExtension(name) {
   if (!name) return "";
   const dotIndex = name.lastIndexOf(".");
-  return dotIndex <= 0 ? "" : name.slice(dotIndex).toLowerCase();
+  return dotIndex <= 0 || dotIndex === name.length - 1
+    ? ""
+    : name.slice(dotIndex).toLowerCase();
 }
 
 export function normaliseFile(resource) {

--- a/frontend/src/features/resources/util.js
+++ b/frontend/src/features/resources/util.js
@@ -1,3 +1,9 @@
+export function getExtension(name) {
+  if (!name) return "";
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex <= 0 ? "" : name.slice(dotIndex).toLowerCase();
+}
+
 export function normaliseFile(resource) {
   return {
     _id: resource._id,
@@ -10,6 +16,7 @@ export function normaliseFile(resource) {
     fileType: resource.fileId?.type,
     contentType: resource.fileId?.contentType,
     size: resource.fileId?.size,
+    extension: getExtension(resource.fileId?.name),
   };
 }
 


### PR DESCRIPTION
## Issue

Users had no way to rename an uploaded resource from the Manage Resources page. Fixing a typo or renaming a file required deleting it and re-uploading, losing any state conditionals or references already set up on it. Separately, the "Download" button on a resource's preview didn't reliably download the file, meaning for cross-origin file URLs (e.g. Firebase Storage), the browser would just open/navigate to the file instead of saving it.

## Solution

- Added `PATCH /api/resources/:scenarioId/:resourceId` to rename a resource (file or collection), with server-side validation (non-blank, ≤255 chars).
- File resources have their extension locked. The rename endpoint rejects any attempt to change a file's extension, so it can't accidentally be mislabeled as a different type.
- Added inline rename UI to the resources list: a pencil icon toggles into a text input, with the file extension shown as a fixed, non-editable suffix. A checkmark button replaces the delete button while editing, so an accidental click can't delete the resource mid-rename.
- Fixed text overflow: long resource names now truncate with an ellipsis (and wrap instead of overflowing in the preview panel) rather than pushing the delete/edit controls off-screen.
- Fixed the resource preview's Download button: it now fetches the file and downloads it via a blob URL instead of relying on the native `download` attribute, which browsers ignore for cross-origin file URLs.

## Risk

- File renames are now validated server-side (255-char limit, extension lock) — any existing script or integration that renames resources with a different extension will start receiving a 400 where it previously succeeded.
- Collections (groups) can be renamed via the API and are covered by a backend test, but adding a button for it in the app seemed like a separate issue that was out of scope for this ticket, meaning that only file resources are renameable from the page for now.
- Download now fetches the whole file into memory client-side before saving it, rather than letting the browser stream it directly. This is worth keeping an eye on for very large files.

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [x] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline renaming for files and collections from the resource management page.
  * Resource names are trimmed and limited to 255 characters.
  * Added safer resource downloads with file-type labels and appropriate filenames.
* **Bug Fixes**
  * Improved display of long names with wrapping and truncation.
  * Rename failures now restore the previous name and refresh resource data.
  * Added clearer feedback when downloads or rename actions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->