### PR TITLE
Vps 184 drag to multiselect

### DIFF
--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import {
   handleMouseUpGlobal,
 } from "../handlers/pointer/pointer";
 import { handleContextGlobal } from "../handlers/pointer/context";
+import { hasMarqueeMoved } from "../handlers/pointer/marquee";
 import LoadingOverlay from "./LoadingOverlay.tsx";
 import useEditorStore from "../stores/editor.ts";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
@@ -41,6 +42,10 @@ function Canvas() {
 
   const mode = useEditorStore((state) => state.mode);
   const createType = useEditorStore((state) => state.createType);
+  const mutationBounds = useEditorStore((state) => state.mutationBounds);
+
+  const isDraggingMarquee =
+    mode.includes("marquee") && hasMarqueeMoved(mutationBounds);
 
   const canvasRef = useRef<SVGSVGElement | null>(null);
 
@@ -82,7 +87,7 @@ function Canvas() {
     <CanvasContext.Provider value={{ toSVGSpace, canvasRef }}>
       <div
         className={`flex-grow relative ${loading ? "pointer-events-none" : ""} ${
-          mode.includes("create") ? "cursor-crosshair" : ""
+          mode.includes("create") || isDraggingMarquee ? "cursor-crosshair" : ""
         }`}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -11,6 +11,7 @@ import Rectangle from "./Rectangle";
 import useEditorStore from "../stores/editor";
 import useVisualScene from "../stores/visual";
 import { getSelectedComponentBounds } from "../handlers/pointer/pointer";
+import { hasMarqueeMoved } from "../handlers/pointer/marquee";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 
 const componentMap: Record<string, React.FC<Record<string, unknown>>> = {
@@ -52,7 +53,8 @@ function Overlay() {
   const createType = useEditorStore((s) => s.createType);
   const components = useVisualScene((s) => s.components);
 
-  const isMarqueeing = mode.includes("marquee");
+  const isMarqueeing =
+    mode.includes("marquee") && hasMarqueeMoved(mutationBounds);
   const hasSelection = selected.length > 0 && !isMarqueeing;
   const type = hasSelection
     ? selected.length > 1

--- a/frontend/src/features/authoring/canvas/Overlay.tsx
+++ b/frontend/src/features/authoring/canvas/Overlay.tsx
@@ -52,7 +52,8 @@ function Overlay() {
   const createType = useEditorStore((s) => s.createType);
   const components = useVisualScene((s) => s.components);
 
-  const hasSelection = selected.length > 0;
+  const isMarqueeing = mode.includes("marquee");
+  const hasSelection = selected.length > 0 && !isMarqueeing;
   const type = hasSelection
     ? selected.length > 1
       ? "box"
@@ -89,6 +90,15 @@ function Overlay() {
           fill="none"
           stroke="var(--color-primary)"
           strokeWidth={1}
+        />
+      )}
+      {isMarqueeing && (
+        <Rectangle
+          bounds={mutationBounds}
+          fill="var(--color-accent)"
+          fillOpacity={0.05}
+          stroke="var(--color-accent)"
+          strokeWidth={3}
         />
       )}
       {mode.includes("mutation") &&

--- a/frontend/src/features/authoring/handlers/pointer/marquee.ts
+++ b/frontend/src/features/authoring/handlers/pointer/marquee.ts
@@ -1,6 +1,6 @@
 import useEditorStore from "../../stores/editor";
 import useVisualScene from "../../stores/visual";
-import type { Component, Vec2 } from "../../types";
+import type { Bounds, Component, Vec2 } from "../../types";
 import {
   expandBoxVerts,
   getRotatedCorners,
@@ -8,11 +8,17 @@ import {
   subtract,
 } from "../../util";
 
-// below this drag distance (canvas units), treat mouseup as a plain click
-// rather than a marquee -- otherwise a click with no movement still runs a
-// zero-area hit test, which can select a component the user never visually
-// touched (e.g. an unfilled shape whose bounds cover that point)
+// below this drag distance (canvas units), treat the gesture as a plain
+// click rather than a marquee -- this both skips the (otherwise zero-area)
+// hit test on mouseup, and gates marquee-only visuals (crosshair cursor,
+// the dashed rectangle) so they don't flash on an ordinary click
 const MIN_DRAG_DISTANCE = 2;
+
+export function hasMarqueeMoved(bounds: Bounds) {
+  const [a, b] = bounds.verts;
+  const delta = subtract(b, a);
+  return Math.hypot(delta.x, delta.y) > MIN_DRAG_DISTANCE;
+}
 
 // pre-drag selection, so a shift-drag adds to it rather than replacing it
 let baseSelection: string[] = [];
@@ -50,10 +56,9 @@ export function handleMarqueeEnd() {
   const { mutationBounds, setSelected, setMode } = useEditorStore.getState();
   const { components } = useVisualScene.getState();
 
-  const [a, b] = mutationBounds.verts;
-  const delta = subtract(b, a);
-  const dragged = Math.hypot(delta.x, delta.y) > MIN_DRAG_DISTANCE;
-  const hits = dragged ? getMarqueeHits(mutationBounds.verts, components) : [];
+  const hits = hasMarqueeMoved(mutationBounds)
+    ? getMarqueeHits(mutationBounds.verts, components)
+    : [];
 
   setSelected(Array.from(new Set([...baseSelection, ...hits])));
   setMode(["normal"]);

--- a/frontend/src/features/authoring/handlers/pointer/marquee.ts
+++ b/frontend/src/features/authoring/handlers/pointer/marquee.ts
@@ -1,0 +1,60 @@
+import useEditorStore from "../../stores/editor";
+import useVisualScene from "../../stores/visual";
+import type { Component, Vec2 } from "../../types";
+import {
+  expandBoxVerts,
+  getRotatedCorners,
+  polygonsIntersect,
+  subtract,
+} from "../../util";
+
+// below this drag distance (canvas units), treat mouseup as a plain click
+// rather than a marquee -- otherwise a click with no movement still runs a
+// zero-area hit test, which can select a component the user never visually
+// touched (e.g. an unfilled shape whose bounds cover that point)
+const MIN_DRAG_DISTANCE = 2;
+
+// pre-drag selection, so a shift-drag adds to it rather than replacing it
+let baseSelection: string[] = [];
+
+export function handleMarqueeStart(e: React.MouseEvent, position: Vec2) {
+  const { selected, setOffset, setMutationBounds, setMode } =
+    useEditorStore.getState();
+
+  baseSelection = e.shiftKey ? selected : [];
+
+  setOffset(position);
+  setMutationBounds({ verts: [position, position], rotation: 0 });
+  setMode(["marquee"]);
+}
+
+function getMarqueeHits(
+  rectVerts: Vec2[],
+  components: Record<string, Component>
+) {
+  const rectCorners = expandBoxVerts(rectVerts);
+
+  return Object.values(components)
+    .filter((component) =>
+      polygonsIntersect(rectCorners, getRotatedCorners(component.bounds))
+    )
+    .map((component) => component.id);
+}
+
+export function handleMarqueeDrag(_: React.MouseEvent, position: Vec2) {
+  const { offset, setMutationBounds } = useEditorStore.getState();
+  setMutationBounds((prev) => ({ ...prev, verts: [offset, position] }));
+}
+
+export function handleMarqueeEnd() {
+  const { mutationBounds, setSelected, setMode } = useEditorStore.getState();
+  const { components } = useVisualScene.getState();
+
+  const [a, b] = mutationBounds.verts;
+  const delta = subtract(b, a);
+  const dragged = Math.hypot(delta.x, delta.y) > MIN_DRAG_DISTANCE;
+  const hits = dragged ? getMarqueeHits(mutationBounds.verts, components) : [];
+
+  setSelected(Array.from(new Set([...baseSelection, ...hits])));
+  setMode(["normal"]);
+}

--- a/frontend/src/features/authoring/handlers/pointer/marquee.ts
+++ b/frontend/src/features/authoring/handlers/pointer/marquee.ts
@@ -7,6 +7,7 @@ import {
   polygonsIntersect,
   subtract,
 } from "../../util";
+import { getSelectedComponentBounds } from "./pointer";
 
 // below this drag distance (canvas units), treat the gesture as a plain
 // click rather than a marquee -- this both skips the (otherwise zero-area)
@@ -34,13 +35,10 @@ export function handleMarqueeStart(e: React.MouseEvent, position: Vec2) {
   setMode(["marquee"]);
 }
 
-function getMarqueeHits(
-  rectVerts: Vec2[],
-  components: Record<string, Component>
-) {
+function getMarqueeHits(rectVerts: Vec2[], components: Component[]) {
   const rectCorners = expandBoxVerts(rectVerts);
 
-  return Object.values(components)
+  return components
     .filter((component) =>
       polygonsIntersect(rectCorners, getRotatedCorners(component.bounds))
     )
@@ -53,13 +51,26 @@ export function handleMarqueeDrag(_: React.MouseEvent, position: Vec2) {
 }
 
 export function handleMarqueeEnd() {
-  const { mutationBounds, setSelected, setMode } = useEditorStore.getState();
+  const { mutationBounds, setSelected, setMutationBounds, setMode } =
+    useEditorStore.getState();
   const { components } = useVisualScene.getState();
 
+  // filter out audio components
+  const visualComponents = Object.values(components).filter(
+    (c) => c.type !== "audio"
+  );
+
   const hits = hasMarqueeMoved(mutationBounds)
-    ? getMarqueeHits(mutationBounds.verts, components)
+    ? getMarqueeHits(mutationBounds.verts, visualComponents)
     : [];
 
   setSelected(Array.from(new Set([...baseSelection, ...hits])));
+
+  // mutationBounds still holds the marquee drag rectangle -- refresh it to
+  // match the actual selection, otherwise the next resize/rotate (which only
+  // overwrites part of mutationBounds) starts from the stale marquee rect
+  const bounds = getSelectedComponentBounds();
+  if (bounds) setMutationBounds(bounds);
+
   setMode(["normal"]);
 }

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -159,7 +159,7 @@ function handleComponentDrag(_: React.MouseEvent, position: Vec2) {
 
   const { components } = useVisualScene.getState();
   const others = Object.values(components).filter(
-    (c) => !selected.includes(c.id)
+    (c) => c.type !== "audio" && !selected.includes(c.id)
   );
   const { delta, guides } = snapTranslation(verts, bounds.rotation, others, "");
   verts = translate(verts, delta);

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -18,6 +18,7 @@ import {
   divide,
   expandBoxVerts,
   getBoxCenter,
+  getRotatedCorners,
   rotate,
   rotateMany,
   scale,
@@ -25,6 +26,11 @@ import {
   translate,
 } from "../../util";
 import { handleCreateDrag, handleCreateEnd, handleCreateStart } from "./create";
+import {
+  handleMarqueeDrag,
+  handleMarqueeEnd,
+  handleMarqueeStart,
+} from "./marquee";
 import {
   getCoordsVec,
   getHandleType,
@@ -51,7 +57,7 @@ export function handleMouseDownGlobal(e: React.MouseEvent, position: Vec2) {
   } else if (target.dataset.id) {
     handleComponentClick(e, position);
   } else {
-    handleCanvasClick();
+    handleCanvasClick(e, position);
   }
 
   if (target.dataset.type !== "document") {
@@ -76,6 +82,8 @@ export function handleMouseMoveGlobal(e: React.MouseEvent, position: Vec2) {
     handleTextSelection(e, position);
   } else if (mode.includes("create")) {
     handleCreateDrag(e, position);
+  } else if (mode.includes("marquee")) {
+    handleMarqueeDrag(e, position);
   } else {
     handleComponentDrag(e, position);
   }
@@ -90,15 +98,15 @@ export function handleMouseUpGlobal() {
     handleCreateEnd();
   } else if (mode.includes("mutation")) {
     handleMutationEnd();
+  } else if (mode.includes("marquee")) {
+    handleMarqueeEnd();
   }
 
   setMouseDown(false);
 }
 
-function handleCanvasClick() {
-  const { setSelected, setMode } = useEditorStore.getState();
-  setSelected([]);
-  setMode(["normal"]);
+function handleCanvasClick(e: React.MouseEvent, position: Vec2) {
+  handleMarqueeStart(e, position);
 }
 
 // component handlers
@@ -268,13 +276,7 @@ function computeBounds(components: Component[]) {
   const max = { x: -Infinity, y: -Infinity };
 
   components.forEach((component) => {
-    const { verts, rotation } = component.bounds;
-
-    const rotated = rotateMany(
-      expandBoxVerts(verts),
-      getBoxCenter(verts),
-      rotation
-    );
+    const rotated = getRotatedCorners(component.bounds);
 
     rotated.forEach((pos: Vec2) => {
       min.x = Math.min(min.x, pos.x);

--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -60,7 +60,7 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
     if (!bounds.rotation) {
       const components = Object.values(
         useVisualScene.getState().components
-      ).filter((c) => !selected.includes(c.id));
+      ).filter((c) => c.type !== "audio" && !selected.includes(c.id));
 
       // resolve modifiers (shift/ctrl) against the raw point first so we snap the
       // actual resize point, not the mouse position they'd otherwise overwrite

--- a/frontend/src/features/authoring/handlers/pointer/snap.ts
+++ b/frontend/src/features/authoring/handlers/pointer/snap.ts
@@ -1,5 +1,5 @@
 import type { Bounds, Component, Guide, Vec2 } from "../../types";
-import { expandBoxVerts, getBoxCenter, rotateMany } from "../../util";
+import { getRotatedCorners } from "../../util";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../../util/canvas";
 
 export const SNAP_THRESHOLD = 10;
@@ -14,11 +14,7 @@ interface AABB {
 }
 
 function getAABB(bounds: Bounds): AABB {
-  const corners = rotateMany(
-    expandBoxVerts(bounds.verts),
-    getBoxCenter(bounds.verts),
-    bounds.rotation
-  );
+  const corners = getRotatedCorners(bounds);
   const xs = corners.map((v) => v.x);
   const ys = corners.map((v) => v.y);
   const minX = Math.min(...xs);

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -4,7 +4,7 @@ import type { BaseTextStyle, Bounds, Guide, Vec2 } from "../types";
 import { getComponent } from "../scene/scene";
 import { getStyleForSelection } from "../scene/operations/text";
 
-type Mode = "normal" | "resize" | "create" | "text" | "mutation";
+type Mode = "normal" | "resize" | "create" | "text" | "mutation" | "marquee";
 
 interface EditorState {
   loading: boolean;

--- a/frontend/src/features/authoring/util.ts
+++ b/frontend/src/features/authoring/util.ts
@@ -1,4 +1,4 @@
-import type { RelativeBounds, Vec2 } from "./types";
+import type { Bounds, RelativeBounds, Vec2 } from "./types";
 
 type Degree = number;
 type Radian = number;
@@ -92,6 +92,44 @@ export function getBoxCenter(verts: Vec2[]) {
     x: verts[0].x + (verts[1].x - verts[0].x) / 2,
     y: verts[0].y + (verts[1].y - verts[0].y) / 2,
   };
+}
+
+export function getRotatedCorners(bounds: Bounds) {
+  return rotateMany(
+    expandBoxVerts(bounds.verts),
+    getBoxCenter(bounds.verts),
+    bounds.rotation
+  );
+}
+
+function normalize(v: Vec2): Vec2 {
+  const len = Math.hypot(v.x, v.y);
+  return len === 0 ? v : { x: v.x / len, y: v.y / len };
+}
+
+// outward normal of each edge of a convex polygon, in vertex order
+function getEdgeNormals(verts: Vec2[]) {
+  return verts.map((v, i) => {
+    const next = verts[(i + 1) % verts.length];
+    const edge = subtract(next, v);
+    return normalize({ x: -edge.y, y: edge.x });
+  });
+}
+
+function project(verts: Vec2[], axis: Vec2) {
+  const dots = verts.map((v) => v.x * axis.x + v.y * axis.y);
+  return [Math.min(...dots), Math.max(...dots)];
+}
+
+// separating axis theorem: two convex polygons intersect iff their
+// projections overlap on every candidate axis (each polygon's edge normals)
+export function polygonsIntersect(vertsA: Vec2[], vertsB: Vec2[]) {
+  const axes = [...getEdgeNormals(vertsA), ...getEdgeNormals(vertsB)];
+  return axes.every((axis) => {
+    const [minA, maxA] = project(vertsA, axis);
+    const [minB, maxB] = project(vertsB, axis);
+    return minA <= maxB && minB <= maxA;
+  });
 }
 
 export function getRelativeBounds(


### PR DESCRIPTION
## Issue

no marquee selection for multi-select, so you have to shift click everything one by one. extremely slow and frustrating.

## Solution

added marquee selection, based on SAT intersection-test.

## Risk

Nada.

## Checklist

- [x] Acceptance criteria met
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-to-select marquee selection on the authoring canvas.
  * Supports additive selection while holding Shift.
  * Selection accurately includes rotated components intersecting the marquee.
  * Added visual marquee bounds and a crosshair cursor during selection.

* **Bug Fixes**
  * Improved selection and snapping calculations for rotated components.
  * Prevented audio components from affecting snapping guides and resize alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->