### PR TITLE
feat: simple canvas improvements

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -23,7 +23,7 @@ import {
   PlayIcon,
   UserPlusIcon,
 } from "lucide-react";
-import { handleGlobal } from "./handlers/keyboard/keyboard";
+import { handleGlobal, handleGlobalKeyUp } from "./handlers/keyboard/keyboard";
 import { clearHistory, historyEvents } from "./scene/history";
 import { debounce } from "../../util/debounce";
 import { getScene } from "./scene/scene";
@@ -37,6 +37,7 @@ const listeners = [
   ["cut", cut],
   ["paste", paste],
   ["keydown", handleGlobal],
+  ["keyup", handleGlobalKeyUp],
 ];
 
 // const AUTOSAVE_INTERVAL = 30000; // 30 secs

--- a/frontend/src/features/authoring/canvas/handles/ConstrainedHandle.tsx
+++ b/frontend/src/features/authoring/canvas/handles/ConstrainedHandle.tsx
@@ -1,30 +1,52 @@
-import { getBoxCenter, rotate } from "../../util";
+import { getBoxCenter, mutate, rotate, subtract } from "../../util";
 import useEditorStore from "../../stores/editor";
 import { getSelectedComponentBounds } from "../../handlers/pointer/pointer";
+import { getCoordsVec } from "../../handlers/pointer/resize";
 import { HANDLE_RADIUS } from "../../../../util/canvas";
+import type { Vec2 } from "../../types";
 
 interface Props {
   x: number;
   y: number;
 }
 
+const RESIZE_CURSORS = ["ns-resize", "nesw-resize", "ew-resize", "nwse-resize"];
+
+// picks the resize cursor matching this handle's visual direction
+function getResizeCursor(
+  localPoint: Vec2,
+  center: Vec2,
+  x: number,
+  y: number,
+  rotation: number
+) {
+  // ignore speech-bubble tail
+  if (x === 2 || y === 2) return "crosshair";
+
+  // use the sign only, not the magnitude
+  const { x: dx, y: dy } = mutate(subtract(localPoint, center), Math.sign);
+  const baseAngle = Math.atan2(dx, -dy) * (180 / Math.PI);
+  const angle = (((baseAngle + rotation) % 360) + 360) % 360;
+  return RESIZE_CURSORS[Math.round(angle / 45) % 4];
+}
+
 const ResizeHandle = ({ x, y }: Props) => {
   const mode = useEditorStore((s) => s.mode);
 
   const bounds = getSelectedComponentBounds();
+  if (!bounds) return null;
+
   const verts = bounds.verts;
-
-  let point = {
-    x: x === 0.5 ? (verts[0].x + verts[1].x) / 2 : verts[x].x,
-    y: y === 0.5 ? (verts[0].y + verts[1].y) / 2 : verts[y].y,
-  };
-
-  point = rotate(point, getBoxCenter(verts), bounds.rotation);
+  const center = getBoxCenter(verts);
+  const localPoint = getCoordsVec(verts, [x, y]);
+  const point = rotate(localPoint, center, bounds.rotation);
 
   return (
     <g
       pointerEvents={mode.includes("mutation") ? "none" : "auto"}
-      style={{ cursor: "crosshair" }}
+      style={{
+        cursor: getResizeCursor(localPoint, center, x, y, bounds.rotation),
+      }}
     >
       <ellipse
         data-handle

--- a/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/clipboard.ts
@@ -129,8 +129,12 @@ export function paste(e: ClipboardEvent) {
 
       items.forEach((obj) => {
         if (obj.type) {
+          // paste-in-place
           newSelection.push(
-            parseComponent(obj as unknown as Component, nextZIndex++)
+            parseComponent(obj as unknown as Component, nextZIndex++, {
+              x: 0,
+              y: 0,
+            })
           );
         } else {
           const component = structuredClone(defaults["textbox"]);

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -25,7 +25,10 @@ export function handleGlobal(e: KeyboardEvent) {
     return;
   }
 
-  handleShortcut(e);
+  const shortcutHandled = handleShortcut(e);
+  if (shortcutHandled && !(mode.includes("text") && e.key === "Escape")) {
+    return;
+  }
 
   if (mode.includes("text")) handleTextMode(e);
   else if (selected.length) handleComponentOperations(e, selected);

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -25,7 +25,7 @@ export function handleGlobal(e: KeyboardEvent) {
     return;
   }
 
-  if (handleShortcut(e)) return;
+  handleShortcut(e);
 
   if (mode.includes("text")) handleTextMode(e);
   else if (selected.length) handleComponentOperations(e, selected);

--- a/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/keyboard.ts
@@ -17,10 +17,28 @@ export function handleGlobal(e: KeyboardEvent) {
   if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
   if (isEditableShortcutTarget(e.target)) return;
 
+  // alt is used as a live drag/resize modifier (disables snapping); stop the
+  // browser's own bare-alt behaviour (e.g. Firefox focusing the menu bar)
+  // from firing while the editor has focus
+  if (e.key === "Alt") {
+    e.preventDefault();
+    return;
+  }
+
   if (handleShortcut(e)) return;
 
   if (mode.includes("text")) handleTextMode(e);
   else if (selected.length) handleComponentOperations(e, selected);
+}
+
+// mirrors the Alt guard above on keyup, since some browsers fire their
+// bare-alt behaviour there instead of on keydown
+export function handleGlobalKeyUp(e: KeyboardEvent) {
+  const target = e.target as HTMLElement;
+  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+  if (isEditableShortcutTarget(e.target)) return;
+
+  if (e.key === "Alt") e.preventDefault();
 }
 
 function handleComponentOperations(e: KeyboardEvent, selected: string[]) {

--- a/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
@@ -193,6 +193,25 @@ const shortcuts: Shortcut[] = [
     when: canAdjustSelectedTextFontSize,
     run: () => adjustSelectedTextFontSize(-1),
   },
+  {
+    combos: ["escape"],
+    when: () => {
+      const { mode, selected } = useEditorStore.getState();
+      return mode.some((m) => m !== "normal") || selected.length > 0;
+    },
+    run: () => {
+      const { mode, setMode, setSelected, setActiveGuides, setMouseDown } =
+        useEditorStore.getState();
+      if (mode.some((m) => m !== "normal")) {
+        // cancel the active drag/resize/marquee/text-edit
+        setMode(["normal"]);
+        setActiveGuides([]);
+        setMouseDown(false);
+      } else {
+        setSelected([]);
+      }
+    },
+  },
 ];
 
 export function handleShortcut(e: KeyboardEvent) {

--- a/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/shortcuts.ts
@@ -203,13 +203,14 @@ const shortcuts: Shortcut[] = [
       const { mode, setMode, setSelected, setActiveGuides, setMouseDown } =
         useEditorStore.getState();
       if (mode.some((m) => m !== "normal")) {
-        // cancel the active drag/resize/marquee/text-edit
+        // cancel the active drag/resize/marquee/create/text-edit
         setMode(["normal"]);
         setActiveGuides([]);
         setMouseDown(false);
-      } else {
-        setSelected([]);
+        if (!mode.includes("text")) setSelected([]);
+        return;
       }
+      setSelected([]);
     },
   },
 ];

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -95,6 +95,9 @@ function handleEditing(e: KeyboardEvent, selected: string) {
     // create a new block at cursor
     const newCursor = createBlock([selected], start);
     setSelection({ start: newCursor, end });
+  } else if (e.key === "Escape") {
+    // clear current selection
+    setSelection({ start: null, end: null });
   }
 
   setDesiredColumn(null);

--- a/frontend/src/features/authoring/handlers/keyboard/text.ts
+++ b/frontend/src/features/authoring/handlers/keyboard/text.ts
@@ -95,9 +95,6 @@ function handleEditing(e: KeyboardEvent, selected: string) {
     // create a new block at cursor
     const newCursor = createBlock([selected], start);
     setSelection({ start: newCursor, end });
-  } else if (e.key === "Escape") {
-    // clear current selection
-    setSelection({ start: null, end: null });
   }
 
   setDesiredColumn(null);

--- a/frontend/src/features/authoring/handlers/pointer/pointer.ts
+++ b/frontend/src/features/authoring/handlers/pointer/pointer.ts
@@ -149,7 +149,7 @@ function handleComponentClick(e: React.MouseEvent, position: Vec2) {
   setMode(["normal"]);
 }
 
-function handleComponentDrag(_: React.MouseEvent, position: Vec2) {
+function handleComponentDrag(e: React.MouseEvent, position: Vec2) {
   const { selected, setMutationBounds, offset, setMode, setActiveGuides } =
     useEditorStore.getState();
   if (!selected?.length) return;
@@ -157,15 +157,24 @@ function handleComponentDrag(_: React.MouseEvent, position: Vec2) {
   const bounds = getSelectedComponentBounds()!;
   let verts = translate(bounds.verts, subtract(position, offset));
 
-  const { components } = useVisualScene.getState();
-  const others = Object.values(components).filter(
-    (c) => c.type !== "audio" && !selected.includes(c.id)
-  );
-  const { delta, guides } = snapTranslation(verts, bounds.rotation, others, "");
-  verts = translate(verts, delta);
+  if (e.altKey) {
+    setActiveGuides([]);
+  } else {
+    const { components } = useVisualScene.getState();
+    const others = Object.values(components).filter(
+      (c) => c.type !== "audio" && !selected.includes(c.id)
+    );
+    const { delta, guides } = snapTranslation(
+      verts,
+      bounds.rotation,
+      others,
+      ""
+    );
+    verts = translate(verts, delta);
+    setActiveGuides(guides);
+  }
 
   setMutationBounds((prev) => ({ ...prev, verts }));
-  setActiveGuides(guides);
   setMode(["mutation"]);
 }
 

--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -211,7 +211,7 @@ function updateResize(
 }
 
 function mirror(verts: Vec2[], center: Vec2, coords: number[]) {
-  const point = { x: verts[coords[0]].x, y: verts[coords[1]].y };
+  const point = getCoordsVec(verts, coords);
   const inversePosition = add(scale(subtract(point, center), -1), center);
   return modifyVerts(verts, inverse(coords), inversePosition);
 }

--- a/frontend/src/features/authoring/handlers/pointer/resize.ts
+++ b/frontend/src/features/authoring/handlers/pointer/resize.ts
@@ -56,8 +56,9 @@ export function handleResizeDrag(e: React.MouseEvent, position: Vec2) {
       -bounds.rotation
     );
 
-    // alignment guides only make sense in global space, so only snap unrotated components
-    if (!bounds.rotation) {
+    // alignment guides only make sense in global space, so only snap unrotated
+    // components, and let alt bypass snapping entirely
+    if (!bounds.rotation && !e.altKey) {
       const components = Object.values(
         useVisualScene.getState().components
       ).filter((c) => c.type !== "audio" && !selected.includes(c.id));

--- a/frontend/src/features/authoring/scene/operations/component.ts
+++ b/frontend/src/features/authoring/scene/operations/component.ts
@@ -1,4 +1,4 @@
-import type { Bounds, Component } from "../../types";
+import type { Bounds, Component, Vec2 } from "../../types";
 import { getComponent, getScene } from "../scene";
 import { mutate, subtract, translate } from "../../util";
 import { getObject, merge } from "../util";
@@ -118,8 +118,11 @@ export function stringifyComponent(id: string) {
   return JSON.stringify(component);
 }
 
-export function parseComponent(component: Component, zIndex?: number) {
-  const offset = { x: 10, y: 10 };
+export function parseComponent(
+  component: Component,
+  zIndex?: number,
+  offset: Vec2 = { x: 10, y: 10 }
+) {
   component.bounds.verts = translate(component.bounds.verts, offset);
   component.zIndex = zIndex ?? component.zIndex + 1;
   delete (component as Record<string, unknown>).id;

--- a/frontend/src/features/authoring/text/cursor.ts
+++ b/frontend/src/features/authoring/text/cursor.ts
@@ -128,7 +128,7 @@ export function syncModelSelection() {
 
 export function syncVisualCursor() {
   const editorState = useEditorStore.getState();
-  if (!editorState.selected || !editorState.selection.start) return;
+  if (!editorState.selected) return;
   const blocks = (
     useVisualScene.getState().components[
       editorState.selected[0]


### PR DESCRIPTION
## Issue

a few missing features:
- esc to cancel drag/selection/resize
- mirror (ctrl) resizing for cardinal direction resize
- paste-in-place
- directional cursors for resizing
- hold alt to disable snapping while dragging/resizing

resolves VPS-182

## Solution

all of the above were minor changes, take a look at the code.

## Risk

zero

## Checklist

- [ ] Acceptance criteria met
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold **Alt** while moving or resizing components to bypass alignment snapping for freeform positioning.
  * Pasted components now appear in place instead of receiving an automatic offset.

* **Bug Fixes**
  * Improved resize-handle positioning and directional, rotation-aware cursors.
  * Improved Escape behavior when cancelling authoring actions and changing modes.
  * Prevented unintended browser behavior from bare Alt presses in the editor.
  * Improved text cursor synchronization in additional selection states.
  * Resize handles now remain hidden when selection bounds are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->