### PR TITLE
chore: simplify left section of editor topbar

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -195,11 +195,15 @@ export default function AuthoringToolPage() {
     <>
       <div className="font-ibm flex flex-col h-screen w-screen overflow-hidden gap-m">
         <div className="flex pt-l px-l">
-          <button onClick={goBack} className="btn btn-phantom text-m px-0">
+          <button
+            onClick={goBack}
+            aria-label="Back"
+            className="btn btn-phantom text-m px-0"
+          >
             <ArrowLeftIcon size={20} />
           </button>
           {isOwner && (
-            <div className="flex flex-1 min-w-0 items-bottom">
+            <div className="flex flex-1 min-w-0">
               <button
                 onClick={() => setShowEditModal(true)}
                 className="btn btn-phantom text-m max-w-full min-w-0 tooltip tooltip-bottom"

--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -195,18 +195,20 @@ export default function AuthoringToolPage() {
     <>
       <div className="font-ibm flex flex-col h-screen w-screen overflow-hidden gap-m">
         <div className="flex pt-l px-l">
-          <button onClick={goBack} className="btn btn-phantom text-m">
+          <button onClick={goBack} className="btn btn-phantom text-m px-0">
             <ArrowLeftIcon size={20} />
-            Back
           </button>
           {isOwner && (
-            <div className="flex flex-1 min-w-0">
+            <div className="flex flex-1 min-w-0 items-bottom">
               <button
                 onClick={() => setShowEditModal(true)}
-                className="btn btn-phantom text-m max-w-full min-w-0"
+                className="btn btn-phantom text-m max-w-full min-w-0 tooltip tooltip-bottom"
+                data-tip="Edit Details"
               >
-                <PencilIcon size={20} className="shrink-0" />
-                <span className="min-w-0 truncate">{ownedScenario.name}</span>
+                <span className="min-w-0 flex items-baseline gap-2">
+                  <span className="truncate">{ownedScenario.name}</span>
+                  <PencilIcon size={14} className="shrink-0" />
+                </span>
               </button>
             </div>
           )}


### PR DESCRIPTION
## Issue

Top left section is unecessarily verbose, not similair to most tools.

## Solution

Removed the 'back' text, shrinked and moved the edit icon.

## Risk

Nada.

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the authoring page header with a compact icon-only back button.
  * Added an edit icon and tooltip support to the scenario name control.
  * Improved header spacing and alignment.
  * Enhanced accessibility with a descriptive label for the back button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->