### PR TITLE
chore: move fab menu to top right of page

### DIFF
--- a/frontend/src/components/FabMenu.jsx
+++ b/frontend/src/components/FabMenu.jsx
@@ -7,7 +7,7 @@ import {
   UsersRoundIcon,
 } from "lucide-react";
 
-const FabMenu = () => {
+const FabMenu = ({ className }) => {
   const history = useHistory();
 
   const handleThemeToggle = () => {
@@ -25,39 +25,39 @@ const FabMenu = () => {
 
   return (
     <div
-      className={`fixed bottom-xl right-xl z-3 ${open ? "pointer-events-auto" : "pointer-events-none"}`}
+      className={`fixed z-3 ${open ? "pointer-events-auto" : "pointer-events-none"} ${className}`}
       onMouseLeave={() => setOpen(false)}
     >
-      <div className="flex flex-col items-end gap-4">
+      <div className="flex flex-col items-end gap-2">
+        <div className="p-2">
+          <button
+            onMouseEnter={() => setOpen(true)}
+            className={`flex items-center justify-center transition-all duration-300 rounded-xs rotate-45 cursor-pointer border-1 pointer-events-auto w-8 h-8 ${open ? "border-secondary bg-secondary text-base-100" : "border-primary bg-base-100"}`}
+            aria-label="Open Menu"
+          >
+            <EllipsisVerticalIcon size={16} className="-rotate-45" />
+          </button>
+        </div>
         <div className="p-2">
           <label
-            className={`swap swap-rotate transition-all duration-300 w-12 h-12 rounded-xs rotate-45 cursor-pointer bg-base-100 border-1 border-primary ${open ? "opacity-100" : "opacity-0 pointer-events-none"} `}
+            className={`swap swap-rotate transition-all duration-300 rounded-xs rotate-45 cursor-pointer bg-base-100 border-1 border-primary w-8 h-8 ${open ? "opacity-100" : "opacity-0 pointer-events-none"} `}
           >
             <input
               type="checkbox"
               className="theme-controller"
               onChange={handleThemeToggle}
             />
-            <SunIcon size={20} className="swap-off fill-current" />
-            <MoonIcon size={20} className="swap-on fill-current" />
+            <SunIcon size={16} className="swap-off fill-current" />
+            <MoonIcon size={16} className="swap-on fill-current" />
           </label>
         </div>
         <div className="p-2">
           <button
-            className={`flex items-center justify-center transition-all duration-300 w-12 h-12 rounded-xs rotate-45 cursor-pointer bg-base-100 border-1 border-primary ${open ? "opacity-100" : "opacity-0 pointer-events-none"} `}
+            className={`flex items-center justify-center transition-all duration-300 rounded-xs rotate-45 cursor-pointer bg-base-100 border-1 border-primary w-8 h-8 ${open ? "opacity-100" : "opacity-0 pointer-events-none"} `}
             onClick={() => history.push("/aboutus")}
             aria-label="About Us"
           >
-            <UsersRoundIcon size={20} className="-rotate-45" />
-          </button>
-        </div>
-        <div className="p-2">
-          <button
-            onMouseEnter={() => setOpen(true)}
-            className={`flex items-center justify-center transition-all duration-300 w-12 h-12 rounded-xs rotate-45 cursor-pointer border-1 pointer-events-auto ${open ? "border-secondary bg-secondary text-base-100" : "border-primary bg-base-100"}`}
-            aria-label="Open Menu"
-          >
-            <EllipsisVerticalIcon size={20} className="-rotate-45" />
+            <UsersRoundIcon size={16} className="-rotate-45" />
           </button>
         </div>
       </div>

--- a/frontend/src/features/TopNavBar/TopNavBar.jsx
+++ b/frontend/src/features/TopNavBar/TopNavBar.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import AuthenticationContext from "../../context/AuthenticationContext";
 import { LogOutIcon } from "lucide-react";
+import FabMenu from "../../components/FabMenu";
 
 export default function TopNavBar() {
   const { signOut } = useContext(AuthenticationContext);
@@ -20,8 +21,8 @@ export default function TopNavBar() {
 
   return (
     <div className="fixed top-0 left-0 right-0 bg-base-100 pl-xl pr-[calc(var(--spacing-xl)+7.5rem)] flex border-b-1 font-dm border-gradient z-1">
-      <div className="py-m w-30 -mb-[1px]">
-        <button onClick={handleLogout} className="btn btn-phantom text-m">
+      <div className="pt-l w-30 -mb-[1px]">
+        <button onClick={handleLogout} className="btn btn-phantom text-m px-0">
           <LogOutIcon size={20} />
           <span>Logout</span>
         </button>
@@ -46,6 +47,7 @@ export default function TopNavBar() {
           Create & Edit
         </button>
       </div>
+      <FabMenu className="right-xl top-l" />
     </div>
   );
 }

--- a/frontend/src/features/aboutUs/AboutUsPage.jsx
+++ b/frontend/src/features/aboutUs/AboutUsPage.jsx
@@ -33,12 +33,13 @@ const AboutUsPage = () => {
   return (
     <div className="flex h-screen w-screen relative bg-base-100 font-dm font-normal">
       <button
-        className="absolute top-8 left-8 bg-transparent border-none p-2 cursor-pointer z-10"
+        className="absolute top-l left-xl bg-transparent border-none cursor-pointer z-10"
         onClick={goBack}
         aria-label="Close"
       >
         <XIcon size={32} />
       </button>
+      <FabMenu className="top-l right-xl" />
       <div className="w-1/2 flex flex-col justify-center items-center bg-base-100">
         <div className="flex flex-col items-start leading-tight text-base-content font-normal text-[5vw] mb-[10vh]">
           <span>Virtual</span>
@@ -96,8 +97,6 @@ const AboutUsPage = () => {
           </div>
         </div>
       </div>
-
-      <FabMenu />
     </div>
   );
 };

--- a/frontend/src/features/create/CreateLandingPage.jsx
+++ b/frontend/src/features/create/CreateLandingPage.jsx
@@ -5,7 +5,6 @@ import Thumbnail from "../authoring/components/Thumbnail";
 import ModalDialog from "../../components/ModalDialogue";
 import DetailEditModal from "../scenarioInfo/components/DetailEditModal";
 import TopNavBar from "../../features/TopNavBar/TopNavBar";
-import FabMenu from "../../components/FabMenu";
 import { PlusIcon, SearchIcon, Trash2Icon } from "lucide-react";
 import { handle } from "../../components/ContextMenu/portal";
 import RightContextMenu from "../../components/ContextMenu/RightContextMenu";
@@ -136,8 +135,6 @@ export default function CreateLandingPage() {
           onSave={handleCreate}
         />
       </ModalDialog>
-
-      <FabMenu />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/DashboardLandingPage.jsx
+++ b/frontend/src/features/dashboard/DashboardLandingPage.jsx
@@ -4,7 +4,6 @@ import ScenarioContext from "../../context/ScenarioContext";
 import TopNavBar from "../TopNavBar/TopNavBar";
 import Thumbnail from "../authoring/components/Thumbnail";
 import { SearchIcon } from "lucide-react";
-import FabMenu from "../../components/FabMenu";
 
 export default function DashboardLandingPage() {
   const { allScenarios } = useContext(ScenarioContext);
@@ -65,8 +64,6 @@ export default function DashboardLandingPage() {
           </div>
         ))}
       </div>
-
-      <FabMenu />
     </div>
   );
 }

--- a/frontend/src/features/playScenario/PlayLandingPage.jsx
+++ b/frontend/src/features/playScenario/PlayLandingPage.jsx
@@ -3,7 +3,6 @@ import { useHistory } from "react-router-dom";
 import ScenarioContext from "../../context/ScenarioContext";
 import Thumbnail from "../authoring/components/Thumbnail";
 import TopNavBar from "../../features/TopNavBar/TopNavBar";
-import FabMenu from "../../components/FabMenu";
 import { SearchIcon } from "lucide-react";
 
 export default function PlayLandingPage() {
@@ -67,8 +66,6 @@ export default function PlayLandingPage() {
           </div>
         ))}
       </div>
-
-      <FabMenu />
     </div>
   );
 }

--- a/frontend/src/features/scenarioInfo/ScenarioInfo.jsx
+++ b/frontend/src/features/scenarioInfo/ScenarioInfo.jsx
@@ -54,12 +54,13 @@ function ScenarioInfo() {
     <div className="bg-base-100 text-base-content">
       {/* Responsive Container optimised for 900x500 min to 1600x900 max */}
       <button
-        className="fixed z-10 btn btn-phantom text-m ml-xl mt-l font-dm px-0"
+        className="fixed z-10 btn btn-phantom text-m left-xl top-l font-dm px-0"
         onClick={handleBackToPlay}
       >
         <ArrowLeftIcon size={20} />
         Back
       </button>
+      <FabMenu className="right-xl top-l" />
       <div className="min-w-[900px] max-w-[1500px] mx-auto flex gap-3xl px-xl">
         {/* Sidebar */}
         {/* the calc used in the padding top is to get the searchbar to align with the scenario metadata, by imitating the same sizing flow */}
@@ -210,8 +211,6 @@ function ScenarioInfo() {
           onClose={() => setShowEditModal(false)}
         />
       </ModalDialog>
-
-      <FabMenu />
     </div>
   );
 }


### PR DESCRIPTION
## Issue

Fab menu looks wierd on bottom right on scenario info, overlapping the play button.

<img width="1561" height="835" alt="image" src="https://github.com/user-attachments/assets/19de548b-1b8f-480d-893e-1b156c2d11e6" />

<img width="1561" height="826" alt="image" src="https://github.com/user-attachments/assets/d14d1681-ab75-480a-b728-13a32ef2f7e1" />

<img width="1579" height="864" alt="image" src="https://github.com/user-attachments/assets/9a10a7ac-bf13-4992-9603-f9949ac0fbe2" />

<img width="1593" height="840" alt="image" src="https://github.com/user-attachments/assets/f5aa0f55-3fc1-425f-b712-706c5366ee6c" />


## Solution

Moved it from bottom right to top right on all pages.

## Risk

Nada.

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing
