### PR TITLE
fix(authoring): layer operations on colliding zIndex

### DIFF
--- a/frontend/src/features/authoring/ImageCreateMenu.tsx
+++ b/frontend/src/features/authoring/ImageCreateMenu.tsx
@@ -9,7 +9,7 @@ import { type User } from "firebase/auth";
 import { useParams } from "react-router-dom";
 import { ImageIcon } from "lucide-react";
 import { add } from "./scene/operations/modifiers";
-import { defaults } from "./scene/operations/component";
+import { defaults, getNextZIndex } from "./scene/operations/component";
 import type { ImageComponent, UploadedFile, Scene } from "./types";
 import { handleGeneric } from "../../util/api";
 import ModalDialog from "../../components/ModalDialogue";
@@ -47,12 +47,16 @@ async function addImageToScene(
   // Still on the slide where the operation began:
   // add normally so visual state/history are updated.
   if (getSceneId() === originScene._id) {
+    // Images bypass createComponentFromBounds, so the top-of-stack zIndex that
+    // every other component type gets on creation has to be assigned here.
+    newImage.zIndex = getNextZIndex();
     add(newImage);
     return;
   }
 
   // User moved to another slide while the image was loading.
   // Add it to the original slide instead of the currently active one.
+  newImage.zIndex = getNextZIndex(originScene.components);
   originScene.components[imageId] = newImage as ImageComponent;
 
   await modifyScene(originScene);

--- a/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
@@ -145,6 +145,7 @@ export function paste(e: ClipboardEvent) {
       const doc = plainToDoc(textData);
       const component = structuredClone(defaults["textbox"]);
       component.document = structuredClone(doc);
+      component.zIndex = getNextZIndex();
       setSelected([add(component)]);
     }
   }

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -126,8 +126,8 @@ export function parseComponent(component: Component, zIndex?: number) {
   return add(component);
 }
 
-export function getNextZIndex() {
-  const zIndices = Object.values(getScene().components).map((c) => c.zIndex);
+export function getNextZIndex(components = getScene().components) {
+  const zIndices = Object.values(components).map((c) => c.zIndex ?? 0);
   return zIndices.length ? Math.max(...zIndices) + 1 : 0;
 }
 

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -217,9 +217,20 @@ function shiftComponentLayers(
   const components = Object.values(getScene().components);
   const selectedIds = new Set(ids);
 
-  // Sort components by zIndex (ascending) and capture the original zIndex scale
-  const sortedComponents = [...components].sort((a, b) => a.zIndex - b.zIndex);
-  const zIndexScale = sortedComponents.map((c) => c.zIndex);
+  // Sort by zIndex (ascending) — this is the order the canvas renders
+  const sortedComponents = [...components].sort(
+    (a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0)
+  );
+  const rawZIndexScale = sortedComponents.map((c) => c.zIndex ?? 0);
+
+  // Components tied on one zIndex have no order to swap, so reordering them
+  // against the original scale writes back the values they already had.
+  // Renumber onto a strictly increasing scale first; the sort is stable, so
+  // this preserves the order currently on screen.
+  const hasDuplicates = new Set(rawZIndexScale).size !== rawZIndexScale.length;
+  const zIndexScale = hasDuplicates
+    ? sortedComponents.map((_, index) => index)
+    : rawZIndexScale;
 
   let newSortedComponents: Component[] = [];
 
@@ -264,6 +275,13 @@ function shiftComponentLayers(
       }
     }
   }
+
+  // Renumbering rewrites every tied component, so a reorder that moves nothing
+  // must bail out before it costs an undo step and a full-scene save.
+  const orderUnchanged = newSortedComponents.every(
+    (comp, index) => comp.id === sortedComponents[index].id
+  );
+  if (orderUnchanged) return;
 
   // Apply target zIndices back to modified components
   const changed = newSortedComponents


### PR DESCRIPTION
## Issue

Layer operations like send to back do nothing when the component has the same zIndex as another.
e.g. send image backward behind textbox but both have zIndex 0.

## Solution

Renumber duplicate zIndex and do not default components to zIndex 0

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New images and plain-text pasted text boxes now appear above existing scene elements.
  - Improved layer ordering when components share the same depth position.
  - Prevented unnecessary updates when rearranging components without changing their order.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->