### PR TITLE
fix: standardise scenario dedup

### DIFF
--- a/frontend/src/features/create/CreateLandingPage.jsx
+++ b/frontend/src/features/create/CreateLandingPage.jsx
@@ -9,6 +9,7 @@ import { PlusIcon, SearchIcon, Trash2Icon } from "lucide-react";
 import { handle } from "../../components/ContextMenu/portal";
 import RightContextMenu from "../../components/ContextMenu/RightContextMenu";
 import DeleteScenarioModal from "./DeleteScenarioModal";
+import { dedupById } from "../../util/dedup";
 
 const ScenarioMenu = ({ scenario, requestDelete }) => {
   return (
@@ -32,14 +33,10 @@ export default function CreateLandingPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [scenarioToDelete, setScenarioToDelete] = useState(null);
 
-  const scenarios = Array.from(
-    new Map(
-      [...allScenarios.owned, ...allScenarios.accessible].map((scenario) => [
-        scenario._id,
-        scenario,
-      ])
-    ).values()
-  );
+  const scenarios = dedupById([
+    ...allScenarios.owned,
+    ...allScenarios.accessible,
+  ]);
 
   const filteredScenarios = scenarios.filter((scenario) =>
     scenario.name.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/features/dashboard/DashboardLandingPage.jsx
+++ b/frontend/src/features/dashboard/DashboardLandingPage.jsx
@@ -4,6 +4,7 @@ import ScenarioContext from "../../context/ScenarioContext";
 import TopNavBar from "../TopNavBar/TopNavBar";
 import Thumbnail from "../authoring/components/Thumbnail";
 import { SearchIcon } from "lucide-react";
+import { dedupById } from "../../util/dedup";
 
 export default function DashboardLandingPage() {
   const { allScenarios } = useContext(ScenarioContext);
@@ -11,14 +12,10 @@ export default function DashboardLandingPage() {
 
   const [search, setSearch] = useState("");
 
-  const scenarios = Array.from(
-    new Map(
-      [...allScenarios.owned, ...allScenarios.accessible].map((scenario) => [
-        scenario._id,
-        scenario,
-      ])
-    ).values()
-  );
+  const scenarios = dedupById([
+    ...allScenarios.owned,
+    ...allScenarios.accessible,
+  ]);
 
   const filteredScenarios = scenarios.filter((scenario) =>
     scenario.name.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/features/playScenario/PlayLandingPage.jsx
+++ b/frontend/src/features/playScenario/PlayLandingPage.jsx
@@ -4,6 +4,7 @@ import ScenarioContext from "../../context/ScenarioContext";
 import Thumbnail from "../authoring/components/Thumbnail";
 import TopNavBar from "../../features/TopNavBar/TopNavBar";
 import { SearchIcon } from "lucide-react";
+import { dedupById } from "../../util/dedup";
 
 export default function PlayLandingPage() {
   const { allScenarios } = useContext(ScenarioContext);
@@ -12,15 +13,11 @@ export default function PlayLandingPage() {
 
   const [search, setSearch] = useState("");
 
-  const scenarios = Array.from(
-    new Map(
-      [
-        ...allScenarios.owned,
-        ...allScenarios.assigned,
-        ...allScenarios.accessible,
-      ].map((scenario) => [scenario._id, scenario])
-    ).values()
-  );
+  const scenarios = dedupById([
+    ...allScenarios.owned,
+    ...allScenarios.assigned,
+    ...allScenarios.accessible,
+  ]);
 
   const filteredScenarios = scenarios.filter((scenario) =>
     scenario.name.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/features/scenarioInfo/ScenarioInfo.jsx
+++ b/frontend/src/features/scenarioInfo/ScenarioInfo.jsx
@@ -8,29 +8,30 @@ import FabMenu from "../../components/FabMenu";
 import { ArrowLeftIcon, SearchIcon } from "lucide-react";
 import ModalDialog from "../../components/ModalDialogue";
 import DetailEditModal from "./components/DetailEditModal";
+import { dedupById } from "../../util/dedup";
 
 function ScenarioInfo() {
-  const [search, setSearch] = useState("");
   const { user } = useContext(AuthenticationContext);
   const { allScenarios, updateScenarioDetails } = useContext(ScenarioContext);
 
   const history = useHistory();
   const location = useLocation();
 
+  const [search, setSearch] = useState("");
   const [showEditModal, setShowEditModal] = useState(false);
 
-  const scenarios = [
-    allScenarios.owned,
-    allScenarios.accessible,
-    allScenarios.assigned,
-  ].flat();
-
-  const selectedScenarioId = new URLSearchParams(location.search).get("id");
-  const selectedScenario = scenarios.find((s) => s._id === selectedScenarioId);
+  const scenarios = dedupById([
+    ...allScenarios.owned,
+    ...allScenarios.accessible,
+    ...allScenarios.assigned,
+  ]);
 
   const filteredScenarios = scenarios.filter((scenario) =>
     scenario.name.toLowerCase().includes(search.toLowerCase())
   );
+
+  const selectedScenarioId = new URLSearchParams(location.search).get("id");
+  const selectedScenario = scenarios.find((s) => s._id === selectedScenarioId);
 
   const handleScenarioSelect = (scenario) => {
     history.replace(`/scenario-info?id=${scenario._id}`);

--- a/frontend/src/util/dedup.ts
+++ b/frontend/src/util/dedup.ts
@@ -1,0 +1,3 @@
+export function dedupById<T extends { _id: string }>(arr: T[]): T[] {
+  return Array.from(new Map(arr.map((item) => [item._id, item])).values());
+}


### PR DESCRIPTION
## Issue

Scenario info page shows duplication scenario entries, due to the scenario appearing in both the owned and accessible lists.

## Solution

Use the existing dedup logic, but extact it out to a util function to ensure same implementation across all pages.

## Risk

Nada.

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when combining owned, assigned, and accessible scenarios across creation, dashboard, play, and scenario information views.
  * Prevented duplicate scenarios from appearing in lists while preserving existing search and selection behavior.

* **Refactor**
  * Centralized scenario deduplication to provide more consistent results across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->