### PR TITLE
feat(authoring): show placeholder during image upload

### DIFF
--- a/frontend/src/features/authoring/ImageCreateMenu.tsx
+++ b/frontend/src/features/authoring/ImageCreateMenu.tsx
@@ -10,7 +10,13 @@ import { useParams } from "react-router-dom";
 import { ImageIcon } from "lucide-react";
 import { add } from "./scene/operations/modifiers";
 import { defaults } from "./scene/operations/component";
-import type { ImageComponent, UploadedFile, Scene } from "./types";
+import type {
+  Bounds,
+  ImageComponent,
+  UploadedFile,
+  Scene,
+  Vec2,
+} from "./types";
 import { handleGeneric } from "../../util/api";
 import ModalDialog from "../../components/ModalDialogue";
 import useEditorStore from "./stores/editor.ts";
@@ -23,6 +29,10 @@ import { getImages, uploadImage } from "./images";
 
 type ModifyScene = (scene: Scene) => Promise<unknown> | undefined;
 
+// Time the placeholder is held over the finished image so its blur and label
+// can finish resolving, rather than the two swapping in a single frame.
+const HANDOFF_MS = 250;
+
 const ACCEPTED_IMAGE_MIME_TYPES = [
   "image/png",
   "image/jpeg",
@@ -33,7 +43,8 @@ const ACCEPTED_IMAGE_MIME_TYPES = [
 async function addImageToScene(
   image: UploadedFile,
   originScene: Scene,
-  modifyScene: ModifyScene
+  modifyScene: ModifyScene,
+  verts?: Vec2[]
 ) {
   const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
 
@@ -42,7 +53,7 @@ async function addImageToScene(
   newImage.id = imageId;
   newImage.fileId = image._id;
   newImage.href = image.url;
-  newImage.bounds!.verts = await getImageDimensions(image.url);
+  newImage.bounds!.verts = verts ?? (await getImageDimensions(image.url));
 
   // Still on the slide where the operation began:
   // add normally so visual state/history are updated.
@@ -66,21 +77,65 @@ async function addNewImage(
   modifyScene: ModifyScene,
   queryClient: QueryClient
 ) {
-  const { setLoading } = useEditorStore.getState();
-  setLoading(true);
+  const { addPendingImage, updatePendingImage, removePendingImage } =
+    useEditorStore.getState();
+
+  // Measure and preview the local file so a placeholder of the right size can
+  // be shown on the canvas for the duration of the upload.
+  const previewUrl = URL.createObjectURL(file);
+  const placeholderId = v4();
 
   try {
-    const image = await uploadImage(user, scenarioId, file);
+    const verts = await getImageDimensions(previewUrl);
+    const bounds: Bounds = { verts, rotation: 0 };
+
+    addPendingImage({
+      id: placeholderId,
+      sceneId: originScene._id,
+      bounds,
+      previewUrl,
+      progress: 0,
+      settled: false,
+    });
+
+    const image = await uploadImage(user, scenarioId, file, (fraction) =>
+      // Hold the last tenth back: the bytes are sent, but the server still has
+      // to store the file and answer.
+      updatePendingImage(placeholderId, { progress: fraction * 0.9 })
+    );
+
     await queryClient.invalidateQueries({
       queryKey: ["images", scenarioId],
     });
-    await addImageToScene(image, originScene, modifyScene);
+
+    // Decode the uploaded file before handing over, so the placeholder is
+    // never replaced by an empty frame while the browser fetches it.
+    await preload(image.url);
+    updatePendingImage(placeholderId, { progress: 1, settled: true });
+
+    await addImageToScene(image, originScene, modifyScene, verts);
+
+    // The placeholder now sits over the real image, unblurred and showing the
+    // same picture, so removing it is invisible.
+    await wait(HANDOFF_MS);
   } catch (e) {
     console.error(e);
     toast.error("Image upload failed");
   } finally {
-    setLoading(false);
+    removePendingImage(placeholderId);
+    URL.revokeObjectURL(previewUrl);
   }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function preload(url: string) {
+  const img = new Image();
+  img.src = url;
+  // a failure here is not fatal — the <image> element will load it anyway
+  await img.decode().catch(() => {});
 }
 
 async function getImageDimensions(url: string, defaultHeight = 300) {

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -16,6 +16,7 @@ import {
 } from "../handlers/pointer/pointer";
 import { handleContextGlobal } from "../handlers/pointer/context";
 import LoadingOverlay from "./LoadingOverlay.tsx";
+import ImagePlaceholder from "../elements/ImagePlaceholder";
 import useEditorStore from "../stores/editor.ts";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 import Background from "../elements/Background";
@@ -38,6 +39,9 @@ function resolve(component: Component) {
 function Canvas() {
   const scene = useVisualScene((state) => state.components);
   const background = useVisualScene((state) => state.background);
+  const sceneId = useVisualScene((state) => state.id);
+  const pendingImages = useEditorStore((state) => state.pendingImages);
+  const loading = useEditorStore((state) => state.loading);
 
   const mode = useEditorStore((state) => state.mode);
   const createType = useEditorStore((state) => state.createType);
@@ -77,7 +81,10 @@ function Canvas() {
     .sort((a, b) => a.zIndex - b.zIndex)
     .map(resolve);
 
-  const loading = useEditorStore((state) => state.loading);
+  const placeholders = pendingImages
+    .filter((image) => image.sceneId === sceneId)
+    .map((image) => <ImagePlaceholder key={image.id} {...image} />);
+
   return (
     <CanvasContext.Provider value={{ toSVGSpace, canvasRef }}>
       <div
@@ -147,6 +154,7 @@ function Canvas() {
           />
           <Background background={background} />
           {components}
+          {placeholders}
         </svg>
       </div>
     </CanvasContext.Provider>

--- a/frontend/src/features/authoring/elements/ImagePlaceholder.tsx
+++ b/frontend/src/features/authoring/elements/ImagePlaceholder.tsx
@@ -1,0 +1,95 @@
+import type { PendingImage } from "../stores/editor";
+import { getRelativeBounds } from "../util";
+
+// How much the preview is blurred at 0% progress, in canvas units. The blur
+// resolves as the upload progresses, so the image "develops" into place.
+const MAX_BLUR = 24;
+const LABEL_FONT_SIZE = 20;
+const LABEL_PADDING = 12;
+
+// Drawn in place of an image while its file is uploading. Purely visual —
+// placeholders never enter the scene model, so they are not saved or undoable.
+function ImagePlaceholder({
+  id,
+  bounds,
+  previewUrl,
+  progress,
+  settled,
+}: PendingImage) {
+  const { x, y, width, height } = getRelativeBounds(bounds.verts);
+
+  const blur = settled ? 0 : MAX_BLUR * (1 - progress);
+  const percent = Math.round((settled ? 1 : progress) * 100);
+  const label = `Uploading… ${percent}%`;
+
+  // rough, but text metrics are not worth a measuring pass here
+  const labelWidth = label.length * LABEL_FONT_SIZE * 0.55 + LABEL_PADDING * 2;
+  const labelHeight = LABEL_FONT_SIZE + LABEL_PADDING;
+  const centre = { x: x + width / 2, y: y + height / 2 };
+
+  return (
+    <g className="pointer-events-none">
+      <defs>
+        {/* keeps the blur from bleeding outside the image bounds */}
+        <clipPath id={`placeholder-clip-${id}`}>
+          <rect x={x} y={y} width={width} height={height} />
+        </clipPath>
+      </defs>
+
+      <image
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        href={previewUrl}
+        preserveAspectRatio="none"
+        clipPath={`url(#placeholder-clip-${id})`}
+        style={{
+          filter: `blur(${blur}px)`,
+          transition: "filter 250ms ease-out",
+        }}
+      />
+
+      <g
+        style={{
+          opacity: settled ? 0 : 1,
+          transition: "opacity 250ms ease-out",
+        }}
+      >
+        {/* outline, so a pale image still reads as a distinct object */}
+        <rect
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          fill="none"
+          stroke="var(--color-backdrop-content)"
+          strokeWidth={2}
+          strokeDasharray="8 6"
+          opacity={0.6}
+        />
+        <rect
+          x={centre.x - labelWidth / 2}
+          y={centre.y - labelHeight / 2}
+          width={labelWidth}
+          height={labelHeight}
+          rx={labelHeight / 2}
+          fill="var(--color-backdrop)"
+          opacity={0.85}
+        />
+        <text
+          x={centre.x}
+          y={centre.y}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={LABEL_FONT_SIZE}
+          fill="var(--color-backdrop-content)"
+        >
+          {label}
+        </text>
+      </g>
+    </g>
+  );
+}
+
+export default ImagePlaceholder;

--- a/frontend/src/features/authoring/images.ts
+++ b/frontend/src/features/authoring/images.ts
@@ -11,14 +11,21 @@ export async function getImages(user: User, scenarioId: string) {
   return response.data;
 }
 
-export async function uploadImage(user: User, scenarioId: string, file: File) {
+export async function uploadImage(
+  user: User,
+  scenarioId: string,
+  file: File,
+  onProgress?: (fraction: number) => void
+) {
   const formData = new FormData();
   formData.append("file", file);
 
-  const response = (await api.post(
-    user,
-    `api/files/${scenarioId}`,
-    formData
-  )) as AxiosResponse<UploadedFile>;
+  const response = (await api.post(user, `api/files/${scenarioId}`, formData, {
+    // axios 0.21 hands back a native ProgressEvent
+    onUploadProgress: (event: ProgressEvent) => {
+      if (!onProgress || !event.lengthComputable || !event.total) return;
+      onProgress(event.loaded / event.total);
+    },
+  })) as AxiosResponse<UploadedFile>;
   return response.data;
 }

--- a/frontend/src/features/authoring/stores/editor.ts
+++ b/frontend/src/features/authoring/stores/editor.ts
@@ -6,8 +6,23 @@ import { getStyleForSelection } from "../scene/operations/text";
 
 type Mode = "normal" | "resize" | "create" | "text" | "mutation";
 
+// An image that is being uploaded, drawn on the canvas until the real
+// component takes its place.
+export interface PendingImage {
+  id: string;
+  sceneId: string;
+  bounds: Bounds;
+  // local object URL of the file being uploaded, used as a preview
+  previewUrl: string;
+  // upload progress, 0 to 1
+  progress: number;
+  // upload finished — the placeholder resolves before the real image takes over
+  settled: boolean;
+}
+
 interface EditorState {
   loading: boolean;
+  pendingImages: PendingImage[];
   selected: string[];
   hovered: string | null;
   createType: string | null;
@@ -31,6 +46,9 @@ interface EditorState {
   activeStyle: BaseTextStyle | null;
 
   setLoading: (loading: boolean) => void;
+  addPendingImage: (image: PendingImage) => void;
+  updatePendingImage: (id: string, patch: Partial<PendingImage>) => void;
+  removePendingImage: (id: string) => void;
   setSelection: (selection: ModelSelection) => void;
   setVisualSelection: Dynamic<VisualSelection>;
   setDesiredColumn: (column: number | null) => void;
@@ -63,6 +81,7 @@ function setter<K extends keyof EditorState>(set: ZustandSet, prop: K) {
 
 const useEditorStore = create<EditorState>((set) => ({
   loading: false,
+  pendingImages: [],
   selected: [],
   hovered: null,
   createType: null,
@@ -72,6 +91,18 @@ const useEditorStore = create<EditorState>((set) => ({
   activeGuides: [],
 
   setLoading: (value: boolean) => set({ loading: value }),
+  addPendingImage: (image) =>
+    set((state) => ({ pendingImages: [...state.pendingImages, image] })),
+  updatePendingImage: (id, patch) =>
+    set((state) => ({
+      pendingImages: state.pendingImages.map((image) =>
+        image.id === id ? { ...image, ...patch } : image
+      ),
+    })),
+  removePendingImage: (id) =>
+    set((state) => ({
+      pendingImages: state.pendingImages.filter((image) => image.id !== id),
+    })),
   setSelected: (id) => set({ selected: id }),
   setHovered: (id) => set({ hovered: id }),
   setCreateType: (type: string) => set({ createType: type }),


### PR DESCRIPTION
## Issue

Uploading an image blocks all user interaction until it is finished

## Solution

Show a non-interactive placeholder in the editor while an image is being uploaded

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live image-upload placeholders directly on the canvas.
  * Display upload progress with a blurred preview, progress percentage, and visual transition when complete.
  * Improved image uploads with real-time progress tracking and automatic image preloading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->