### PR TITLE
Improve scene background modal UI

### DIFF
--- a/frontend/src/components/ListContainer/ImageListContainer.jsx
+++ b/frontend/src/components/ListContainer/ImageListContainer.jsx
@@ -5,15 +5,27 @@ export default function ImageListContainer({
   data,
   onItemSelected,
   selectedId,
+  horizontal = false,
 }) {
   return (
-    <div className="grid grid-cols-4 gap-2">
+    <div
+      className={
+        horizontal
+          ? "flex gap-2 overflow-x-auto pb-2"
+          : "grid grid-cols-4 gap-2"
+      }
+    >
       {data?.map((item) => (
         <button
           type="button"
           key={item._id}
           onClick={() => onItemSelected(item)}
-          className={item._id === selectedId ? "border-accent border-2" : ""}
+          className={`${horizontal ? "shrink-0" : ""} ${
+            item._id === selectedId ? "border-accent border-2" : ""
+          }`}
+          style={
+            horizontal ? { flexBasis: "calc((100% - 1.5rem) / 4)" } : undefined
+          }
         >
           <div
             className="aspect-square bg-cover bg-center hover:opacity-50 hover:cursor-pointer"

--- a/frontend/src/features/authoring/topbar/BackgroundMenu.tsx
+++ b/frontend/src/features/authoring/topbar/BackgroundMenu.tsx
@@ -19,6 +19,7 @@ import ModalDialog from "../../../components/ModalDialogue";
 import Thumbnail from "../components/Thumbnail";
 import useVisualScene from "../stores/visual";
 import useEditorStore from "../stores/editor";
+import ChromePicker from "../wrapper/ChromePicker";
 import { getScene } from "../scene/scene";
 import { modifySceneProp } from "../scene/operations/modifiers";
 import { getImages, uploadImage } from "../images";
@@ -83,7 +84,7 @@ function BackgroundMenu({
       setFit("cover");
     } else if (background.kind === "color") {
       setSource("color");
-      setColor(background.color.slice(0, 7));
+      setColor(background.color);
     } else {
       setSource("image");
       setFit(background.fit ?? "cover");
@@ -155,7 +156,7 @@ function BackgroundMenu({
   }
 
   return (
-    <ModalDialog wide title="Background" open={show} onClose={close}>
+    <ModalDialog wide title="Scene Background" open={show} onClose={close}>
       <div className="grid grid-cols-[minmax(20rem,1fr)_minmax(22rem,1.25fr)] gap-6 items-start">
         <div className="flex min-h-0 flex-col gap-4">
           <fieldset
@@ -163,31 +164,29 @@ function BackgroundMenu({
               source === "color" ? "border-accent" : "border-base-300"
             }`}
           >
-            <label className="flex cursor-pointer items-center gap-3">
-              <input
-                type="radio"
-                name="background-source"
-                className="radio radio-sm"
-                checked={source === "color"}
-                onChange={() => setSource("color")}
-              />
-              <span className="font-medium">Solid colour</span>
-            </label>
-            <div className="mt-3 flex items-center gap-3 pl-7">
-              <input
-                id="background-color"
-                type="color"
-                className="size-11 cursor-pointer rounded-sm bg-transparent"
-                value={color}
-                onFocus={() => setSource("color")}
-                onChange={(event) => {
-                  setColor(event.target.value);
-                  setSource("color");
-                }}
-              />
-              <label htmlFor="background-color" className="font-mono uppercase">
-                {color}
+            <div className="flex items-center justify-between gap-3">
+              <label className="flex cursor-pointer items-center gap-3">
+                <input
+                  type="radio"
+                  name="background-source"
+                  className="radio radio-sm"
+                  checked={source === "color"}
+                  onChange={() => setSource("color")}
+                />
+                <span className="text-sm font-medium">Solid colour</span>
               </label>
+              <div>
+                <ChromePicker
+                  compact
+                  value={color}
+                  tooltip="Choose background colour"
+                  onOpen={() => setSource("color")}
+                  onChange={(value) => {
+                    setColor(value);
+                    setSource("color");
+                  }}
+                />
+              </div>
             </div>
           </fieldset>
 
@@ -196,41 +195,20 @@ function BackgroundMenu({
               source === "image" ? "border-accent" : "border-base-300"
             }`}
           >
-            <label className="flex cursor-pointer items-center gap-3">
-              <input
-                type="radio"
-                name="background-source"
-                className="radio radio-sm"
-                checked={source === "image"}
-                onChange={() => setSource("image")}
-              />
-              <span className="font-medium">Image</span>
-            </label>
-
-            <div className="mt-3 flex items-end gap-3 pl-7">
-              <fieldset className="fieldset flex-1">
-                <label className="label" htmlFor="background-fit">
-                  Image fit
-                </label>
-                <select
-                  id="background-fit"
-                  className="select w-full"
-                  value={fit}
-                  onChange={(event) => {
-                    setFit(event.target.value as BackgroundFit);
-                    setSource("image");
-                  }}
-                >
-                  {fitOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </fieldset>
+            <div className="flex items-center justify-between gap-3">
+              <label className="flex cursor-pointer items-center gap-3">
+                <input
+                  type="radio"
+                  name="background-source"
+                  className="radio radio-sm"
+                  checked={source === "image"}
+                  onChange={() => setSource("image")}
+                />
+                <span className="text-sm font-medium">Image</span>
+              </label>
               <button
                 type="button"
-                className="btn"
+                className="btn btn-sm"
                 onClick={() => fileInputRef.current?.click()}
               >
                 <UploadIcon size={16} />
@@ -246,13 +224,14 @@ function BackgroundMenu({
               onChange={(event) => void handleFileChange(event)}
             />
 
-            <div className="mt-4 min-h-0 pl-7">
-              <p className="label mb-2">Uploaded images</p>
+            <div className="mt-4 min-h-0">
+              <p className="mb-2 text-sm">Uploaded images</p>
               {imagesQuery.isLoading ? (
-                <p>Loading images...</p>
+                <p className="text-sm">Loading images...</p>
               ) : imagesQuery.data?.length ? (
-                <div className="max-h-[28vh] overflow-y-auto pr-1">
+                <div className="min-w-0">
                   <ImageListContainer
+                    horizontal
                     data={imagesQuery.data}
                     selectedId={selectedImage?._id}
                     onItemSelected={(image: UploadedFile) => {
@@ -262,37 +241,36 @@ function BackgroundMenu({
                   />
                 </div>
               ) : (
-                <div className="rounded-sm bg-base-200 p-5 text-center">
+                <div className="rounded-sm bg-base-200 p-5 text-center text-sm">
                   No uploaded images yet.
                 </div>
               )}
             </div>
-          </fieldset>
 
-          <div className="flex items-center justify-between gap-3">
-            {background ? (
-              <button
-                type="button"
-                className="btn btn-ghost text-error"
-                onClick={removeBackground}
+            <fieldset className="fieldset mt-3">
+              <label className="label text-sm" htmlFor="background-fit">
+                Image fit
+              </label>
+              <select
+                id="background-fit"
+                className="select w-full"
+                value={fit}
+                onChange={(event) => {
+                  setFit(event.target.value as BackgroundFit);
+                  setSource("image");
+                }}
               >
-                Remove background
-              </button>
-            ) : (
-              <span />
-            )}
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!previewBackground}
-              onClick={applyBackground}
-            >
-              Apply background
-            </button>
-          </div>
+                {fitOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </fieldset>
+          </fieldset>
         </div>
 
-        <div className="sticky top-0">
+        <div className="sticky top-0 flex flex-col">
           <p className="label mb-2">Current scene preview</p>
           <div className="aspect-video w-full overflow-hidden rounded-sm border border-base-300 bg-base-200">
             <Thumbnail
@@ -306,6 +284,32 @@ function BackgroundMenu({
               Select or upload an image to preview it.
             </p>
           )}
+          <div className="mt-4 flex items-center justify-between gap-3">
+            {background ? (
+              <button
+                type="button"
+                className="btn btn-ghost text-error"
+                onClick={removeBackground}
+              >
+                Remove background
+              </button>
+            ) : (
+              <span />
+            )}
+            <div className="ml-auto flex items-center gap-3">
+              <button type="button" className="btn" onClick={close}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!previewBackground}
+                onClick={applyBackground}
+              >
+                Apply
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </ModalDialog>

--- a/frontend/src/features/authoring/topbar/Topbar.tsx
+++ b/frontend/src/features/authoring/topbar/Topbar.tsx
@@ -61,16 +61,6 @@ function Topbar({ saving, save }: { saving: boolean; save: () => void }) {
             Properties
           </button>
         </li>
-        <li className="text-xs">
-          <button
-            type="button"
-            className="p-1.5"
-            onClick={() => setShowBackgroundMenu(true)}
-          >
-            Background
-          </button>
-        </li>
-
         <div className="divider divider-horizontal" />
 
         <li className="tooltip tooltip-bottom" data-tip="Undo">
@@ -94,6 +84,14 @@ function Topbar({ saving, save }: { saving: boolean; save: () => void }) {
           </a>
         </li>
         <ShapeCreateMenu />
+
+        <div className="divider divider-horizontal" />
+
+        <li className="text-xs">
+          <button type="button" onClick={() => setShowBackgroundMenu(true)}>
+            Background
+          </button>
+        </li>
 
         {/* element properties */}
         {hasSelection && (

--- a/frontend/src/features/authoring/wrapper/ChromePicker.tsx
+++ b/frontend/src/features/authoring/wrapper/ChromePicker.tsx
@@ -58,7 +58,7 @@ function ChromePicker({
           className={`btn btn-sm gap-2 ${open ? "bg-base-100" : ""}`}
           aria-label={tooltip ?? "Choose colour"}
           onClick={() => {
-            onOpen?.();
+            if (!open) onOpen?.();
             setOpen(!open);
           }}
         >

--- a/frontend/src/features/authoring/wrapper/ChromePicker.tsx
+++ b/frontend/src/features/authoring/wrapper/ChromePicker.tsx
@@ -5,11 +5,15 @@ function ChromePicker({
   children,
   value,
   onChange,
+  onOpen,
   tooltip,
+  compact = false,
 }: React.PropsWithChildren<{
   value: string;
   onChange: (value: string) => void;
+  onOpen?: () => void;
   tooltip?: string;
+  compact?: boolean;
 }>) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -25,8 +29,54 @@ function ChromePicker({
     return () => document.removeEventListener("mousedown", handleClick, true);
   }, []);
 
+  const picker = open && (
+    <div
+      className={`z-20 absolute ${compact ? "right-0 top-full mt-2" : "top-[40px]"}`}
+    >
+      <Chrome
+        color={value}
+        onChange={(val) => {
+          const color = val.hexa;
+          const base = color.slice(0, 7);
+          const isNewColor = prevBase.current !== base; // if new color is the same as prev only alpha changes then doesnt update alpha when its == 0
+          prevBase.current = base;
+
+          const fixedColour =
+            isNewColor && color.slice(-2) === "00" ? `${base}ff` : color;
+
+          onChange(fixedColour);
+        }}
+      />
+    </div>
+  );
+
+  if (compact) {
+    return (
+      <div ref={ref} className="relative flex">
+        <button
+          type="button"
+          className={`btn btn-sm gap-2 ${open ? "bg-base-100" : ""}`}
+          aria-label={tooltip ?? "Choose colour"}
+          onClick={() => {
+            onOpen?.();
+            setOpen(!open);
+          }}
+        >
+          <span
+            className="size-4 rounded-xs border border-base-300"
+            style={{ backgroundColor: value }}
+          />
+          <span className="font-mono text-xs uppercase">
+            {value.slice(0, 7)}
+          </span>
+        </button>
+        {picker}
+      </div>
+    );
+  }
+
   return (
-    <div style={{ position: "relative", display: "flex" }}>
+    <div ref={ref} style={{ position: "relative", display: "flex" }}>
       <li
         className={tooltip ? "tooltip tooltip-bottom" : undefined}
         data-tip={tooltip}
@@ -43,24 +93,7 @@ function ChromePicker({
           </div>
         </a>
       </li>
-      {open && (
-        <div ref={ref} className="z-1 absolute top-[40px]">
-          <Chrome
-            color={value}
-            onChange={(val) => {
-              const color = val.hexa;
-              const base = color.slice(0, 7);
-              const isNewColor = prevBase.current !== base; // if new color is the same as prev only alpha changes then doesnt update alpha when its == 0
-              prevBase.current = base;
-
-              const fixedColour =
-                isNewColor && color.slice(-2) === "00" ? `${base}ff` : color;
-
-              onChange(fixedColour);
-            }}
-          />
-        </div>
-      )}
+      {picker}
     </div>
   );
 }


### PR DESCRIPTION
## Issue

The scene background controls were visually inconsistent with the rest of the authoring interface. The toolbar action was separated from the element creation controls, while the modal used oversized labels and controls, a vertically growing image library, and actions split across different columns.

## Solution

- Rename the modal to **Scene Background** and move the toolbar action beside Add Shape with a separator.
- Place the colour picker and upload action inline with their respective radio controls.
- Reorder the uploaded image library above the image-fit selector, show four images at once, and allow horizontal scrolling.
- Expand the image-fit selector and move Remove background, Cancel, and Apply beneath the scene preview.
- Preserve draft changes until Apply; Cancel and close discard them, while Remove background applies immediately and closes the modal.

<img width="2540" height="1260" alt="Scene Background modal UI" src="https://github.com/user-attachments/assets/8ffb1620-85ec-4abd-bb40-13b0fd73f7e2" />

## Risk

Low. The shared colour picker and image list components gained opt-in compact and horizontal modes while retaining their existing defaults. Frontend formatting, lint, unit tests, and the production build pass locally.

## Checklist

- [x] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added horizontal scrolling support for image lists.
  * Introduced a redesigned Scene Background menu with improved color and image controls.
  * Added compact color-picker controls and a Cancel action for background changes.

* **Improvements**
  * Preserved full selected color values for more precise background customization.
  * Reorganized background controls in the top toolbar.
  * Improved loading, empty-state, image layout, and image-fit presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->