### PR TITLE
chore(authoring): text box writing ux

### DIFF
--- a/frontend/src/features/authoring/handlers/pointer/create.ts
+++ b/frontend/src/features/authoring/handlers/pointer/create.ts
@@ -1,5 +1,7 @@
 import { createComponentFromBounds } from "../../scene/operations/component";
+import { getComponent } from "../../scene/scene";
 import useEditorStore from "../../stores/editor";
+import { syncModelSelection } from "../../text/cursor";
 import type { Vec2 } from "../../types";
 import { add, mutate, scale, subtract } from "../../util";
 
@@ -32,9 +34,31 @@ export function handleCreateDrag(_: React.MouseEvent, position: Vec2) {
 }
 
 export function handleCreateEnd() {
-  const { mutationBounds, setMode, setSelected, createType } =
-    useEditorStore.getState();
+  const {
+    mutationBounds,
+    setMode,
+    setSelected,
+    setMutationBounds,
+    setVisualSelection,
+    setDesiredColumn,
+    createType,
+  } = useEditorStore.getState();
   const id = createComponentFromBounds(createType, mutationBounds);
   setSelected([id]);
-  setMode(["normal"]);
+
+  if (createType !== "textbox") {
+    setMode(["normal"]);
+    return;
+  }
+
+  // drop straight into text mode with the cursor at the start of the empty
+  // document, so a new textbox can be typed into without clicking into it
+  setMode(["text"]);
+  setMutationBounds({ ...getComponent(id).bounds });
+  setDesiredColumn(null);
+  setVisualSelection({
+    start: { blockI: 0, lineI: 0, spanI: 0, charI: 0 },
+    end: null,
+  });
+  syncModelSelection();
 }

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -16,9 +16,10 @@ export const defaults = {
     stroke: "#00000000",
     strokeWidth: 3, // default stroke width 3
     bounds: {
+      // sized to hold the placeholder text at the 32px default font size
       verts: [
         { x: 0, y: 0 },
-        { x: 400, y: 100 },
+        { x: 600, y: 100 },
       ],
       rotation: 0,
     },

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -16,7 +16,6 @@ export const defaults = {
     stroke: "#00000000",
     strokeWidth: 3, // default stroke width 3
     bounds: {
-      // sized to hold the placeholder text at the 32px default font size
       verts: [
         { x: 0, y: 0 },
         { x: 600, y: 100 },
@@ -27,11 +26,11 @@ export const defaults = {
       style: {},
       blocks: [
         {
-          style: {},
+          style: { alignment: "left" },
           spans: [
             {
               style: {},
-              text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla venenatis.",
+              text: "",
             },
           ],
         },

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -13,7 +13,7 @@ const fallback: BaseTextStyle = {
   alignment: "center",
   lineHeight: 1.1,
   fontFamily: "Arial",
-  fontSize: 16,
+  fontSize: 24,
   fontWeight: "normal",
   fontStyle: "normal",
   textDecoration: "none",


### PR DESCRIPTION
## Issue

- Default text box font size 16px is very small
- Lorem ipsum exists to be deleted

## Solution

- 24px is bigger
- Remove default lorem ipsum
- Default to left-aligned text

## Risk

None

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing
