### PR TITLE
vps 172 improve play audio resources buttons

### DIFF
--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -11,7 +11,12 @@ import PlayScenarioCanvas from "./PlayScenarioCanvas";
 import { applyPropertyOperations } from "../../components/Properties/propertyOperations";
 import NotesPanel from "./components/NotesPanel";
 import SceneTimer from "./components/SceneTimer";
-import { PlayIcon } from "lucide-react";
+import {
+  BookMarkedIcon,
+  NotebookPenIcon,
+  Volume2Icon,
+  VolumeOffIcon,
+} from "lucide-react";
 import ResourcesOverlay from "../resources/ResourcesOverlay";
 
 const sceneCache = new Map();
@@ -437,21 +442,27 @@ export default function PlayScenarioPage({ group }) {
 
       <div className="absolute top-2 right-2 z-30 flex items-center gap-2">
         {isMultiplayer && (
-          <button
-            className="btn btn-sm"
-            onClick={() => setNoteOpen(true)}
-            aria-label="Open notes"
-          >
-            Notes
-          </button>
+          <div className="tooltip tooltip-left" data-tip="Open notes">
+            <button
+              className="btn"
+              onClick={() => setNoteOpen(true)}
+              type="button"
+              aria-label="Open notes"
+            >
+              <NotebookPenIcon size={16} />
+            </button>
+          </div>
         )}
-        <button
-          className="btn btn-sm"
-          onClick={() => setResourcesOpen(true)}
-          aria-label="Open resources"
-        >
-          Resources
-        </button>
+        <div className="tooltip tooltip-left" data-tip="Open resources">
+          <button
+            className="btn"
+            onClick={() => setResourcesOpen(true)}
+            type="button"
+            aria-label="Open resources"
+          >
+            <BookMarkedIcon size={16} />
+          </button>
+        </div>
       </div>
 
       {isMultiplayer && (

--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -422,14 +422,6 @@ export default function PlayScenarioPage({ group }) {
           />
         </div>
       )}
-      {!audioAllowed && (
-        <div className="absolute top-4 left-4 z-30">
-          <button className="btn" onClick={() => setAudioAllowed(true)}>
-            <PlayIcon size={16} />
-            Enable Audio
-          </button>
-        </div>
-      )}
       <PlayScenarioCanvas
         scene={currScene}
         incrementor={isMultiplayer ? incrementor : undefined}
@@ -441,6 +433,29 @@ export default function PlayScenarioPage({ group }) {
       />
 
       <div className="absolute top-2 right-2 z-30 flex items-center gap-2">
+        {audioAllowed ? (
+          <div className="tooltip tooltip-bottom" data-tip="Disable audio">
+            <button
+              className="btn"
+              onClick={() => setAudioAllowed(false)}
+              type="button"
+              aria-label="Disable audio"
+            >
+              <Volume2Icon size={16} />
+            </button>
+          </div>
+        ) : (
+          <div className="tooltip tooltip-left" data-tip="Enable audio">
+            <button
+              className="btn"
+              onClick={() => setAudioAllowed(true)}
+              type="button"
+              aria-label="Enable audio"
+            >
+              <VolumeOffIcon size={16} />
+            </button>
+          </div>
+        )}
         {isMultiplayer && (
           <div className="tooltip tooltip-left" data-tip="Open notes">
             <button


### PR DESCRIPTION
## Issue

The resources button in the play scenario is not visible enough. UI changes must be made.

## Solution

The following were done:
- enable audio move to the right
- both the buttons become icons
- make buttons larger
- add tooltips

<img width="1917" height="852" alt="image" src="https://github.com/user-attachments/assets/007ddfa6-b68e-432c-b8e3-413858ddfc0b" />

## Risk

Minimal

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined icon controls for audio, notes, and resources, with helpful tooltips and accessibility labels.
  - Added the ability to disable audio directly from the scenario view.
- **Bug Fixes**
  - Improved scenario loading after refresh conflicts, helping prevent outdated navigation results and recover more reliably when refreshing fails.
- **Usability**
  - Updated the scenario canvas and resources overlay for smoother, more consistent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->