### PR TITLE
fix: duplicate then undo crashing

### DIFF
--- a/frontend/src/features/authoring/AuthoringToolPage.jsx
+++ b/frontend/src/features/authoring/AuthoringToolPage.jsx
@@ -86,6 +86,7 @@ export default function AuthoringToolPage() {
         // reading past the end of the document
         editorState.setSelection({ start: null, end: null });
         editorState.setVisualSelection({ start: null, end: null });
+        setSelected([]);
 
         const batch = record;
         const targetSceneId = batch[0]?.sceneId;


### PR DESCRIPTION
## Issue

duplicate then undo crashing, because a render was occurring between component deletion from store and selecting clearing, therefore ui trying to render selection overlay for non-existent component.

## Solution

cleared selection immediately after operation.

## Risk

inefficient, doesn't resolve the core issue of the extra render that occurs when all post operation actions should be batched before next render.

## Checklist

- [ ] Acceptance criteria met
- [ ] Continuous integration build passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Undo and redo now correctly reset component selections while restoring editor changes, then preserve selections for restored components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->