### PR TITLE
feat(authoring): auto-resize text boxes to fit their text

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -11,6 +11,7 @@ import { copy, cut, paste } from "./handlers/keyboard/clipboard";
 import useEditorStore from "./stores/editor";
 import { useHistory } from "react-router-dom";
 import { replace, replaceComponent } from "./scene/operations/modifiers";
+import { fitTextBox } from "./scene/operations/autofit";
 import { diffToSelection, findEditDiff } from "./scene/operations/text";
 import { syncVisualCursor } from "./text/cursor";
 import { syncPropertyChips } from "./text/property";
@@ -182,6 +183,8 @@ export default function AuthoringToolPage() {
     for (const component of Object.values(getScene()?.components ?? {})) {
       if (component.type !== "textbox") continue;
       if (!syncPropertyChips(component.document, properties)) continue;
+      // a renamed property changes the chip width, which can rewrap the text
+      fitTextBox(component);
       next[component.id] = buildVisualComponent(component);
       changed = true;
     }

--- a/frontend/src/features/authoring/pipeline.ts
+++ b/frontend/src/features/authoring/pipeline.ts
@@ -22,7 +22,7 @@ export function buildVisualScene(modelScene: Scene) {
   return { ...modelScene, id: modelScene._id, components: visualComponents };
 }
 
-function pad(verts: Vec2[], amount: number) {
+export function pad(verts: Vec2[], amount: number) {
   const center = getBoxCenter(verts);
   return verts.map((vert) => {
     const relative = subtract(center, vert);

--- a/frontend/src/features/authoring/scene/operations/autofit.ts
+++ b/frontend/src/features/authoring/scene/operations/autofit.ts
@@ -1,0 +1,62 @@
+import { pad } from "../../pipeline";
+import { buildVisualDocument, squash } from "../../text/build";
+import type {
+  BaseTextStyle,
+  Component,
+  RelativeBounds,
+  TextBoxComponent,
+} from "../../types";
+import { correct, getBoxCenter, getRelativeBounds } from "../../util";
+
+// sub-pixel differences aren't worth a resize, and would churn on every keystroke
+const EPSILON = 0.5;
+
+// height of a box holding one empty line i.e. the floor fitTextBox shrinks an emptied one back down to
+export function getSingleLineHeight(
+  padding: number,
+  style?: Partial<BaseTextStyle>
+) {
+  const { fontSize, lineHeight } = squash(style);
+  return lineHeight * fontSize + padding * 2;
+}
+
+// outer height the text needs, including padding above and below
+function getRequiredHeight(component: TextBoxComponent) {
+  const relative = getRelativeBounds(
+    pad(component.bounds.verts, component.padding)
+  ) as RelativeBounds;
+  relative.rotation = component.bounds.rotation;
+
+  const doc = buildVisualDocument({
+    ...component.document,
+    bounds: relative,
+    id: component.id,
+  });
+
+  const last = doc.blocks[doc.blocks.length - 1];
+  if (!last) return null;
+
+  return last.y + last.height + component.padding * 2;
+}
+
+// resize shape to fit text: height tracks the content, width is left alone since it's what the text wraps against
+export function fitTextBox(component: Component) {
+  if (component.type !== "textbox") return false;
+
+  const { verts, rotation } = component.bounds;
+  const height = Math.abs(verts[1].y - verts[0].y);
+  const required = getRequiredHeight(component);
+
+  if (required == null || !Number.isFinite(required)) return false;
+  if (Math.abs(height - required) <= EPSILON) return false;
+
+  // anchor the top edge and move the bottom one to meet the text
+  const topI = verts[0].y <= verts[1].y ? 0 : 1;
+  const newVerts = verts.map((vert) => ({ ...vert }));
+  newVerts[1 - topI].y = verts[topI].y + required;
+
+  // resizing moves the box centre, which is also the rotation origin, so we need to recalculate it
+  component.bounds.verts = correct(newVerts, getBoxCenter(verts), rotation);
+
+  return true;
+}

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -3,14 +3,17 @@ import { getComponent, getScene } from "../scene";
 import { mutate, subtract, translate } from "../../util";
 import { getObject, merge } from "../util";
 import { add, modify } from "./modifiers";
+import { getSingleLineHeight } from "./autofit";
 
 type LayerDirection = "forward" | "backward";
 type LayerMode = "step" | "extreme";
 
+const TEXTBOX_PADDING = 20;
+
 export const defaults = {
   textbox: {
     type: "textbox",
-    padding: 20,
+    padding: TEXTBOX_PADDING,
     clickable: true,
     fill: "#00000000", // default value is rgba 0
     stroke: "#00000000",
@@ -18,7 +21,7 @@ export const defaults = {
     bounds: {
       verts: [
         { x: 0, y: 0 },
-        { x: 600, y: 100 },
+        { x: 600, y: getSingleLineHeight(TEXTBOX_PADDING) }, // a new box starts exactly one line high
       ],
       rotation: 0,
     },

--- a/frontend/src/features/authoring/scene/operations/modifiers.ts
+++ b/frontend/src/features/authoring/scene/operations/modifiers.ts
@@ -9,6 +9,7 @@ import {
 import { getComponent, getScene, setScene } from "../scene";
 import type { Component, Scene } from "../../types";
 import { arrayToObject } from "../util";
+import { fitTextBox } from "./autofit";
 
 export function replace(scene: Scene) {
   const clone = structuredClone(scene);
@@ -48,6 +49,12 @@ export function modify<A extends [string[], ...unknown[]], R>(
 
     const output = fn(...args);
 
+    // before updateHistory so the new bounds share the edit's undo step
+    ids.forEach((id) => {
+      const component = getComponent(id);
+      if (component) fitTextBox(component);
+    });
+
     if (previousStates.length) updateHistory(previousStates);
 
     ids.forEach((id) => {
@@ -85,6 +92,9 @@ export function add(props: Record<string, any>, history = true) {
   if (!props.id) props.id = v4();
   const id = props.id as string;
   getScene().components[id] = props as Component;
+
+  // skipped for history=false: that's undo/redo restoring an exact state
+  if (history) fitTextBox(props as Component);
 
   if (history) updateHistory([{ id, prevState: null }]);
 

--- a/frontend/src/features/authoring/text/build.ts
+++ b/frontend/src/features/authoring/text/build.ts
@@ -104,6 +104,86 @@ function buildVisualLines(
 
   let wordBuffer: SpanRef[] = [];
 
+  function endLine() {
+    currentLine.x = generateLineOffset(alignment, maxWidth, currentLine.width);
+    currentLine.height = lineHeight * currentLine.maxFontSize;
+    currentLine.baseline = currentLine.height - currentLine.maxDescent;
+    lines.push(currentLine);
+  }
+
+  function wrapLine() {
+    endLine();
+    currentLine = createNewLine({ y: currentLine.y + currentLine.height });
+  }
+
+  function pushSpan(
+    ref: SpanRef,
+    style: BaseTextStyle,
+    text: string,
+    startIndex: number,
+    width: number,
+    charOffsets: number[]
+  ) {
+    currentLine.spans.push({
+      text,
+      charOffsets,
+      style,
+      width,
+      x: currentLine.width,
+      parentId: ref.index,
+      startIndex,
+      property: ref.span.property,
+    });
+    currentLine.width += width;
+
+    setFont(style);
+    const descent = measure("Mg").actualBoundingBoxDescent;
+    if (descent > currentLine.maxDescent) currentLine.maxDescent = descent;
+    if (style.fontSize > currentLine.maxFontSize)
+      currentLine.maxFontSize = style.fontSize;
+  }
+
+  // a word too wide for the box has no wrap point, so break between characters
+  function pushBrokenSpan(
+    ref: SpanRef,
+    style: BaseTextStyle,
+    offsets: number[]
+  ) {
+    let start = 0;
+
+    while (start < ref.text.length) {
+      const base = offsets[start];
+
+      let end = start;
+      while (
+        end < ref.text.length &&
+        currentLine.width + offsets[end + 1] - base <= maxWidth
+      )
+        end++;
+
+      if (end === start) {
+        // retry on an empty line; if not even one char fits, take it anyway
+        if (currentLine.width > 0) {
+          wrapLine();
+          continue;
+        }
+        end = start + 1;
+      }
+
+      pushSpan(
+        ref,
+        style,
+        ref.text.slice(start, end),
+        ref.start + start,
+        offsets[end] - base,
+        offsets.slice(start, end + 1).map((offset) => offset - base)
+      );
+
+      start = end;
+      if (start < ref.text.length) wrapLine();
+    }
+  }
+
   function flushWordBuffer() {
     if (wordBuffer.length === 0) return;
 
@@ -128,38 +208,30 @@ function buildVisualLines(
     });
     const wordWidth = measuredParts.reduce((sum, p) => sum + p.width, 0);
 
+    // a word that fits on a line of its own moves down whole, and is only broken
+    // up if it overflows even then
     if (currentLine.width + wordWidth > maxWidth && currentLine.width > 0) {
-      currentLine.x = generateLineOffset(
-        alignment,
-        maxWidth,
-        currentLine.width
-      );
-      currentLine.height = lineHeight * currentLine.maxFontSize;
-      currentLine.baseline = currentLine.height - currentLine.maxDescent;
-      lines.push(currentLine);
-
-      currentLine = createNewLine({ y: currentLine.y + currentLine.height });
+      wrapLine();
     }
 
     for (const part of measuredParts) {
       const { ref, style, width, offsets } = part;
-      currentLine.spans.push({
-        text: ref.text,
-        charOffsets: offsets,
-        style,
-        width,
-        x: currentLine.width,
-        parentId: ref.index,
-        startIndex: ref.start,
-        property: ref.span.property,
-      });
-      currentLine.width += width;
 
-      setFont(style);
-      const descent = measure("Mg").actualBoundingBoxDescent;
-      if (descent > currentLine.maxDescent) currentLine.maxDescent = descent;
-      if (style.fontSize > currentLine.maxFontSize)
-        currentLine.maxFontSize = style.fontSize;
+      // chips are atomic; a box narrower than its padding has nothing to break against
+      const breakable =
+        !ref.span.property && ref.text.length > 0 && maxWidth > 0;
+
+      if (breakable && currentLine.width + width > maxWidth) {
+        pushBrokenSpan(ref, style, offsets);
+        continue;
+      }
+
+      // an atomic part that doesn't fit drops to the next line instead of
+      // running past the edge, so the box gains a line rather than overflowing
+      if (currentLine.width > 0 && currentLine.width + width > maxWidth)
+        wrapLine();
+
+      pushSpan(ref, style, ref.text, ref.start, width, offsets);
     }
 
     wordBuffer = [];
@@ -186,21 +258,14 @@ function buildVisualLines(
         const style = squash(blockStyle, span.style);
         setFont(style);
         const spaceWidth = measure(token).width;
-        currentLine.spans.push({
-          text: token,
+        pushSpan(
+          { span, text: token, index: j, start: offset },
           style,
-          width: spaceWidth,
-          x: currentLine.width,
-          parentId: j,
-          startIndex: offset,
-          charOffsets: generateOffsets(token, style),
-        });
-        currentLine.width += spaceWidth;
-
-        const descent = measure("Mg").actualBoundingBoxDescent;
-        if (descent > currentLine.maxDescent) currentLine.maxDescent = descent;
-        if (style.fontSize > currentLine.maxFontSize)
-          currentLine.maxFontSize = style.fontSize;
+          token,
+          offset,
+          spaceWidth,
+          generateOffsets(token, style)
+        );
       } else {
         wordBuffer.push({ span, text: token, index: j, start: offset });
       }
@@ -213,12 +278,7 @@ function buildVisualLines(
 
   flushWordBuffer();
 
-  if (currentLine.spans.length > 0) {
-    currentLine.x = generateLineOffset(alignment, maxWidth, currentLine.width);
-    currentLine.height = lineHeight * currentLine.maxFontSize;
-    currentLine.baseline = currentLine.height - currentLine.maxDescent;
-    lines.push(currentLine);
-  }
+  if (currentLine.spans.length > 0) endLine();
 
   return lines;
 }

--- a/frontend/src/features/authoring/text/cursor.ts
+++ b/frontend/src/features/authoring/text/cursor.ts
@@ -141,6 +141,13 @@ export function syncVisualCursor() {
   );
 }
 
+// a line wrapped at whitespace ends with that space, and the position before it is addressed as the next line's start.
+// a mid-word break has nothing to skip
+function trailingSkip(line: VisualLine) {
+  const last = line.spans[line.spans.length - 1];
+  return last && /\s$/.test(last.text) ? 1 : 0;
+}
+
 // force cursor at line extreme to wrap to the start of the next line (more intuitive)
 export function normaliseVisualCursor(
   cursor: VisualCursor,
@@ -217,7 +224,7 @@ export function goToLineEnd(cursor: VisualCursor, blocks: VisualBlock[]) {
   const isFinalSpan =
     cursor.spanI === line.spans.length - 1 &&
     cursor.lineI === block.lines.length - 1;
-  cursor.charI = isFinalSpan ? span.text.length : span.text.length - 1;
+  cursor.charI = span.text.length - (isFinalSpan ? 0 : trailingSkip(line));
   return cursor;
 }
 
@@ -287,7 +294,7 @@ export function moveCursorVisual(
       if (
         charI <
         (spanI === line.spans.length - 1 && lineI < block.lines.length - 1
-          ? span.text.length - 1
+          ? span.text.length - trailingSkip(line)
           : span.text.length)
       ) {
         charI++;
@@ -348,5 +355,8 @@ export function moveCursorVisual(
       }
     }
   }
-  return { blockI, lineI, spanI, charI };
+
+  // the end of a mid-word break is the same model position as the next line's
+  // start; collapse to the canonical one or the next keypress looks like a no-op
+  return normaliseVisualCursor({ blockI, lineI, spanI, charI }, blocks);
 }

--- a/frontend/src/features/authoring/text/cursor.ts
+++ b/frontend/src/features/authoring/text/cursor.ts
@@ -334,15 +334,18 @@ export function moveCursorVisual(
         charI = line.spans[spanI].text.length;
         amount++;
       } else if (lineI > 0) {
+        // one position back from the end of the previous line, which shares a
+        // position with this line's start
         lineI--;
         const line = block.lines[lineI];
-        const span = line.spans[line.spans.length - 1];
-        spanI =
-          span.text.length > 1 ? line.spans.length - 1 : line.spans.length - 2;
-        charI =
-          span.text.length > 1
-            ? span.text.length - 1
-            : line.spans[spanI].text.length;
+        spanI = line.spans.length - 1;
+        charI = line.spans[spanI].text.length - 1;
+
+        // a cursor at a span start is addressed as the previous span's end
+        if (charI === 0 && spanI > 0) {
+          spanI--;
+          charI = line.spans[spanI].text.length;
+        }
         amount++;
       } else if (blockI > 0) {
         blockI--;


### PR DESCRIPTION
## Issue

Text boxes larger than their actual visible content bloats canvas space

## Solution

Auto-resize text boxes

## Risk

Low

## Checklist

- [x] Acceptance criteria met
- [x] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Text boxes now automatically resize to fit content after edits and property-name changes, including rotated text boxes.
  - Default text-box height now adapts to the configured text style and padding.

- **Bug Fixes**
  - Improved wrapping for long words, whitespace, and property chips.
  - Corrected cursor movement at wrapped lines, word breaks, and line endings.
  - Preserved trailing spaces as addressable cursor positions during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->