### PR TITLE
VPS-89 and VPS-171/Subscript, Superscript, and Bullet Points

### DIFF
--- a/frontend/src/features/authoring/canvas/handles/ConstrainedHandle.tsx
+++ b/frontend/src/features/authoring/canvas/handles/ConstrainedHandle.tsx
@@ -12,6 +12,7 @@ const ResizeHandle = ({ x, y }: Props) => {
   const mode = useEditorStore((s) => s.mode);
 
   const bounds = getSelectedComponentBounds();
+  if (!bounds) return null;
   const verts = bounds.verts;
 
   let point = {

--- a/frontend/src/features/authoring/canvas/handles/RotationHandle.tsx
+++ b/frontend/src/features/authoring/canvas/handles/RotationHandle.tsx
@@ -7,6 +7,7 @@ const RotationHandle = () => {
   const mode = useEditorStore((s) => s.mode);
 
   const bounds = getSelectedComponentBounds();
+  if (!bounds) return null;
   const center = getBoxCenter(bounds.verts);
 
   const y = Math.min(bounds.verts[0].y, bounds.verts[1].y);

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -1,5 +1,6 @@
 import { modifyComponentProp } from "../../scene/operations/component";
 import { remove } from "../../scene/operations/modifiers";
+import { indentBlocks, setBlockListStyle } from "../../scene/operations/text";
 import useEditorStore from "../../stores/editor";
 import type { Vec2 } from "../../types";
 import { translate } from "../../util";
@@ -9,7 +10,7 @@ import { isEditableShortcutTarget } from "./utils";
 
 export function handleGlobal(e: KeyboardEvent) {
   const mode = useEditorStore.getState().mode;
-  const { selected } = useEditorStore.getState();
+  const { selected, markerSelection } = useEditorStore.getState();
 
   // don't want to interfere with input elements
 
@@ -19,8 +20,45 @@ export function handleGlobal(e: KeyboardEvent) {
 
   if (handleShortcut(e)) return;
 
+  if (markerSelection && handleMarkerSelectionKey(e, markerSelection)) return;
+
   if (mode.includes("text")) handleTextMode(e);
   else if (selected.length) handleComponentOperations(e, selected);
+}
+
+function handleMarkerSelectionKey(
+  e: KeyboardEvent,
+  markerSelection: { id: string; start: number; end: number }
+) {
+  const { setMarkerSelection } = useEditorStore.getState();
+
+  if (e.key === "Backspace" || e.key === "Delete") {
+    e.preventDefault();
+    setBlockListStyle(
+      [markerSelection.id],
+      { start: markerSelection.start, end: markerSelection.end },
+      "none"
+    );
+    setMarkerSelection(null);
+    return true;
+  }
+
+  if (e.key === "Tab") {
+    e.preventDefault();
+    indentBlocks(
+      [markerSelection.id],
+      { start: markerSelection.start, end: markerSelection.end },
+      e.shiftKey ? -1 : 1
+    );
+    return true;
+  }
+
+  if (e.key === "Escape") {
+    setMarkerSelection(null);
+    return true;
+  }
+
+  return false;
 }
 
 function handleComponentOperations(e: KeyboardEvent, selected: string[]) {

--- a/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
@@ -20,8 +20,8 @@ type Shortcut = {
 
 function toggleTextStyle(
   selected: string,
-  prop: "fontWeight" | "fontStyle" | "textDecoration",
-  enabledValue: "bold" | "italic" | "underline",
+  prop: "fontWeight" | "fontStyle" | "textDecoration" | "verticalAlign",
+  enabledValue: "bold" | "italic" | "underline" | "super" | "sub",
   disabledValue: "normal" | "none"
 ) {
   const current = useEditorStore.getState().activeStyle;
@@ -143,6 +143,24 @@ const shortcuts: Shortcut[] = [
       const { selected } = useEditorStore.getState();
       if (!selected.length) return;
       toggleTextStyle(selected[0], "textDecoration", "underline", "none");
+    },
+  },
+  {
+    combos: ["mod+."],
+    when: () => useEditorStore.getState().mode.includes("text"),
+    run: () => {
+      const { selected } = useEditorStore.getState();
+      if (!selected.length) return;
+      toggleTextStyle(selected[0], "verticalAlign", "super", "normal");
+    },
+  },
+  {
+    combos: ["mod+,"],
+    when: () => useEditorStore.getState().mode.includes("text"),
+    run: () => {
+      const { selected } = useEditorStore.getState();
+      if (!selected.length) return;
+      toggleTextStyle(selected[0], "verticalAlign", "sub", "normal");
     },
   },
 ];

--- a/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
@@ -11,6 +11,8 @@ import useEditorStore from "../../stores/editor";
 import { handleSelectAll } from "./text";
 import { matchesShortcut } from "./utils";
 import { setTextStyle } from "../../text/style";
+import { toggleBulletShortcut } from "../../text/list";
+import { syncVisualCursor } from "../../text/cursor";
 
 type Shortcut = {
   combos: string[];
@@ -51,8 +53,10 @@ const shortcuts: Shortcut[] = [
   {
     combos: ["backspace", "delete"],
     when: () => {
-      const { mode, selected } = useEditorStore.getState();
-      return !mode.includes("text") && selected.length > 0;
+      const { mode, selected, markerSelection } = useEditorStore.getState();
+      // a marker selection has its own Backspace/Delete handling (strip
+      // list formatting) -- this generic component-delete must yield to it
+      return !mode.includes("text") && !markerSelection && selected.length > 0;
     },
     run: () => {
       const { selected, setSelected } = useEditorStore.getState();
@@ -161,6 +165,18 @@ const shortcuts: Shortcut[] = [
       const { selected } = useEditorStore.getState();
       if (!selected.length) return;
       toggleTextStyle(selected[0], "verticalAlign", "sub", "normal");
+    },
+  },
+  {
+    // shift+8 usually reports e.key as "*" (the shifted character) rather
+    // than "8", so both are matched to work across browsers/layouts
+    combos: ["mod+shift+8", "mod+shift+*"],
+    when: () => useEditorStore.getState().mode.includes("text"),
+    run: () => {
+      const { selected } = useEditorStore.getState();
+      if (!selected.length) return;
+      toggleBulletShortcut(selected[0]);
+      syncVisualCursor();
     },
   },
 ];

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -12,6 +12,7 @@ import {
   isStartOfListBlock,
   setBlockListStyle,
 } from "../../scene/operations/text";
+import { getBlockRange } from "../../text/list";
 import useEditorStore from "../../stores/editor";
 import useVisualScene from "../../stores/visual";
 import {
@@ -47,16 +48,10 @@ export function handleTextMode(e: KeyboardEvent) {
 }
 
 function handleIndent(e: KeyboardEvent, selected: string) {
-  const { selection } = useEditorStore.getState();
-  const { start, end } = selection;
-  if (!start) return;
+  const range = getBlockRange(selected);
+  if (!range) return;
 
   e.preventDefault();
-
-  const range = {
-    start: Math.min(start.blockI, end?.blockI ?? start.blockI),
-    end: Math.max(start.blockI, end?.blockI ?? start.blockI),
-  };
 
   indentBlocks([selected], range, e.shiftKey ? -1 : 1);
   syncVisualCursor();

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -129,8 +129,9 @@ function handleEditing(e: KeyboardEvent, selected: string) {
     setSelection({ start: newCursor, end: null });
   } else if (e.key === "Enter" && e.shiftKey) {
     // soft line break: a new line within the same list item, no new marker
-    const newCursor = createSoftBreak([selected], start);
-    setSelection({ start: newCursor, end });
+    const cursor = end ? deleteSelection([selected], selection) : start;
+    const newCursor = createSoftBreak([selected], cursor);
+    setSelection({ start: newCursor, end: null });
   } else if (e.key === "Enter" && isEmptyListBlock(selected, start)) {
     // enter on an empty bullet line (i.e. a second enter right after the
     // previous one created it) ends the list instead of adding another line

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -1,9 +1,16 @@
 import {
+  applyAutoBullet,
+  canAutoBullet,
   createBlock,
+  createSoftBreak,
   deleteChar,
   deleteSelection,
+  indentBlocks,
   insertChar,
   insertSelection,
+  isEmptyListBlock,
+  isStartOfListBlock,
+  setBlockListStyle,
 } from "../../scene/operations/text";
 import useEditorStore from "../../stores/editor";
 import useVisualScene from "../../stores/visual";
@@ -30,11 +37,29 @@ export function handleTextMode(e: KeyboardEvent) {
   if ((e.metaKey || e.ctrlKey) && e.key == "a") {
     e.preventDefault();
     handleSelectAll(selected[0]);
+  } else if (e.key === "Tab") {
+    handleIndent(e, selected[0]);
   } else if (e.key.startsWith("Arrow") || ["Home", "End"].includes(e.key)) {
     handleNavigation(e, selected[0]);
   } else {
     handleEditing(e, selected[0]);
   }
+}
+
+function handleIndent(e: KeyboardEvent, selected: string) {
+  const { selection } = useEditorStore.getState();
+  const { start, end } = selection;
+  if (!start) return;
+
+  e.preventDefault();
+
+  const range = {
+    start: Math.min(start.blockI, end?.blockI ?? start.blockI),
+    end: Math.max(start.blockI, end?.blockI ?? start.blockI),
+  };
+
+  indentBlocks([selected], range, e.shiftKey ? -1 : 1);
+  syncVisualCursor();
 }
 
 export function handleSelectAll(selected: string) {
@@ -76,18 +101,50 @@ function handleEditing(e: KeyboardEvent, selected: string) {
   const { start, end } = selection;
   if (!start) return;
 
-  if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+  if (e.key === " " && !end && canAutoBullet(selected, start)) {
+    // markdown-style shorthand: a lone leading "-"/"*" followed by a space
+    // becomes a bullet, consuming the trigger char instead of inserting the space
+    const newCursor = applyAutoBullet([selected], start);
+    setSelection({ start: newCursor, end: null });
+  } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
     // insert character at cursor
     const newCursor = end
       ? insertSelection(selected, selection, e.key)
       : insertChar([selected], start, e.key);
     setSelection({ start: newCursor, end: null });
+  } else if (
+    e.key === "Backspace" &&
+    !end &&
+    isStartOfListBlock(selected, start)
+  ) {
+    // backspace at the start of a bulleted line strips the bullet first
+    // (whether or not the line has content) instead of deleting into the
+    // previous block
+    setBlockListStyle(
+      [selected],
+      { start: start.blockI, end: start.blockI },
+      "none"
+    );
+    syncVisualCursor();
   } else if (e.key === "Backspace") {
     // delete character before cursor
     const newCursor = !end
       ? deleteChar([selected], start)
       : deleteSelection([selected], selection);
     setSelection({ start: newCursor, end: null });
+  } else if (e.key === "Enter" && e.shiftKey) {
+    // soft line break: a new line within the same list item, no new marker
+    const newCursor = createSoftBreak([selected], start);
+    setSelection({ start: newCursor, end });
+  } else if (e.key === "Enter" && isEmptyListBlock(selected, start)) {
+    // enter on an empty bullet line (i.e. a second enter right after the
+    // previous one created it) ends the list instead of adding another line
+    setBlockListStyle(
+      [selected],
+      { start: start.blockI, end: start.blockI },
+      "none"
+    );
+    syncVisualCursor();
   } else if (e.key === "Enter") {
     // create a new block at cursor
     const newCursor = createBlock([selected], start);

--- a/frontend/src/features/authoring/handlers/pointer/MarkerContext.tsx
+++ b/frontend/src/features/authoring/handlers/pointer/MarkerContext.tsx
@@ -1,7 +1,21 @@
 import { Ban, List, Minus, SquareCheck } from "lucide-react";
 import { handle } from "../../../../components/ContextMenu/portal";
 import { setBlockListStyle } from "../../scene/operations/text";
+import useEditorStore from "../../stores/editor";
 import type { ListMarkerStyle } from "../../types";
+
+// mirrors handleMarkerSelectionKey's Backspace/Delete behaviour: removing
+// the list entirely invalidates the marker selection's blocks, so it must
+// be cleared here too -- otherwise it goes stale and swallows the next
+// Backspace/Delete as a no-op instead of deleting the selected component
+function applyMarkerStyle(
+  id: string,
+  range: { start: number; end: number },
+  value: ListMarkerStyle | "none"
+) {
+  setBlockListStyle([id], range, value);
+  if (value === "none") useEditorStore.getState().setMarkerSelection(null);
+}
 
 const OPTIONS: {
   value: ListMarkerStyle | "none";
@@ -28,12 +42,7 @@ const MarkerMenu = ({
       {OPTIONS.map((option) => (
         <li key={option.value}>
           <a
-            onClick={handle(
-              setBlockListStyle,
-              [id],
-              { start, end },
-              option.value
-            )}
+            onClick={handle(applyMarkerStyle, id, { start, end }, option.value)}
           >
             {option.icon}
             {option.label}

--- a/frontend/src/features/authoring/handlers/pointer/MarkerContext.tsx
+++ b/frontend/src/features/authoring/handlers/pointer/MarkerContext.tsx
@@ -1,0 +1,47 @@
+import { Ban, List, Minus, SquareCheck } from "lucide-react";
+import { handle } from "../../../../components/ContextMenu/portal";
+import { setBlockListStyle } from "../../scene/operations/text";
+import type { ListMarkerStyle } from "../../types";
+
+const OPTIONS: {
+  value: ListMarkerStyle | "none";
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  { value: "dash", label: "Dash", icon: <Minus size={16} /> },
+  { value: "bullet", label: "Bullet", icon: <List size={16} /> },
+  { value: "checkbox", label: "Checkbox", icon: <SquareCheck size={16} /> },
+  { value: "none", label: "Remove bullets", icon: <Ban size={16} /> },
+];
+
+const MarkerMenu = ({
+  id,
+  start,
+  end,
+}: {
+  id: string;
+  start: number;
+  end: number;
+}) => {
+  return (
+    <ul className="menu bg-base-200 rounded-box w-fit">
+      {OPTIONS.map((option) => (
+        <li key={option.value}>
+          <a
+            onClick={handle(
+              setBlockListStyle,
+              [id],
+              { start, end },
+              option.value
+            )}
+          >
+            {option.icon}
+            {option.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default MarkerMenu;

--- a/frontend/src/features/authoring/handlers/pointer/context.ts
+++ b/frontend/src/features/authoring/handlers/pointer/context.ts
@@ -1,11 +1,17 @@
 import { render } from "../../../../components/ContextMenu/portal";
 import useEditorStore from "../../stores/editor";
+import useVisualScene from "../../stores/visual";
+import { getListGroupRange } from "../../text/list";
+import type { VisualDocument } from "../../text/types";
 import ComponentMenu from "./ComponentContext";
+import MarkerMenu from "./MarkerContext";
 
 export function handleContextGlobal(e: React.MouseEvent) {
   const target = e.target as HTMLElement;
 
-  if (target.dataset.id) {
+  if (target.dataset.type === "marker") {
+    handleMarkerContext(e);
+  } else if (target.dataset.id) {
     handleComponentContext(e);
   }
 }
@@ -21,6 +27,54 @@ function handleComponentContext(e: React.MouseEvent) {
   e.preventDefault();
   render({
     menu: ComponentMenu({ ids }),
+    position: { x: e.clientX, y: e.clientY },
+  });
+}
+
+// right-clicking a marker that's already part of the current marker
+// selection keeps that selection (so right-click works the same as the
+// dropdown on an existing mass selection); otherwise it establishes one
+// first, same as a single left click would
+function handleMarkerContext(e: React.MouseEvent) {
+  const target = e.target as HTMLElement;
+  const id = target.dataset.id as string;
+  const blockI = Number(target.dataset.blockIndex);
+
+  const {
+    markerSelection,
+    setMarkerSelection,
+    setSelected,
+    setMode,
+    setSelection,
+    setVisualSelection,
+  } = useEditorStore.getState();
+
+  const alreadySelected =
+    markerSelection?.id === id &&
+    blockI >= markerSelection.start &&
+    blockI <= markerSelection.end;
+
+  let range = alreadySelected
+    ? { start: markerSelection.start, end: markerSelection.end }
+    : null;
+
+  if (!range) {
+    const component = useVisualScene.getState().components[id];
+    const { document: doc } = component as unknown as {
+      document: VisualDocument;
+    };
+    range = getListGroupRange(doc, blockI);
+
+    setSelected([id]);
+    setMode(["normal"]);
+    setSelection({ start: null, end: null });
+    setVisualSelection({ start: null, end: null });
+    setMarkerSelection({ id, ...range });
+  }
+
+  e.preventDefault();
+  render({
+    menu: MarkerMenu({ id, start: range.start, end: range.end }),
     position: { x: e.clientX, y: e.clientY },
   });
 }

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -52,7 +52,7 @@ export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
   } else if (target.dataset.type === "checkbox") {
     handleCheckboxClick(e);
   } else if (target.dataset.type === "marker") {
-    handleMarkerClick(e);
+    handleMarkerClick(e, position);
   } else if (target.dataset.type === "document") {
     handleDocumentClick(e, position);
   } else if (target.dataset.id) {
@@ -165,7 +165,7 @@ function handleCheckboxClick(e: React.MouseEvent) {
 // so it can be bulk-deleted without touching the content -- a single click
 // selects the whole contiguous run of list blocks (the "list group"), a
 // double click selects just that one item
-function handleMarkerClick(e: React.MouseEvent) {
+function handleMarkerClick(e: React.MouseEvent, position: Vec2) {
   const target = e.target as HTMLElement;
   const id = target.dataset.id as string;
   const blockI = Number(target.dataset.blockIndex);
@@ -177,6 +177,7 @@ function handleMarkerClick(e: React.MouseEvent) {
     setSelection,
     setVisualSelection,
     setMarkerSelection,
+    setOffset,
   } = useEditorStore.getState();
   const component = useVisualScene.getState().components[id];
   const { document: doc } = component as unknown as {
@@ -186,6 +187,7 @@ function handleMarkerClick(e: React.MouseEvent) {
   setSelected([id]);
   setMode(["normal"]);
   setMutationBounds({ ...component.bounds });
+  setOffset(position);
   // a marker selection is distinct from a text selection -- clear any
   // active text cursor/highlight so they don't compete visually
   setSelection({ start: null, end: null });

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -1,7 +1,9 @@
 import { fastIsEqual } from "fast-is-equal";
 import { modifyComponentBounds } from "../../scene/operations/component";
+import { toggleChecked } from "../../scene/operations/text";
 import useEditorStore from "../../stores/editor";
 import useVisualScene from "../../stores/visual";
+import { getListGroupRange } from "../../text/list";
 import {
   getRelativePosition,
   moveCursorVisual,
@@ -40,12 +42,17 @@ const MIN_COMPONENT_SIZE = 1;
 export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
   const target = e.target as HTMLElement;
 
-  const { mode, setVisualSelection, setSelection } = useEditorStore.getState();
+  const { mode, setVisualSelection, setSelection, setMarkerSelection } =
+    useEditorStore.getState();
 
   if (mode.includes("create")) {
     handleCreateStart(e, position);
   } else if (target.dataset.handle) {
     handleResizeStart(e);
+  } else if (target.dataset.type === "checkbox") {
+    handleCheckboxClick(e);
+  } else if (target.dataset.type === "marker") {
+    handleMarkerClick(e);
   } else if (target.dataset.type === "document") {
     handleDocumentClick(e, position);
   } else if (target.dataset.id) {
@@ -54,7 +61,12 @@ export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
     handleCanvasClick();
   }
 
-  if (target.dataset.type !== "document") {
+  // a marker click sets its own markerSelection (see handleMarkerClick);
+  // anything else clears it so it doesn't linger and catch a later
+  // Backspace/Delete meant for something else
+  if (target.dataset.type !== "marker") setMarkerSelection(null);
+
+  if (!["document", "marker"].includes(target.dataset.type ?? "")) {
     setVisualSelection({ start: null, end: null });
     setSelection({ start: null, end: null });
   }
@@ -139,6 +151,53 @@ function handleComponentClick(e: React.MouseEvent, position: Vec2) {
   if (bounds) setMutationBounds(bounds);
 
   setMode(["normal"]);
+}
+
+function handleCheckboxClick(e: React.MouseEvent) {
+  const target = e.target as HTMLElement;
+  const id = target.dataset.id as string;
+  const blockI = Number(target.dataset.blockIndex);
+
+  toggleChecked([id], blockI);
+}
+
+// clicking a dash/bullet marker selects the marker itself (not its text)
+// so it can be bulk-deleted without touching the content -- a single click
+// selects the whole contiguous run of list blocks (the "list group"), a
+// double click selects just that one item
+function handleMarkerClick(e: React.MouseEvent) {
+  const target = e.target as HTMLElement;
+  const id = target.dataset.id as string;
+  const blockI = Number(target.dataset.blockIndex);
+
+  const {
+    setSelected,
+    setMode,
+    setMutationBounds,
+    setSelection,
+    setVisualSelection,
+    setMarkerSelection,
+  } = useEditorStore.getState();
+  const component = useVisualScene.getState().components[id];
+  const { document: doc } = component as unknown as {
+    document: VisualDocument;
+  };
+
+  setSelected([id]);
+  setMode(["normal"]);
+  setMutationBounds({ ...component.bounds });
+  // a marker selection is distinct from a text selection -- clear any
+  // active text cursor/highlight so they don't compete visually
+  setSelection({ start: null, end: null });
+  setVisualSelection({ start: null, end: null });
+
+  if (e.detail >= 2) {
+    setMarkerSelection({ id, start: blockI, end: blockI });
+    return;
+  }
+
+  const { start, end } = getListGroupRange(doc, blockI);
+  setMarkerSelection({ id, start, end });
 }
 
 function handleComponentDrag(_: React.MouseEvent, position: Vec2) {

--- a/frontend/src/features/authoring/scene/operations/text.ts
+++ b/frontend/src/features/authoring/scene/operations/text.ts
@@ -270,6 +270,7 @@ export const indentBlocks = modify(
         block.list.level -= 1;
       } else {
         block.list = undefined;
+        block.softBreak = undefined;
       }
     }
   }
@@ -289,6 +290,7 @@ export const setBlockListStyle = modify(
       const block = doc.blocks[i];
       if (markerStyle === "none") {
         block.list = undefined;
+        block.softBreak = undefined;
       } else {
         block.list = {
           markerStyle,

--- a/frontend/src/features/authoring/scene/operations/text.ts
+++ b/frontend/src/features/authoring/scene/operations/text.ts
@@ -2,6 +2,7 @@ import { getComponentProp } from "../scene";
 import type { ModelCursor, ModelSelection } from "../../text/types";
 import type {
   BaseTextStyle,
+  ListMarkerStyle,
   ModelBlock,
   ModelDocument,
   ModelSpan,
@@ -111,8 +112,10 @@ export const deleteSelection = modify((id: string[], sel: ModelSelection) => {
   return normaliseDocument(doc, start);
 });
 
-export const createBlock = modify((id: string[], cursor: ModelCursor) => {
-  const blocks = getComponentProp(id[0], `document.blocks`) as ModelBlock[];
+// splits the block at the cursor into "before"/"after" span lists, leaving
+// the "before" half in place -- shared by createBlock and createSoftBreak,
+// which differ only in what they attach to the new "after" block
+function splitBlockAtCursor(blocks: ModelBlock[], cursor: ModelCursor) {
   const block = blocks[cursor.blockI];
 
   splitSpan(blocks, cursor);
@@ -133,13 +136,178 @@ export const createBlock = modify((id: string[], cursor: ModelCursor) => {
   }
 
   block.spans = oldSpans;
+  return { block, newSpans };
+}
+
+export const createBlock = modify((id: string[], cursor: ModelCursor) => {
+  const blocks = getComponentProp(id[0], `document.blocks`) as ModelBlock[];
+  const { block, newSpans } = splitBlockAtCursor(blocks, cursor);
+
   blocks.splice(cursor.blockI + 1, 0, {
     spans: newSpans,
     style: { ...block.style },
+    list: block.list ? { ...block.list, checked: false } : undefined,
   });
 
   return { blockI: cursor.blockI + 1, spanI: 0, charI: 0 };
 });
+
+// Shift+Enter: a soft line break -- stays part of the same list item (same
+// marker/level) but renders no marker of its own
+export const createSoftBreak = modify((id: string[], cursor: ModelCursor) => {
+  const blocks = getComponentProp(id[0], `document.blocks`) as ModelBlock[];
+  const { block, newSpans } = splitBlockAtCursor(blocks, cursor);
+
+  blocks.splice(cursor.blockI + 1, 0, {
+    spans: newSpans,
+    style: { ...block.style },
+    list: block.list ? { ...block.list } : undefined,
+    softBreak: true,
+  });
+
+  return { blockI: cursor.blockI + 1, spanI: 0, charI: 0 };
+});
+
+const AUTO_BULLET_TRIGGERS: Record<string, ListMarkerStyle> = {
+  "-": "dash",
+  "*": "bullet",
+};
+
+// true when the cursor sits right after a leading "-" or "*" as the very
+// first character of the line and the block isn't already a list -- the
+// trigger for markdown-style "- "/"* " auto-bulleting on the next space.
+// any text already following that leading character is left alone.
+export function canAutoBullet(id: string, cursor: ModelCursor) {
+  const doc = getComponentProp(id, "document") as ModelDocument;
+  const block = doc.blocks[cursor.blockI];
+  if (!block || block.list) return false;
+
+  return (
+    cursor.spanI === 0 &&
+    cursor.charI === 1 &&
+    block.spans[0].text[0] in AUTO_BULLET_TRIGGERS
+  );
+}
+
+// consumes the leading "-"/"*" (the triggering space is not inserted) and
+// turns the block into a list -- "-" becomes a dash marker, "*" becomes a
+// round bullet -- preserving any text that already followed it
+export const applyAutoBullet = modify((id: string[], cursor: ModelCursor) => {
+  const doc = getComponentProp(id[0], "document") as ModelDocument;
+  const block = doc.blocks[cursor.blockI];
+  const span = block.spans[0];
+  const trigger = span.text[0];
+  const remaining = span.text.slice(1);
+
+  if (remaining === "" && block.spans.length > 1) {
+    block.spans.shift();
+  } else {
+    span.text = remaining;
+  }
+
+  block.list = { markerStyle: AUTO_BULLET_TRIGGERS[trigger], level: 0 };
+  return { blockI: cursor.blockI, spanI: 0, charI: 0 };
+});
+
+// true when the cursor sits at the very start of an empty list block --
+// the trigger for Enter to exit list formatting instead of adding another
+// bulleted line
+export function isEmptyListBlock(id: string, cursor: ModelCursor) {
+  const doc = getComponentProp(id, "document") as ModelDocument;
+  const block = doc.blocks[cursor.blockI];
+  if (!block?.list) return false;
+
+  return (
+    cursor.spanI === 0 &&
+    cursor.charI === 0 &&
+    block.spans.length === 1 &&
+    block.spans[0].text === ""
+  );
+}
+
+// true when the cursor sits at the very start of a list block, whether or
+// not it has content -- the trigger for Backspace to strip the bullet
+// instead of merging into the previous block. a soft-break continuation
+// has no marker of its own to strip, so it's excluded here and left to the
+// normal merge-into-previous-block behaviour, which undoes the soft break
+export function isStartOfListBlock(id: string, cursor: ModelCursor) {
+  const doc = getComponentProp(id, "document") as ModelDocument;
+  const block = doc.blocks[cursor.blockI];
+  if (!block?.list || block.softBreak) return false;
+
+  return cursor.spanI === 0 && cursor.charI === 0;
+}
+
+export const toggleChecked = modify((id: string[], blockI: number) => {
+  const doc = getComponentProp(id[0], "document") as ModelDocument;
+  const block = doc.blocks[blockI];
+  if (!block.list) return;
+  block.list.checked = !block.list.checked;
+});
+
+// 9 nesting levels, 0-indexed: 0-8
+export const MAX_LIST_LEVEL = 8;
+
+// applies to every block in the (inclusive) index range that already has a
+// list marker -- plain paragraphs are left untouched, matching Tab's no-op
+// behaviour on non-list lines
+export const indentBlocks = modify(
+  (id: string[], range: { start: number; end: number }, direction: 1 | -1) => {
+    const doc = getComponentProp(id[0], "document") as ModelDocument;
+
+    for (let i = range.start; i <= range.end; i++) {
+      const block = doc.blocks[i];
+      if (!block.list) continue;
+
+      if (direction > 0) {
+        block.list.level = Math.min(MAX_LIST_LEVEL, block.list.level + 1);
+      } else if (block.list.level > 0) {
+        block.list.level -= 1;
+      } else {
+        block.list = undefined;
+      }
+    }
+  }
+);
+
+// applies to every block in the (inclusive) index range: switching marker
+// style preserves an existing level/checked state, "none" clears the list
+export const setBlockListStyle = modify(
+  (
+    id: string[],
+    range: { start: number; end: number },
+    markerStyle: ListMarkerStyle | "none"
+  ) => {
+    const doc = getComponentProp(id[0], "document") as ModelDocument;
+
+    for (let i = range.start; i <= range.end; i++) {
+      const block = doc.blocks[i];
+      if (markerStyle === "none") {
+        block.list = undefined;
+      } else {
+        block.list = {
+          markerStyle,
+          level: block.list?.level ?? 0,
+          checked: block.list?.checked ?? false,
+        };
+      }
+    }
+  }
+);
+
+export const setBlockStyle = modify(
+  (
+    id: string[],
+    blockI: number,
+    prop: "alignment" | "lineHeight",
+    value: string | number
+  ) => {
+    const doc = getComponentProp(id[0], "document") as ModelDocument;
+    const block = doc.blocks[blockI];
+    if (!block) return;
+    block.style = { ...block.style, [prop]: value };
+  }
+);
 
 export const applySelectionStyle = modify(
   (id: string[], sel: ModelSelection, style: Partial<BaseTextStyle>) => {
@@ -149,9 +317,10 @@ export const applySelectionStyle = modify(
     const { start, end } = isolateSelection(id[0], normaliseSelection(sel));
 
     if (style.alignment || style.lineHeight) {
-      for (let i = sel.start!.blockI; i <= sel.end!.blockI; i++) {
-        if (style.alignment) blocks[i].style!.alignment = style.alignment;
-        if (style.lineHeight) blocks[i].style!.lineHeight = style.lineHeight;
+      for (let i = start.blockI; i <= end.blockI; i++) {
+        const blockStyle = (blocks[i].style ??= {});
+        if (style.alignment) blockStyle.alignment = style.alignment;
+        if (style.lineHeight) blockStyle.lineHeight = style.lineHeight;
       }
     }
 
@@ -184,7 +353,10 @@ function collectSelectedSpans(
     let startSpan = b === start.blockI ? start.spanI : 0;
     const endSpan = b === end.blockI ? end.spanI : block.spans.length - 1;
 
-    if (b === start.blockI && start.charI === block.spans[startSpan].text.length) {
+    if (
+      b === start.blockI &&
+      start.charI === block.spans[startSpan].text.length
+    ) {
       startSpan++;
     }
 
@@ -205,7 +377,10 @@ export function getStyleForSelection(id: string, sel: ModelSelection) {
     // superscript/bold run that's been entirely highlighted), use that
     // format -- so typing over it keeps the formatting instead of
     // picking up whatever style happens to sit at either endpoint
-    const normd = normaliseSelection(sel) as { start: ModelCursor; end: ModelCursor };
+    const normd = normaliseSelection(sel) as {
+      start: ModelCursor;
+      end: ModelCursor;
+    };
     const spans = collectSelectedSpans(doc.blocks, normd.start, normd.end);
     const first = spans[0];
     const uniform =

--- a/frontend/src/features/authoring/scene/operations/text.ts
+++ b/frontend/src/features/authoring/scene/operations/text.ts
@@ -105,7 +105,12 @@ export const deleteSelection = modify((id: string[], sel: ModelSelection) => {
   if (!newSpans.length)
     newSpans = [{ text: "", style: startBlock.spans[0].style }];
 
-  const newBlock = { spans: newSpans, style: startBlock.style };
+  const newBlock = {
+    spans: newSpans,
+    style: startBlock.style,
+    list: startBlock.list ? { ...startBlock.list } : undefined,
+    softBreak: startBlock.softBreak,
+  };
   blocks.splice(start.blockI, end.blockI - start.blockI + 1, newBlock);
 
   // needs normalisation to merge adjacent spans with the same style

--- a/frontend/src/features/authoring/scene/operations/text.ts
+++ b/frontend/src/features/authoring/scene/operations/text.ts
@@ -168,6 +168,32 @@ export const applySelectionStyle = modify(
   }
 );
 
+// spans actually covered by a (raw, unsplit) selection range -- a cursor at
+// a span boundary is normalised to the end of the preceding span (see
+// normaliseCursor), so the first touched span is the *next* one whenever
+// the start cursor sits exactly at such a boundary
+function collectSelectedSpans(
+  blocks: ModelBlock[],
+  start: ModelCursor,
+  end: ModelCursor
+) {
+  const spans: ModelSpan[] = [];
+
+  for (let b = start.blockI; b <= end.blockI; b++) {
+    const block = blocks[b];
+    let startSpan = b === start.blockI ? start.spanI : 0;
+    const endSpan = b === end.blockI ? end.spanI : block.spans.length - 1;
+
+    if (b === start.blockI && start.charI === block.spans[startSpan].text.length) {
+      startSpan++;
+    }
+
+    for (let s = startSpan; s <= endSpan; s++) spans.push(block.spans[s]);
+  }
+
+  return spans;
+}
+
 export function getStyleForSelection(id: string, sel: ModelSelection) {
   const doc = getComponentProp(id, "document") as ModelDocument;
   const { start, end } = sel;
@@ -175,10 +201,23 @@ export function getStyleForSelection(id: string, sel: ModelSelection) {
   if (start == null) return squash(doc.style); // no selection
 
   if (end) {
-    // full sel
-    // TODO: choose the least specificity present across selected spans (prefer false for toggles, unknown for values)
-    const block = doc.blocks[end.blockI];
-    return squash(doc.style, block.style, block.spans[end.spanI].style);
+    // full sel: when the whole selection shares one format (e.g. a
+    // superscript/bold run that's been entirely highlighted), use that
+    // format -- so typing over it keeps the formatting instead of
+    // picking up whatever style happens to sit at either endpoint
+    const normd = normaliseSelection(sel) as { start: ModelCursor; end: ModelCursor };
+    const spans = collectSelectedSpans(doc.blocks, normd.start, normd.end);
+    const first = spans[0];
+    const uniform =
+      first && spans.every((s) => shallow(s.style ?? {}, first.style ?? {}));
+
+    const block = doc.blocks[normd.end.blockI];
+    const fallbackSpan = block.spans[normd.end.spanI];
+    return squash(
+      doc.style,
+      block.style,
+      (uniform ? first : fallbackSpan).style
+    );
   }
 
   // start only (cursor)

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -1,5 +1,9 @@
 import create from "zustand";
-import type { ModelSelection, VisualSelection } from "../text/types";
+import type {
+  MarkerSelection,
+  ModelSelection,
+  VisualSelection,
+} from "../text/types";
 import type { BaseTextStyle, Bounds, Guide, Vec2 } from "../types";
 import { getComponent } from "../scene/scene";
 import { getStyleForSelection } from "../scene/operations/text";
@@ -29,12 +33,14 @@ interface EditorState {
   visualSelection: VisualSelection;
   desiredColumn: number | null;
   activeStyle: BaseTextStyle | null;
+  markerSelection: MarkerSelection | null;
 
   setLoading: (loading: boolean) => void;
   setSelection: (selection: ModelSelection) => void;
   setVisualSelection: Dynamic<VisualSelection>;
   setDesiredColumn: (column: number | null) => void;
   setActiveStyle: (style: BaseTextStyle) => void;
+  setMarkerSelection: Dynamic<MarkerSelection | null>;
 
   // modes
   mode: Mode[];
@@ -84,6 +90,7 @@ const useEditorStore = create<EditorState>((set) => ({
   visualSelection: { start: null, end: null },
   activeStyle: null,
   desiredColumn: null,
+  markerSelection: null,
 
   setSelection: (selection) =>
     set(({ selected }) => {
@@ -98,6 +105,7 @@ const useEditorStore = create<EditorState>((set) => ({
   setVisualSelection: setter(set, "visualSelection"),
   setActiveStyle: (style: BaseTextStyle) => set({ activeStyle: style }),
   setDesiredColumn: (column) => set({ desiredColumn: column }),
+  setMarkerSelection: setter(set, "markerSelection"),
 
   mode: ["normal"],
   setMode: (mode) => set({ mode }),
@@ -110,6 +118,7 @@ const useEditorStore = create<EditorState>((set) => ({
       selected: [],
       selection: { start: null, end: null },
       visualSelection: { start: null, end: null },
+      markerSelection: null,
       mode: ["normal"],
       activeGuides: [],
     }),

--- a/frontend/src/features/authoring/text/Text.tsx
+++ b/frontend/src/features/authoring/text/Text.tsx
@@ -1,14 +1,215 @@
-import type { VisualDocument } from "./types";
+import type { MarkerSelection, VisualBlock, VisualDocument } from "./types";
 import Cursor from "./Cursor.tsx";
 import Highlight from "./Highlight";
 import Rectangle from "../canvas/Rectangle";
-import { buildStyle } from "./build";
+import { buildStyle, LIST_MARKER_GAP } from "./build";
 import useEditorStore from "../stores/editor";
 import TextHighlight from "./TextHighlight.tsx";
 
-function buildGroups(doc: VisualDocument) {
+const CHECKBOX_SCALE = 0.8;
+const CHECKBOX_HIT_PADDING = 4;
+const MARKER_HIT_PADDING = 6;
+
+// bullet markers cycle through progressively "lighter" glyphs as they
+// nest; the dash marker stays "-" at every level
+const BULLET_GLYPHS = ["•", "◦", "▪"];
+
+// marker geometry shared between the visible glyph and its (separately
+// painted, see buildMarkerHit) click target
+function markerGeometry(block: VisualBlock) {
+  // a soft-break continuation shares its list's indent but draws no marker
+  if (!block.list || block.lines.length === 0 || block.softBreak) return null;
+
+  const firstLine = block.lines[0];
+  // match the marker to how the first character actually renders (its real
+  // font size/color), not the block's own default -- span-level overrides
+  // (e.g. selecting the bullet's text and bumping font size) don't touch
+  // block.style, so that would leave the marker stuck at the old size
+  const style = firstLine.spans[0]?.style ?? block.style;
+
+  const baseline = block.y + firstLine.y + firstLine.baseline;
+  // anchor to the line's actual start (which already accounts for
+  // indent + alignment) so the marker tracks the text instead of always
+  // sitting at the block's fixed left edge
+  const markerX = firstLine.x - LIST_MARKER_GAP;
+
+  return { list: block.list, style, baseline, markerX };
+}
+
+// tightly wraps the glyph/checkbox itself, drawn first so it stays legible
+// on top -- deliberately snugger than the (generously padded, for easy
+// clicking) hit target below, so selection only highlights the character
+// and not the empty margin around it
+const HIGHLIGHT_PADDING = 2;
+
+function buildMarkerSelectionHighlight(
+  markerStyle: "checkbox" | "dash" | "bullet",
+  style: { fontSize: number },
+  baseline: number,
+  markerX: number
+) {
+  if (markerStyle === "checkbox") {
+    const size = style.fontSize * CHECKBOX_SCALE;
+    const boxX = markerX - size;
+    const boxY = baseline - size;
+    return (
+      <rect
+        x={boxX - HIGHLIGHT_PADDING}
+        y={boxY - HIGHLIGHT_PADDING}
+        width={size + HIGHLIGHT_PADDING * 2}
+        height={size + HIGHLIGHT_PADDING * 2}
+        rx={2}
+        fill="var(--color-selection)"
+      />
+    );
+  }
+
+  const width = style.fontSize * 0.6;
+  const height = style.fontSize * 0.75;
+  return (
+    <rect
+      x={markerX - width - HIGHLIGHT_PADDING}
+      y={baseline - height - HIGHLIGHT_PADDING}
+      width={width + HIGHLIGHT_PADDING * 2}
+      height={height + HIGHLIGHT_PADDING * 2}
+      rx={2}
+      fill="var(--color-selection)"
+    />
+  );
+}
+
+// the visible glyph/checkbox -- safe to paint in normal document order
+// since it's purely cosmetic (see buildMarkerHit for the separately
+// layered interactive click target)
+function buildMarker(block: VisualBlock, isMarkerSelected: boolean) {
+  const geometry = markerGeometry(block);
+  if (!geometry) return null;
+  const { list, style, baseline, markerX } = geometry;
+
+  if (list.markerStyle === "checkbox") {
+    const size = style.fontSize * CHECKBOX_SCALE;
+    const boxX = markerX - size;
+    const boxY = baseline - size;
+
+    return (
+      <g key="marker">
+        {isMarkerSelected &&
+          buildMarkerSelectionHighlight(
+            list.markerStyle,
+            style,
+            baseline,
+            markerX
+          )}
+        <rect
+          x={boxX}
+          y={boxY}
+          width={size}
+          height={size}
+          rx={2}
+          fill="none"
+          stroke={style.textColor}
+          strokeWidth={1.5}
+        />
+        {list.checked && (
+          <path
+            d={`M${boxX + size * 0.2} ${boxY + size * 0.55} L${boxX + size * 0.42} ${boxY + size * 0.78} L${boxX + size * 0.8} ${boxY + size * 0.22}`}
+            fill="none"
+            stroke={style.textColor}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+      </g>
+    );
+  }
+
+  const glyph =
+    list.markerStyle === "bullet"
+      ? BULLET_GLYPHS[list.level % BULLET_GLYPHS.length]
+      : "-";
+
+  return (
+    <g key="marker">
+      {isMarkerSelected &&
+        buildMarkerSelectionHighlight(
+          list.markerStyle,
+          style,
+          baseline,
+          markerX
+        )}
+      <text
+        x={markerX}
+        y={baseline}
+        textAnchor="end"
+        style={{ whiteSpace: "pre", ...buildStyle(style) }}
+      >
+        {glyph}
+      </text>
+    </g>
+  );
+}
+
+// the invisible click target for a marker -- rendered as a separate pass
+// *after* the whole-document hit rectangle (see Text()) so it wins hit
+// testing at its (small) spot instead of being swallowed by that rectangle,
+// which paints on top of everything else in the block by document order
+function buildMarkerHit(block: VisualBlock, docId: string, blockIndex: number) {
+  const geometry = markerGeometry(block);
+  if (!geometry) return null;
+  const { list, style, baseline, markerX } = geometry;
+
+  if (list.markerStyle === "checkbox") {
+    const size = style.fontSize * CHECKBOX_SCALE;
+    const boxX = markerX - size;
+    const boxY = baseline - size;
+
+    return (
+      <rect
+        key={blockIndex}
+        x={boxX - CHECKBOX_HIT_PADDING}
+        y={boxY - CHECKBOX_HIT_PADDING}
+        width={size + CHECKBOX_HIT_PADDING * 2}
+        height={size + CHECKBOX_HIT_PADDING * 2}
+        fill="transparent"
+        style={{ cursor: "pointer" }}
+        data-type="checkbox"
+        data-id={docId}
+        data-block-index={blockIndex}
+      />
+    );
+  }
+
+  const hitSize = style.fontSize + MARKER_HIT_PADDING * 2;
+
+  return (
+    <rect
+      key={blockIndex}
+      x={markerX - hitSize}
+      y={baseline - style.fontSize}
+      width={hitSize}
+      height={hitSize}
+      fill="transparent"
+      style={{ cursor: "pointer" }}
+      data-type="marker"
+      data-id={docId}
+      data-block-index={blockIndex}
+    />
+  );
+}
+
+function buildGroups(
+  doc: VisualDocument,
+  markerSelection: MarkerSelection | null
+) {
   return doc.blocks.map((block, i) => (
     <g key={i}>
+      {buildMarker(
+        block,
+        markerSelection?.id === doc.id &&
+          i >= markerSelection.start &&
+          i <= markerSelection.end
+      )}
       {block.lines.map((line, j) => (
         <text
           key={j}
@@ -30,6 +231,9 @@ function buildGroups(doc: VisualDocument) {
 function Text({ doc, editable }: { doc: VisualDocument; editable?: boolean }) {
   const selected = useEditorStore((state) =>
     editable ? state.selected : null
+  );
+  const markerSelection = useEditorStore((state) =>
+    editable ? state.markerSelection : null
   );
 
   const isSelected = editable && selected && selected[0] === doc.id;
@@ -63,7 +267,7 @@ function Text({ doc, editable }: { doc: VisualDocument; editable?: boolean }) {
         <Highlight color="var(--color-selection)" bounds={bounds} />
       )}
       <g className="select-none" transform={transformation}>
-        {buildGroups(doc)}
+        {buildGroups(doc, markerSelection)}
       </g>
       {isSelected && <Cursor bounds={bounds} />}
       <Rectangle
@@ -73,6 +277,18 @@ function Text({ doc, editable }: { doc: VisualDocument; editable?: boolean }) {
         data-type="document"
         data-id={doc.id}
       />
+      {/* marker/checkbox click targets are interactive only in the
+          authoring canvas (editable) -- the play screen has no matching
+          click handler, so painting them there would just show a
+          misleading pointer cursor with nothing behind it. painted last,
+          when present, so they sit on top of (win hit-testing over) the
+          document rectangle above, which otherwise covers the whole box
+          and would swallow their clicks first */}
+      {editable && (
+        <g className="select-none" transform={transformation}>
+          {doc.blocks.map((block, i) => buildMarkerHit(block, doc.id, i))}
+        </g>
+      )}
     </g>
   );
 }

--- a/frontend/src/features/authoring/text/Text.tsx
+++ b/frontend/src/features/authoring/text/Text.tsx
@@ -2,7 +2,7 @@ import type { MarkerSelection, VisualBlock, VisualDocument } from "./types";
 import Cursor from "./Cursor.tsx";
 import Highlight from "./Highlight";
 import Rectangle from "../canvas/Rectangle";
-import { buildStyle, LIST_MARKER_GAP } from "./build";
+import { buildStyle, scriptShift, LIST_MARKER_GAP } from "./build";
 import useEditorStore from "../stores/editor";
 import TextHighlight from "./TextHighlight.tsx";
 
@@ -210,20 +210,35 @@ function buildGroups(
           i >= markerSelection.start &&
           i <= markerSelection.end
       )}
-      {block.lines.map((line, j) => (
-        <text
-          key={j}
-          x={line.x}
-          y={block.y + line.y + line.baseline}
-          style={{ whiteSpace: "pre" }}
-        >
-          {line.spans.map((span, k) => (
-            <tspan key={k} style={buildStyle(span.style)}>
-              {span.text}
-            </tspan>
-          ))}
-        </text>
-      ))}
+      {block.lines.map((line, j) => {
+        // dy is relative to the previous tspan's position, so a super/sub
+        // shift has to be undone by the following span's delta -- otherwise
+        // the whole rest of the line stays shifted
+        let prevShift = 0;
+        return (
+          <text
+            key={j}
+            x={line.x}
+            y={block.y + line.y + line.baseline}
+            style={{ whiteSpace: "pre" }}
+          >
+            {line.spans.map((span, k) => {
+              const shift = scriptShift(span.style);
+              const dy = shift - prevShift;
+              prevShift = shift;
+              return (
+                <tspan
+                  key={k}
+                  dy={dy || undefined}
+                  style={buildStyle(span.style)}
+                >
+                  {span.text}
+                </tspan>
+              );
+            })}
+          </text>
+        );
+      })}
     </g>
   ));
 }

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -25,12 +25,22 @@ const fallback: BaseTextStyle = {
 // sub/superscript glyphs are rendered smaller, matching common word processor conventions
 const SCRIPT_SCALE = 0.7;
 
+export const LIST_INDENT_STEP = 24;
+export const LIST_MARKER_GAP = 8;
+
 function measure(text: string) {
   return ctx.measureText(text);
 }
 
 function buildFont(styles: Partial<BaseTextStyle>) {
-  const { fontFamily, fontSize, fontWeight, fontStyle, lineHeight, verticalAlign } = styles;
+  const {
+    fontFamily,
+    fontSize,
+    fontWeight,
+    fontStyle,
+    lineHeight,
+    verticalAlign,
+  } = styles;
   const size =
     verticalAlign && verticalAlign !== "normal"
       ? fontSize! * SCRIPT_SCALE
@@ -222,14 +232,19 @@ function buildBlock(
   maxWidth: number,
   blockStyle: BaseTextStyle
 ) {
+  const indent = block.list ? LIST_INDENT_STEP * (block.list.level + 1) : 0;
+
   const visualBlock: VisualBlock = {
     lines: [],
     y: offset,
     style: blockStyle,
+    list: block.list,
+    softBreak: block.softBreak,
     height: 0,
   };
 
-  const lines = buildVisualLines(block.spans, maxWidth, blockStyle);
+  const lines = buildVisualLines(block.spans, maxWidth - indent, blockStyle);
+  if (indent > 0) lines.forEach((line) => (line.x += indent));
 
   if (lines.length > 0) {
     const { y, height } = lines[lines.length - 1];

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -19,15 +19,23 @@ const fallback: BaseTextStyle = {
   textDecoration: "none",
   textColor: "#000000",
   highlightColor: "#00000000",
+  verticalAlign: "normal",
 };
+
+// sub/superscript glyphs are rendered smaller, matching common word processor conventions
+const SCRIPT_SCALE = 0.7;
 
 function measure(text: string) {
   return ctx.measureText(text);
 }
 
 function buildFont(styles: Partial<BaseTextStyle>) {
-  const { fontFamily, fontSize, fontWeight, fontStyle, lineHeight } = styles;
-  return `${fontStyle} ${fontWeight} ${fontSize}px/${lineHeight! * fontSize!}px "${fontFamily}"`;
+  const { fontFamily, fontSize, fontWeight, fontStyle, lineHeight, verticalAlign } = styles;
+  const size =
+    verticalAlign && verticalAlign !== "normal"
+      ? fontSize! * SCRIPT_SCALE
+      : fontSize;
+  return `${fontStyle} ${fontWeight} ${size}px/${lineHeight! * fontSize!}px "${fontFamily}"`;
 }
 
 function setFont(style?: Partial<BaseTextStyle>) {
@@ -48,6 +56,10 @@ export function buildStyle(derived: Partial<BaseTextStyle>) {
     font: buildFont(derived),
     fill: derived.textColor,
     textDecoration: derived.textDecoration,
+    baselineShift:
+      derived.verticalAlign && derived.verticalAlign !== "normal"
+        ? derived.verticalAlign
+        : undefined,
   };
 }
 

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -66,11 +66,22 @@ export function buildStyle(derived: Partial<BaseTextStyle>) {
     font: buildFont(derived),
     fill: derived.textColor,
     textDecoration: derived.textDecoration,
-    baselineShift:
-      derived.verticalAlign && derived.verticalAlign !== "normal"
-        ? derived.verticalAlign
-        : undefined,
   };
+}
+
+const SUPER_SHIFT = -0.35;
+const SUB_SHIFT = 0.15;
+
+// vertical offset (in px, baseline-relative) for super/subscript, sized off
+// the *unscaled* fontSize -- Chrome/Edge dropped CSS `baseline-shift` as a
+// settable style property (SVG2 kept it only as a raw presentation
+// attribute), so the shift has to be applied as an SVG `dy` instead
+export function scriptShift(
+  style: Pick<BaseTextStyle, "fontSize" | "verticalAlign">
+) {
+  if (style.verticalAlign === "super") return style.fontSize * SUPER_SHIFT;
+  if (style.verticalAlign === "sub") return style.fontSize * SUB_SHIFT;
+  return 0;
 }
 
 function generateOffsets(text: string, style: BaseTextStyle) {

--- a/frontend/src/features/authoring/text/list.ts
+++ b/frontend/src/features/authoring/text/list.ts
@@ -19,10 +19,13 @@ export function getListGroupRange(doc: VisualDocument, blockI: number) {
 // an active text selection/cursor takes priority, otherwise falls back to
 // a marker selection (bullets selected as objects, not text) on that box
 export function getBlockRange(id: string) {
-  const { selection, markerSelection } = useEditorStore.getState();
+  const { selected, selection, markerSelection } = useEditorStore.getState();
   const { start, end } = selection;
 
-  if (start) {
+  // the active text selection has no owning id of its own -- it's only
+  // meaningful for the single textbox currently focused for text editing,
+  // so it must never be reused as-is for any other selected textbox
+  if (start && selected.length === 1 && selected[0] === id) {
     return {
       start: Math.min(start.blockI, end?.blockI ?? start.blockI),
       end: Math.max(start.blockI, end?.blockI ?? start.blockI),
@@ -34,6 +37,16 @@ export function getBlockRange(id: string) {
   }
 
   return null;
+}
+
+// a range covering every block in the given textbox's document -- used as
+// the per-target fallback when there's no active in-text selection to
+// derive a range from, so a bulk action still has a valid range for each
+// document instead of reusing one that belongs to a different textbox
+function getFullBlockRange(id: string) {
+  const doc = getComponentProp(id, "document") as ModelDocument;
+  if (!doc?.blocks?.length) return null;
+  return { start: 0, end: doc.blocks.length - 1 };
 }
 
 export function getListStyleForSelection(id: string): ListMarkerStyle | "none" {
@@ -48,7 +61,7 @@ export function setListStyle(
   selected: string,
   value: ListMarkerStyle | "none"
 ) {
-  const range = getBlockRange(selected);
+  const range = getBlockRange(selected) ?? getFullBlockRange(selected);
   if (!range) return;
 
   setBlockListStyle([selected], range, value);

--- a/frontend/src/features/authoring/text/list.ts
+++ b/frontend/src/features/authoring/text/list.ts
@@ -1,0 +1,69 @@
+import { getComponentProp } from "../scene/scene";
+import { setBlockListStyle } from "../scene/operations/text";
+import useEditorStore from "../stores/editor";
+import type { ListMarkerStyle, ModelDocument } from "../types";
+import type { VisualDocument } from "./types";
+
+// the contiguous run of list blocks around blockI (a "list group") -- used
+// both for the initial click-to-select and to re-derive the same range on
+// a later action (context menu, Tab) when the selection wasn't just made
+export function getListGroupRange(doc: VisualDocument, blockI: number) {
+  let start = blockI;
+  while (start > 0 && doc.blocks[start - 1].list) start--;
+  let end = blockI;
+  while (end < doc.blocks.length - 1 && doc.blocks[end + 1].list) end++;
+  return { start, end };
+}
+
+// resolves the block range an action should apply to for a given textbox:
+// an active text selection/cursor takes priority, otherwise falls back to
+// a marker selection (bullets selected as objects, not text) on that box
+function getBlockRange(id: string) {
+  const { selection, markerSelection } = useEditorStore.getState();
+  const { start, end } = selection;
+
+  if (start) {
+    return {
+      start: Math.min(start.blockI, end?.blockI ?? start.blockI),
+      end: Math.max(start.blockI, end?.blockI ?? start.blockI),
+    };
+  }
+
+  if (markerSelection && markerSelection.id === id) {
+    return { start: markerSelection.start, end: markerSelection.end };
+  }
+
+  return null;
+}
+
+export function getListStyleForSelection(id: string): ListMarkerStyle | "none" {
+  const range = getBlockRange(id);
+  if (!range) return "none";
+
+  const doc = getComponentProp(id, "document") as ModelDocument;
+  return doc.blocks[range.start]?.list?.markerStyle ?? "none";
+}
+
+export function setListStyle(
+  selected: string,
+  value: ListMarkerStyle | "none"
+) {
+  const range = getBlockRange(selected);
+  if (!range) return;
+
+  setBlockListStyle([selected], range, value);
+}
+
+// mod+shift+8 -- toggles the round bullet style on/off for the current
+// block(s)
+export function toggleBulletShortcut(selected: string) {
+  const range = getBlockRange(selected);
+  if (!range) return;
+
+  const current = getListStyleForSelection(selected);
+  setBlockListStyle(
+    [selected],
+    range,
+    current === "bullet" ? "none" : "bullet"
+  );
+}

--- a/frontend/src/features/authoring/text/list.ts
+++ b/frontend/src/features/authoring/text/list.ts
@@ -18,7 +18,7 @@ export function getListGroupRange(doc: VisualDocument, blockI: number) {
 // resolves the block range an action should apply to for a given textbox:
 // an active text selection/cursor takes priority, otherwise falls back to
 // a marker selection (bullets selected as objects, not text) on that box
-function getBlockRange(id: string) {
+export function getBlockRange(id: string) {
   const { selection, markerSelection } = useEditorStore.getState();
   const { start, end } = selection;
 

--- a/frontend/src/features/authoring/text/style.ts
+++ b/frontend/src/features/authoring/text/style.ts
@@ -1,5 +1,5 @@
 import { modifyComponentProp } from "../scene/operations/component";
-import { applySelectionStyle } from "../scene/operations/text";
+import { applySelectionStyle, setBlockStyle } from "../scene/operations/text";
 import useEditorStore from "../stores/editor";
 import { syncVisualCursor } from "./cursor";
 import type { BaseTextStyle } from "../types";
@@ -22,11 +22,7 @@ export function setTextStyle(
     syncVisualCursor();
   } else if (selection?.start) {
     if (prop === "lineHeight" || prop === "alignment") {
-      modifyComponentProp(
-        [selected],
-        `document.blocks.${selection.start.blockI}.style.${prop}`,
-        value
-      );
+      setBlockStyle([selected], selection.start.blockI, prop, value);
     } else {
       modifyComponentProp([selected], `document.style.${prop}`, value);
     }

--- a/frontend/src/features/authoring/text/types.ts
+++ b/frontend/src/features/authoring/text/types.ts
@@ -1,4 +1,4 @@
-import type { BaseTextStyle, RelativeBounds } from "../types";
+import type { BaseTextStyle, ModelListMeta, RelativeBounds } from "../types";
 
 export interface VisualSpan {
   text: string;
@@ -24,6 +24,8 @@ export interface VisualLine {
 export interface VisualBlock {
   lines: VisualLine[];
   style: BaseTextStyle;
+  list?: ModelListMeta;
+  softBreak?: boolean;
   y: number;
   height: number;
 }
@@ -56,6 +58,15 @@ export interface ModelSelection {
 export interface VisualSelection {
   start: VisualCursor | null;
   end: VisualCursor | null;
+}
+
+// a selection of bullet markers themselves (not their text) -- lets the
+// user delete just the list formatting of a run of blocks without
+// touching their content
+export interface MarkerSelection {
+  id: string;
+  start: number;
+  end: number;
 }
 
 export type Definite<T> = {

--- a/frontend/src/features/authoring/topbar/TextSection.tsx
+++ b/frontend/src/features/authoring/topbar/TextSection.tsx
@@ -3,27 +3,38 @@ import {
   AlignLeft,
   AlignRight,
   ArrowDownNarrowWide,
+  Ban,
   Bold,
   Highlighter,
   Italic,
+  List,
+  Minus,
   Subscript,
   Superscript,
+  SquareCheck,
   Underline,
 } from "lucide-react";
 import useEditorStore from "../stores/editor";
+import useVisualScene from "../stores/visual";
 import FontInput from "../wrapper/FontInput";
 import NumberInput from "../wrapper/NumberInput";
 import ToggleInput from "../wrapper/ToggleInput";
 import ChromePicker from "../wrapper/ChromePicker";
 import MultiInput from "../wrapper/MultiInput";
-import type { BaseTextStyle } from "../types";
+import type { BaseTextStyle, ListMarkerStyle } from "../types";
+import type { VisualDocument } from "../text/types";
 import { setTextStyle } from "../text/style";
+import { setListStyle } from "../text/list";
 import { getComponent } from "../scene/scene";
 
 function TextSection() {
   const selected = useEditorStore((state) => state.selected); // this comp only renders when a text el is selected
 
   const style = useEditorStore((state) => state.activeStyle);
+  const selection = useEditorStore((state) => state.selection);
+  const visualComponent = useVisualScene((state) =>
+    selected[0] ? state.components[selected[0]] : null
+  );
 
   if (!style) return null;
 
@@ -35,6 +46,18 @@ function TextSection() {
       .filter((id) => getComponent(id)?.type === "textbox")
       .forEach((id) => setTextStyle(id, prop, value));
   }
+
+  function modifyListStyle(value: ListMarkerStyle | "none") {
+    selected
+      .filter((id) => getComponent(id)?.type === "textbox")
+      .forEach((id) => setListStyle(id, value));
+  }
+
+  const blockI = selection.start?.blockI;
+  const doc = (visualComponent as unknown as { document?: VisualDocument })
+    ?.document;
+  const currentListStyle: ListMarkerStyle | "none" =
+    (blockI != null && doc?.blocks[blockI]?.list?.markerStyle) || "none";
 
   return (
     <>
@@ -135,6 +158,23 @@ function TextSection() {
         tooltip="Line height"
       >
         <ArrowDownNarrowWide size={16} />
+      </MultiInput>
+
+      <div className="divider divider-horizontal" />
+
+      <MultiInput
+        value={currentListStyle}
+        values={["none", "dash", "bullet", "checkbox"]}
+        items={[
+          <Ban key={0} size={16} />,
+          <Minus key={1} size={16} />,
+          <List key={2} size={16} />,
+          <SquareCheck key={3} size={16} />,
+        ]}
+        onChange={(value) => modifyListStyle(value as ListMarkerStyle | "none")}
+        tooltip="Bullet style"
+      >
+        <List size={16} />
       </MultiInput>
     </>
   );

--- a/frontend/src/features/authoring/topbar/TextSection.tsx
+++ b/frontend/src/features/authoring/topbar/TextSection.tsx
@@ -6,6 +6,8 @@ import {
   Bold,
   Highlighter,
   Italic,
+  Subscript,
+  Superscript,
   Underline,
 } from "lucide-react";
 import useEditorStore from "../stores/editor";
@@ -76,6 +78,24 @@ function TextSection() {
         tooltip="Underline"
       >
         <Underline size={16} />
+      </ToggleInput>
+      <ToggleInput
+        value={style.verticalAlign}
+        onToggle={(value) => modifyStyle("verticalAlign", value)}
+        enabled="super"
+        disabled="normal"
+        tooltip="Superscript"
+      >
+        <Superscript size={16} />
+      </ToggleInput>
+      <ToggleInput
+        value={style.verticalAlign}
+        onToggle={(value) => modifyStyle("verticalAlign", value)}
+        enabled="sub"
+        disabled="normal"
+        tooltip="Subscript"
+      >
+        <Subscript size={16} />
       </ToggleInput>
       <ChromePicker
         value={style.textColor}

--- a/frontend/src/features/authoring/types.ts
+++ b/frontend/src/features/authoring/types.ts
@@ -153,6 +153,7 @@ export interface SpanTextStyle {
   textDecoration: string;
   textColor: HexString;
   highlightColor: HexString;
+  verticalAlign: "normal" | "super" | "sub";
 }
 
 type HexString = string;

--- a/frontend/src/features/authoring/types.ts
+++ b/frontend/src/features/authoring/types.ts
@@ -128,8 +128,22 @@ export interface ModelDocument extends BaseModelDocument {
   id: string;
 }
 
+export type ListMarkerStyle = "dash" | "bullet" | "checkbox";
+
+export interface ModelListMeta {
+  markerStyle: ListMarkerStyle;
+  level: number;
+  checked?: boolean;
+}
+
 export interface ModelBlock {
   style?: Partial<BlockTextStyle>;
+  list?: ModelListMeta;
+  // true when this block began with a soft line break (Shift+Enter) rather
+  // than a new paragraph -- keeps the same list indent but renders no
+  // marker of its own, and Backspace at its start merges it back up
+  // instead of stripping list formatting
+  softBreak?: boolean;
   spans: ModelSpan[];
 }
 


### PR DESCRIPTION
## Issue

Textboxes in the slide authoring tool had no way to format text as subscript/superscript, and no support for bulleted or checklist-style lists. Authors building CST session slides had no way to structure content beyond plain paragraphs.

## Solution

**Subscript / superscript**
- Added `verticalAlign` (`normal`/`super`/`sub`) as a span-level text style, toggleable from the toolbar and via `mod+.` / `mod+,` shortcuts, rendered at a reduced scale matching standard word-processor conventions.

**Bullet points**
- New per-block list model (`ModelBlock.list`: marker style — dash, round bullet, or checkbox — plus nesting level and checked state), fully optional so existing documents are unaffected.
- Marker style is chosen from a toolbar dropdown, or automatically: typing `- ` or `* ` at the start of a line converts it to a dash/bullet respectively, even when the line already has text after the cursor.
- **Tab / Shift+Tab** indent and outdent a line (or a whole selection) up to 9 nesting levels; outdenting past the top level removes the bullet. Nested bullets cycle through progressively lighter glyphs (dash stays `-` at every level).
- **Enter** continues the same bullet on the next line; pressing Enter again on an empty bullet, or Backspace at the start of one, ends the list and returns to a plain paragraph (with or without existing text on the line).
- **Shift+Enter** inserts a soft line break within the same bullet item — no new marker, and Backspace at its start merges it back into the line above.
- Checkbox markers are click-to-toggle.
- Bullets can be **mass-selected** as objects distinct from their text: a single click on a marker selects the whole contiguous list group, a double click selects just that item. The selection can then be bulk-restyled (via the toolbar dropdown, a right-click context menu, or `mod+shift+8` to toggle round bullets) or bulk-deleted with Backspace/Delete, which strips only the list formatting and leaves the text intact.

**Bug fixes picked up along the way**
- Changing text alignment wasn't working, so that's fixed
- Text alignment wasn't applying correctly for a backwards (right-to-left) drag selection.
- A whole-textbox invisible hit rectangle was painted on top of the new marker/checkbox click targets in SVG paint order, silently swallowing their clicks.

## Risk

- Data model changes (`ModelBlock.list`, span `verticalAlign`) are additive/optional, so existing saved scenes render unchanged.
- The SVG paint-order fix for marker click targets changes DOM structure inside `Text.tsx`; low risk but worth a visual smoke-test across existing slides with text/shapes layered near textboxes.
- New keyboard shortcuts (`mod+shift+8`, Tab/Shift+Tab, Shift+Enter) are scoped to text-editing mode and shouldn't collide with existing bindings, but worth confirming on both Windows and Mac modifier keys.
- No automated test coverage was added for the new text-editing/list logic (this codebase currently has no tests for the authoring text editor).

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bullet, dash, and checkbox lists with indentation, nesting, selection, and context-menu controls.
  * Checkboxes can be toggled directly, and list formatting can be removed without deleting text.
  * Added keyboard support for list creation, indentation, soft breaks, and exiting empty lists.
  * Added superscript and subscript text formatting.
* **Bug Fixes**
  * Improved handling when component bounds are unavailable, preventing editing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->