### PR TITLE
fix: use current property field names in conflict-recovery refresh

### DIFF
--- a/frontend/src/features/playScenario/PlayScenarioPage.jsx
+++ b/frontend/src/features/playScenario/PlayScenarioPage.jsx
@@ -134,8 +134,8 @@ const refreshFromServer = async (user, scenarioId, groupId, isMultiplayer) => {
   }
   return {
     newSceneId: res.data.active,
-    stateVariables: res.data.stateVariables,
-    newStateVersion: res.data.stateVersion,
+    properties: res.data.properties,
+    newPropertyVersion: res.data.propertyVersion,
   };
 };
 
@@ -183,15 +183,15 @@ export default function PlayScenarioPage({ group }) {
         const currentRequestId = ++requestIdRef.current;
 
         try {
-          const { newSceneId, stateVariables, newStateVersion } =
+          const { newSceneId, properties, newPropertyVersion } =
             await refreshFromServer(user, scenarioId, group._id, isMultiplayer);
 
           // Discard response if a newer user action was triggered during request transit
           if (currentRequestId !== requestIdRef.current) return;
 
           setSceneId(newSceneId);
-          setProperties(stateVariables);
-          setPropertyVersion(newStateVersion);
+          setProperties(properties);
+          setPropertyVersion(newPropertyVersion);
           toast.success(
             isMultiplayer
               ? "Someone else made a move first, but you're back on track!"


### PR DESCRIPTION
## Issue

refreshFromServer() and its handleError() call site still read res.data.stateVariables/stateVersion, left over from before the properties/propertyVersion rename (#487). The backend never sends those keys, so a 409 conflict recovery reset properties to undefined, causing property chips to render their name instead of their value during playback.

## Solution

_A clear and concise description of what the solution is_

## Risk

_Potential risks that this PR might bring_

## Checklist

- [ ] Acceptance criteria met
- [ ] Wiki documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scenario playback recovery when the latest data changes on the server.
  * Refreshing scenario state now consistently applies the newest properties and version information after a conflict.
  * Prevented stale scenario data from being restored during conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->