### PR TITLE
feat(authoring): centre new images at true size

### DIFF
--- a/frontend/src/features/authoring/ImageCreateMenu.tsx
+++ b/frontend/src/features/authoring/ImageCreateMenu.tsx
@@ -26,6 +26,7 @@ import SceneContext from "../../context/SceneContext.jsx";
 import { getScene, getSceneId } from "./scene/scene";
 import { v4 } from "uuid";
 import { getImages, uploadImage } from "./images";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../util/canvas";
 
 type ModifyScene = (scene: Scene) => Promise<unknown> | undefined;
 
@@ -138,14 +139,27 @@ async function preload(url: string) {
   await img.decode().catch(() => {});
 }
 
-async function getImageDimensions(url: string, defaultHeight = 300) {
+// Placed at its true pixel size and centred on the canvas. Anything larger
+// than the canvas is scaled down to fit, so it stays wholly on the slide.
+async function getImageDimensions(url: string) {
   const img = new Image();
   img.src = url;
   await img.decode();
-  const scaledWidth = img.naturalWidth * (defaultHeight / img.naturalHeight);
+
+  const scale = Math.min(
+    1,
+    CANVAS_WIDTH / img.naturalWidth,
+    CANVAS_HEIGHT / img.naturalHeight
+  );
+  const width = img.naturalWidth * scale;
+  const height = img.naturalHeight * scale;
+
+  const x = (CANVAS_WIDTH - width) / 2;
+  const y = (CANVAS_HEIGHT - height) / 2;
+
   return [
-    { x: 0, y: 0 },
-    { x: scaledWidth, y: defaultHeight },
+    { x, y },
+    { x: x + width, y: y + height },
   ];
 }
 


### PR DESCRIPTION
## Issue

New images are always added at the top left corner of the canvas with 300px height for no good reason

## Solution

Place new images in the centre of the canvas at true size (or resized to fit the canvas if too large)

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images added to the canvas now scale proportionally to fit within its dimensions without being enlarged.
  * Images are automatically centered instead of being positioned at the origin.
  * Removed the previous fixed-height sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->