### PR TITLE
feat: drag and drop images onto canvas

### DIFF
--- a/frontend/src/features/authoring/ImageCreateMenu.tsx
+++ b/frontend/src/features/authoring/ImageCreateMenu.tsx
@@ -1,171 +1,23 @@
 import { useContext, useRef, useState, type Context } from "react";
-import {
-  useQuery,
-  useQueryClient,
-  type QueryClient,
-} from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ImageListContainer from "../../components/ListContainer/ImageListContainer";
 import { type User } from "firebase/auth";
 import { useParams } from "react-router-dom";
 import { ImageIcon } from "lucide-react";
-import { add } from "./scene/operations/modifiers";
-import { defaults, getNextZIndex } from "./scene/operations/component";
-import type {
-  Bounds,
-  ImageComponent,
-  UploadedFile,
-  Scene,
-  Vec2,
-} from "./types";
+import type { UploadedFile } from "./types";
 import { handleGeneric } from "../../util/api";
 import ModalDialog from "../../components/ModalDialogue";
-import useEditorStore from "./stores/editor.ts";
 import toast from "react-hot-toast";
 import AuthenticationContext from "../../context/AuthenticationContext.jsx";
 import SceneContext from "../../context/SceneContext.jsx";
-import { getScene, getSceneId } from "./scene/scene";
-import { v4 } from "uuid";
-import { getImages, uploadImage } from "./images";
-import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../util/canvas";
-
-type ModifyScene = (scene: Scene) => Promise<unknown> | undefined;
-
-// Time the placeholder is held over the finished image so its blur and label
-// can finish resolving, rather than the two swapping in a single frame.
-const HANDOFF_MS = 250;
-
-const ACCEPTED_IMAGE_MIME_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/webp",
-  "image/gif",
-];
-
-async function addImageToScene(
-  image: UploadedFile,
-  originScene: Scene,
-  modifyScene: ModifyScene,
-  verts?: Vec2[]
-) {
-  const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
-
-  const imageId = v4();
-
-  newImage.id = imageId;
-  newImage.fileId = image._id;
-  newImage.href = image.url;
-  newImage.bounds!.verts = verts ?? (await getImageDimensions(image.url));
-
-  // Still on the slide where the operation began:
-  // add normally so visual state/history are updated.
-  if (getSceneId() === originScene._id) {
-    // Images bypass createComponentFromBounds, so the top-of-stack zIndex that
-    // every other component type gets on creation has to be assigned here.
-    newImage.zIndex = getNextZIndex();
-    add(newImage);
-    return;
-  }
-
-  // User moved to another slide while the image was loading.
-  // Add it to the original slide instead of the currently active one.
-  newImage.zIndex = getNextZIndex(originScene.components);
-  originScene.components[imageId] = newImage as ImageComponent;
-
-  await modifyScene(originScene);
-}
-
-async function addNewImage(
-  file: File,
-  scenarioId: string,
-  user: User,
-  originScene: Scene,
-  modifyScene: ModifyScene,
-  queryClient: QueryClient
-) {
-  const { addPendingImage, updatePendingImage, removePendingImage } =
-    useEditorStore.getState();
-
-  // Measure and preview the local file so a placeholder of the right size can
-  // be shown on the canvas for the duration of the upload.
-  const previewUrl = URL.createObjectURL(file);
-  const placeholderId = v4();
-
-  try {
-    const verts = await getImageDimensions(previewUrl);
-    const bounds: Bounds = { verts, rotation: 0 };
-
-    addPendingImage({
-      id: placeholderId,
-      sceneId: originScene._id,
-      bounds,
-      previewUrl,
-      progress: 0,
-      settled: false,
-    });
-
-    const image = await uploadImage(user, scenarioId, file, (fraction) =>
-      // Hold the last tenth back: the bytes are sent, but the server still has
-      // to store the file and answer.
-      updatePendingImage(placeholderId, { progress: fraction * 0.9 })
-    );
-
-    await queryClient.invalidateQueries({
-      queryKey: ["images", scenarioId],
-    });
-
-    // Decode the uploaded file before handing over, so the placeholder is
-    // never replaced by an empty frame while the browser fetches it.
-    await preload(image.url);
-    updatePendingImage(placeholderId, { progress: 1, settled: true });
-
-    await addImageToScene(image, originScene, modifyScene, verts);
-
-    // The placeholder now sits over the real image, unblurred and showing the
-    // same picture, so removing it is invisible.
-    await wait(HANDOFF_MS);
-  } catch (e) {
-    console.error(e);
-    toast.error("Image upload failed");
-  } finally {
-    removePendingImage(placeholderId);
-    URL.revokeObjectURL(previewUrl);
-  }
-}
-
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function preload(url: string) {
-  const img = new Image();
-  img.src = url;
-  // a failure here is not fatal — the <image> element will load it anyway
-  await img.decode().catch(() => {});
-}
-
-// Placed at its true pixel size and centred on the canvas. Anything larger
-// than the canvas is scaled down to fit, so it stays wholly on the slide.
-async function getImageDimensions(url: string) {
-  const img = new Image();
-  img.src = url;
-  await img.decode();
-
-  const scale = Math.min(
-    1,
-    CANVAS_WIDTH / img.naturalWidth,
-    CANVAS_HEIGHT / img.naturalHeight
-  );
-  const width = img.naturalWidth * scale;
-  const height = img.naturalHeight * scale;
-
-  const x = (CANVAS_WIDTH - width) / 2;
-  const y = (CANVAS_HEIGHT - height) / 2;
-
-  return [
-    { x, y },
-    { x: x + width, y: y + height },
-  ];
-}
+import { getScene } from "./scene/scene";
+import {
+  ACCEPTED_IMAGE_MIME_TYPES,
+  addImageToScene,
+  addNewImage,
+  getImages,
+  type ModifyScene,
+} from "./images";
 
 function ImageCreateMenu() {
   const { scenarioId } = useParams<{ scenarioId: string }>();

--- a/frontend/src/features/authoring/canvas/Canvas.tsx
+++ b/frontend/src/features/authoring/canvas/Canvas.tsx
@@ -21,6 +21,7 @@ import ImagePlaceholder from "../elements/ImagePlaceholder";
 import useEditorStore from "../stores/editor.ts";
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../../util/canvas";
 import Background from "../elements/Background";
+import useImageDrop from "../useImageDrop";
 
 const componentMap: Record<string, React.FC<Record<string, unknown>>> = {
   textbox: (props) => <TextBox {...props} editable={true} />,
@@ -53,8 +54,6 @@ function Canvas() {
 
   const canvasRef = useRef<SVGSVGElement | null>(null);
 
-  if (!scene) return <></>;
-
   function toSVGSpace(cx: number, cy: number) {
     const boundingRect = canvasRef.current?.children[0];
     if (!boundingRect) return { x: 0, y: 0 };
@@ -63,6 +62,10 @@ function Canvas() {
     const y = ((cy - top) / height) * CANVAS_HEIGHT;
     return { x, y };
   }
+
+  const { isDraggingOver, dropHandlers } = useImageDrop(toSVGSpace);
+
+  if (!scene) return <></>;
 
   function handleMouseMove(e: React.MouseEvent) {
     handleMouseMoveGlobal(e, toSVGSpace(e.clientX, e.clientY));
@@ -100,7 +103,29 @@ function Canvas() {
         onMouseUp={handleMouseUp}
         onMouseDown={handleMouseDown}
         onContextMenu={handleContextMenu}
+        {...dropHandlers}
       >
+        {isDraggingOver && (
+          <div
+            className="
+              absolute
+              inset-0
+              z-[9998]
+              flex
+              items-center
+              justify-center
+              border-2
+              border-dashed
+              border-primary
+              bg-primary/10
+              pointer-events-none
+            "
+          >
+            <span className="bg-primary/70 text-secondary text-sm font-medium px-4 py-2 rounded-full backdrop-blur-sm">
+              Drop image to add it to this scene
+            </span>
+          </div>
+        )}
         {mode.includes("create") && (
           <div
             className="

--- a/frontend/src/features/authoring/images.ts
+++ b/frontend/src/features/authoring/images.ts
@@ -1,7 +1,21 @@
 import type { User } from "firebase/auth";
 import type { AxiosResponse } from "axios";
+import type { QueryClient } from "@tanstack/react-query";
+import { v4 } from "uuid";
+import toast from "react-hot-toast";
 import { api } from "../../util/api";
-import type { UploadedFile } from "./types";
+import type {
+  Bounds,
+  ImageComponent,
+  Scene,
+  UploadedFile,
+  Vec2,
+} from "./types";
+import { add } from "./scene/operations/modifiers";
+import { defaults, getNextZIndex } from "./scene/operations/component";
+import { getSceneId } from "./scene/scene";
+import useEditorStore from "./stores/editor";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "../../util/canvas";
 
 export async function getImages(user: User, scenarioId: string) {
   const response = (await api.get(
@@ -28,4 +42,159 @@ export async function uploadImage(
     },
   })) as AxiosResponse<UploadedFile>;
   return response.data;
+}
+
+export const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+];
+
+// Time the placeholder is held over the finished image so its blur and label
+// can finish resolving, rather than the two swapping in a single frame.
+const HANDOFF_MS = 250;
+
+export type ModifyScene = (scene: Scene) => Promise<unknown> | undefined;
+
+export async function addImageToScene(
+  image: UploadedFile,
+  originScene: Scene,
+  modifyScene: ModifyScene,
+  verts?: Vec2[]
+) {
+  const newImage = structuredClone(defaults.image) as Partial<ImageComponent>;
+
+  const imageId = v4();
+
+  newImage.id = imageId;
+  newImage.fileId = image._id;
+  newImage.href = image.url;
+  newImage.bounds!.verts = verts ?? (await getImageVerts(image.url));
+
+  // Still on the slide where the operation began:
+  // add normally so visual state/history are updated.
+  if (getSceneId() === originScene._id) {
+    // Images bypass createComponentFromBounds, so the top-of-stack zIndex that
+    // every other component type gets on creation has to be assigned here.
+    newImage.zIndex = getNextZIndex();
+    add(newImage);
+    return;
+  }
+
+  // User moved to another slide while the image was loading.
+  // Add it to the original slide instead of the currently active one.
+  newImage.zIndex = getNextZIndex(originScene.components);
+  originScene.components[imageId] = newImage as ImageComponent;
+
+  await modifyScene(originScene);
+}
+
+export async function addNewImage(
+  file: File,
+  scenarioId: string,
+  user: User,
+  originScene: Scene,
+  modifyScene: ModifyScene,
+  queryClient: QueryClient,
+  // where the image should be centred; defaults to the middle of the canvas
+  center?: Vec2
+) {
+  const { addPendingImage, updatePendingImage, removePendingImage } =
+    useEditorStore.getState();
+
+  // Measure and preview the local file so a placeholder of the right size can
+  // be shown on the canvas for the duration of the upload.
+  const previewUrl = URL.createObjectURL(file);
+  const placeholderId = v4();
+
+  try {
+    const verts = await getImageVerts(previewUrl, center);
+    const bounds: Bounds = { verts, rotation: 0 };
+
+    addPendingImage({
+      id: placeholderId,
+      sceneId: originScene._id,
+      bounds,
+      previewUrl,
+      progress: 0,
+      settled: false,
+    });
+
+    const image = await uploadImage(user, scenarioId, file, (fraction) =>
+      // Hold the last tenth back: the bytes are sent, but the server still has
+      // to store the file and answer.
+      updatePendingImage(placeholderId, { progress: fraction * 0.9 })
+    );
+
+    await queryClient.invalidateQueries({
+      queryKey: ["images", scenarioId],
+    });
+
+    // Decode the uploaded file before handing over, so the placeholder is
+    // never replaced by an empty frame while the browser fetches it.
+    await preload(image.url);
+    updatePendingImage(placeholderId, { progress: 1, settled: true });
+
+    await addImageToScene(image, originScene, modifyScene, verts);
+
+    // The placeholder now sits over the real image, unblurred and showing the
+    // same picture, so removing it is invisible.
+    await wait(HANDOFF_MS);
+  } catch (e) {
+    console.error(e);
+    toast.error("Image upload failed");
+  } finally {
+    removePendingImage(placeholderId);
+    URL.revokeObjectURL(previewUrl);
+  }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function preload(url: string) {
+  const img = new Image();
+  img.src = url;
+  // a failure here is not fatal — the <image> element will load it anyway
+  await img.decode().catch(() => {});
+}
+
+function clamp(value: number, min: number, max: number) {
+  // max can fall below min for an image exactly as large as the canvas
+  return Math.max(min, Math.min(max, value));
+}
+
+// Placed at its true pixel size, centred on `center` (or on the canvas when no
+// centre is given). Anything larger than the canvas is scaled down to fit, and
+// the result is nudged back inside the slide so it stays wholly visible.
+export async function getImageVerts(url: string, center?: Vec2) {
+  const img = new Image();
+  img.src = url;
+  await img.decode();
+
+  const scale = Math.min(
+    1,
+    CANVAS_WIDTH / img.naturalWidth,
+    CANVAS_HEIGHT / img.naturalHeight
+  );
+  const width = img.naturalWidth * scale;
+  const height = img.naturalHeight * scale;
+
+  const x = clamp(
+    center ? center.x - width / 2 : (CANVAS_WIDTH - width) / 2,
+    0,
+    CANVAS_WIDTH - width
+  );
+  const y = clamp(
+    center ? center.y - height / 2 : (CANVAS_HEIGHT - height) / 2,
+    0,
+    CANVAS_HEIGHT - height
+  );
+
+  return [
+    { x, y },
+    { x: x + width, y: y + height },
+  ];
 }

--- a/frontend/src/features/authoring/useImageDrop.ts
+++ b/frontend/src/features/authoring/useImageDrop.ts
@@ -24,6 +24,10 @@ import type { Vec2 } from "./types";
 // stack of same-sized images does not hide all but the last one.
 const CASCADE_STEP = 24;
 
+// A single drop is capped so a stray folder drag cannot queue hundreds of
+// uploads. Also roughly where the cascade stops fitting on the canvas.
+const MAX_DROP_FILES = 20;
+
 // How many rejected filenames are listed before the message is summarised.
 const MAX_NAMED_FILES = 5;
 
@@ -111,10 +115,20 @@ export default function useImageDrop(
 
     if (images.length === 0) return;
 
+    let accepted = images;
+    if (images.length > MAX_DROP_FILES) {
+      accepted = images.slice(0, MAX_DROP_FILES);
+      toast.error(
+        `Only the first ${MAX_DROP_FILES} images were added. ` +
+          `${images.length - MAX_DROP_FILES} were skipped.`,
+        { duration: 6000 }
+      );
+    }
+
     const origin = toSVGSpace(event.clientX, event.clientY);
     const originScene = getScene();
 
-    images.forEach((file, index) => {
+    accepted.forEach((file, index) => {
       const center = {
         x: origin.x + index * CASCADE_STEP,
         y: origin.y + index * CASCADE_STEP,

--- a/frontend/src/features/authoring/useImageDrop.ts
+++ b/frontend/src/features/authoring/useImageDrop.ts
@@ -1,0 +1,144 @@
+import {
+  useContext,
+  useRef,
+  useState,
+  type Context,
+  type DragEvent,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import type { User } from "firebase/auth";
+import toast from "react-hot-toast";
+import AuthenticationContext from "../../context/AuthenticationContext.jsx";
+import SceneContext from "../../context/SceneContext.jsx";
+import { handleGeneric } from "../../util/api";
+import { getScene } from "./scene/scene";
+import {
+  ACCEPTED_IMAGE_MIME_TYPES,
+  addNewImage,
+  type ModifyScene,
+} from "./images";
+import type { Vec2 } from "./types";
+
+// Each additional image in a multi-file drop is offset by this much, so a
+// stack of same-sized images does not hide all but the last one.
+const CASCADE_STEP = 24;
+
+// How many rejected filenames are listed before the message is summarised.
+const MAX_NAMED_FILES = 5;
+
+// Names the rejected files, capped so a large drop cannot fill the screen.
+function listNames(files: File[]) {
+  const names = files.slice(0, MAX_NAMED_FILES).map((file) => file.name);
+  const remaining = files.length - names.length;
+  if (remaining > 0) names.push(`and ${remaining} more`);
+  return names.join(", ");
+}
+
+function hasFiles(event: DragEvent) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+/**
+ * Uploads image files dropped onto the canvas and adds them to the current
+ * scene, centred on the point they were dropped at.
+ *
+ * @param toSVGSpace converts client coordinates to canvas coordinates
+ */
+export default function useImageDrop(
+  toSVGSpace: (clientX: number, clientY: number) => Vec2
+) {
+  const { scenarioId } = useParams<{ scenarioId: string }>();
+  const queryClient = useQueryClient();
+
+  const { user } = useContext(AuthenticationContext as Context<{ user: User }>);
+  const { modifyScene } = useContext(
+    SceneContext as Context<{ modifyScene: ModifyScene }>
+  );
+
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  // dragenter/dragleave also fire when the pointer crosses into a child
+  // element, so the nesting depth is tracked rather than a plain boolean.
+  const depth = useRef(0);
+
+  function handleDragEnter(event: DragEvent) {
+    if (!hasFiles(event)) return;
+    event.preventDefault();
+    depth.current++;
+    setIsDraggingOver(true);
+  }
+
+  function handleDragOver(event: DragEvent) {
+    if (!hasFiles(event)) return;
+    // without this the browser navigates to the dropped file
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleDragLeave(event: DragEvent) {
+    if (!hasFiles(event)) return;
+    depth.current = Math.max(0, depth.current - 1);
+    if (depth.current === 0) setIsDraggingOver(false);
+  }
+
+  function handleDrop(event: DragEvent) {
+    if (!hasFiles(event)) return;
+    event.preventDefault();
+
+    depth.current = 0;
+    setIsDraggingOver(false);
+
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length === 0) return;
+
+    const images: File[] = [];
+    const rejected: File[] = [];
+
+    files.forEach((file) =>
+      (ACCEPTED_IMAGE_MIME_TYPES.includes(file.type) ? images : rejected).push(
+        file
+      )
+    );
+
+    if (rejected.length > 0) {
+      toast.error(
+        `Unsupported file type: ${listNames(rejected)}`,
+        // a long list of names needs longer than the default to read
+        { duration: 6000 }
+      );
+    }
+
+    if (images.length === 0) return;
+
+    const origin = toSVGSpace(event.clientX, event.clientY);
+    const originScene = getScene();
+
+    images.forEach((file, index) => {
+      const center = {
+        x: origin.x + index * CASCADE_STEP,
+        y: origin.y + index * CASCADE_STEP,
+      };
+
+      addNewImage(
+        file,
+        scenarioId,
+        user,
+        originScene,
+        modifyScene,
+        queryClient,
+        center
+      ).catch(handleGeneric);
+    });
+  }
+
+  return {
+    isDraggingOver,
+    dropHandlers: {
+      onDragEnter: handleDragEnter,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+    },
+  };
+}


### PR DESCRIPTION
## Issue

Drag and drop is a generally expected feature

## Solution

Add drag and drop

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added drag-and-drop image uploads directly onto the canvas.
  - Displays an upload prompt while files are dragged over the canvas.
  - Supports multiple image drops with positioning offsets, up to 20 files per drop.
  - Preserves image proportions, centers images, and scales oversized images to fit the canvas.
  - Shows upload progress and notifications for invalid file types or skipped files.
  - Keeps uploads associated with the scene where they were originally dropped, even if navigation occurs during upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->